### PR TITLE
Use bugzilla_formatdup.conf for detected duplicates in python too. Fixes...

### DIFF
--- a/src/plugins/python_event.conf
+++ b/src/plugins/python_event.conf
@@ -12,8 +12,9 @@ EVENT=post-create analyzer=Python
 EVENT=report_Bugzilla analyzer=Python component!=anaconda
         test -f component || abrt-action-save-package-data
         reporter-bugzilla -b \
-                -c /etc/libreport/plugins/bugzilla.conf
-        # TODO? -F /etc/libreport/plugins/bugzilla_format_python.conf
+                -c /etc/libreport/plugins/bugzilla.conf \
+                -F /etc/libreport/plugins/bugzilla_format.conf \
+                -A /etc/libreport/plugins/bugzilla_formatdup.conf
 
 # Send micro report
 EVENT=report_uReport analyzer=Python


### PR DESCRIPTION
... rhbz#875312.

We use bugzilla_formatdup.conf for coredump problems for some time now,
but for python bugzilla_format.conf was still used both for new bugs and
for dups. This change brings python Bugzilla reporting in sync with coredump
Bugzilla reporting.
