### PR TITLE
spec: make addon-ccpp dependent on libreport-python

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -145,6 +145,7 @@ Requires: %{name}-retrace-client
 %endif
 Requires: %{name} = %{version}-%{release}
 Requires: abrt-libs = %{version}-%{release}
+Requires: libreport-python
 
 %description addon-ccpp
 This package contains hook for C/C++ crashed programs and %{name}'s C/C++


### PR DESCRIPTION
Closes #710

Signed-off-by: Jakub Filak jfilak@redhat.com
