### PR TITLE
Don't switch off disassembly completely if bracktrace was long.

### DIFF
--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -346,9 +346,16 @@ char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char 
                         bt_depth);
         free(bt);
 
-        /* Disable -ex disassemble, output might be huge preventing backtrace generation */
-        args[18] = NULL;
-        args[19] = NULL;
+        /* Replace -ex disassemble (which disasms entire function $pc points to)
+         * to a version which analyzes limited, small patch of code around $pc.
+         * (Users reported a case where bare "disassemble" attempted to process
+         * entire .bss).
+         * TODO: what if "$pc-N" underflows? in my test, this happens:
+         * Dump of assembler code from 0xfffffffffffffff0 to 0x30:
+         * End of assembler dump.
+         * (IOW: "empty" dump)
+         */
+        args[19] = (char*)"disassemble $pc-20, $pc+64";
 
         if (bt_depth <= 64 && thread_apply_all[0] != '\0')
         {


### PR DESCRIPTION
We had a user case when $pc was pointing to .bss,
and gdb's "disassemble" disasm'ed... entire .bss -

Generating backtrace
Backtrace is too big (33561281 bytes), reducing depth to 512
Backtrace is too big (33561281 bytes), reducing depth to 256
Backtrace is too big (33561281 bytes), reducing depth to 128
Backtrace is too big (33561281 bytes), reducing depth to 64
Backtrace is too big (33555685 bytes), reducing depth to 64
Backtrace is too big (33555461 bytes), reducing depth to 64
Backtrace is too big (33555461 bytes), reducing depth to 32
Error: Line 15, column 0: "Thread" header expected
('report_uReport' exited with 1)

This patch swithces to "disassemble $pc-20, $pc+64" which
will prevent such disasters, yet produces at least some disasm.

Related to rhbz#995889.

Signed-off-by: Denys Vlasenko dvlasenk@redhat.com
