### PR TITLE
abrt-action-install-debuginfo: fix --exact handling. Fixes rhbz1027786

### DIFF
--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -206,7 +206,7 @@ if __name__ == "__main__":
 
         missing = filter_installed_debuginfos(b_ids, cachedirs)
 
-    exact_file_missing = 0
+    exact_file_missing = False
     result = RETURN_OK
     if missing:
         log2("%s", missing)
@@ -229,7 +229,7 @@ if __name__ == "__main__":
             for bid in missing:
                 if not os.path.isfile(bid):
                     print _("Missing requested file: {0}").format(bid)
-                    exact_file_missing = 1
+                    exact_file_missing = True
 
         missing = filter_installed_debuginfos(b_ids, cachedirs)
         for bid in missing:


### PR DESCRIPTION
Before this change, running with
--exact=/usr/lib/debug/lib/modules/2.6.32-430.el6.i686/vmlinux
printed this:

Coredump references 0 debuginfo files, 1 of them are not installed
Setting up yum repositories
Looking for needed packages in repositories
Can't find packages for 1 debuginfo files
All debuginfo files are available

and exit code was 0. After this change:

1 of debuginfo files are not installed
Setting up yum repositories
Looking for needed packages in repositories
Can't find packages for 1 debuginfo files
Missing requested file: /usr/lib/debug/lib/modules/2.6.32-430.el6.i686/vmlinux

and exit code is 2.

Signed-off-by: Denys Vlasenko dvlasenk@redhat.com
