### PR TITLE
Improve processing of machine check exceptions. Resolves rhbz812537.

### DIFF
--- a/src/plugins/koops_event.conf
+++ b/src/plugins/koops_event.conf
@@ -1,6 +1,44 @@
 # analyze
 EVENT=post-create analyzer=Kerneloops
-        abrt-action-analyze-oops
+        # Generate duplication hashes
+        abrt-action-analyze-oops || exit $?
+        #
+        # If it exists, we can save a copy of MCE log here:
+        #test -f /var/log/mcelog && cp /var/log/mcelog .
+        # but in current config, sosreport already does that.
+        #
+        # See if MCEs were seen but mcelog isn't installed or running
+        dmesg | grep -qFi 'Machine check events logged' || exit 0
+        #
+        # There was an MCE. IOW: it's not a bug, it's a HW error.
+        # (Ab)use user comment field to inform user about it.
+        test -f /var/log/mcelog &&
+        {
+                echo "The kernel log indicates that hardware errors were detected."
+                echo "/var/log/mcelog file may have more information."
+                echo "The last 20 lines of /var/log/mcelog are:"
+                echo "========================================="
+                # Redirecting sterr in case selinux makes it unreadable
+                # (annoying anyway, but at least user knows what's going on):
+                tail -n20 /var/log/mcelog 2>&1
+                exit 0
+        } >comment
+        #
+        # Apparently, there is no running mcelog daemon!
+        # Let user know that he needs one.
+        {
+        echo "The kernel log indicates that hardware errors were detected."
+        echo "The data was saved by kernel for processing by the mcelog tool."
+        echo "However, /var/log/mcelog file does not exist."
+        echo "Most likely reason is that mcelog is not installed or not configured"
+        echo "to be started during boot."
+        echo "Without this tool running, the binary data saved by kernel"
+        echo "is of limited usefulness."
+        echo "(You can save this data anyway by running 'cat </dev/mcelog >FILE')."
+        echo "The recommended course of action is to install mcelog."
+        echo "If another hardware error would occur, a user-readable description"
+        echo "of it will be saved in /var/log/mcelog."
+        } >comment
 
 # If you want behavior similar to one provided by kerneloops daemon
 # distributed by kerneloops.org - that is, if you want

--- a/src/plugins/vmcore_event.conf
+++ b/src/plugins/vmcore_event.conf
@@ -1,5 +1,11 @@
 # analyze
 EVENT=analyze_VMcore analyzer=vmcore
+        # If kdump machinery already extracted dmesg...
+        if test -f vmcore-dmesg.txt; then
+            # ...use that
+            exec abrt-dump-oops -o vmcore-dmesg.txt >backtrace
+        fi
+        # Else, do it the hard way:
         abrt-action-analyze-vmcore
 
 # If you want behavior similar to one provided by kerneloops daemon


### PR DESCRIPTION
MCE's are detected by abrt as kernel oopses,
but they are hardware errors, not kernel bugs.

This change makes it more clear for the user what they are,
shows more information if it is available, otherwise
explains to user what needs to be done to get it -
user needs to install mcelog tool.

If non-fatal MCE is seen, abrt will detect it as an oops
and alert user in a usual manner. When user opens this
abrt problem for reporting, he will see that "comment"
field is pre-filled with some text.
What it says depends on whether mcelog tool is installed.

If mcelog is installed, the text is:
"""
The kernel log indicates that hardware errors were detected.
/var/log/mcelog file may have more information.
# The last 20 lines of /var/log/mcelog are:

<up to 20 lines of log>
"""

otherwise it is:

"""
The kernel log indicates that hardware errors were detected.
The data was saved by kernel for processing by the mcelog tool.
However, /var/log/mcelog file does not exist.
Most likely reason is that mcelog is not installed or not configured
to be started during boot.
Without this tool running, the binary data saved by kernel
is of limited usefulness.
(You can save this data anyway by running 'cat </dev/mcelog >FILE').
The recommended course of action is to install mcelog.
If another hardware error would occur, a user-readable description
of it will be saved in /var/log/mcelog.
"""

I hope the message is clear enough to let user understand that
it is a hardware error, and instead of filing a bug and/or
talking to our support, user will start looking at his hardware.

If fatal MCE is encountered, kernel always panics,
(abrt has no chance of catching the oops),
kdump kicks in, and then after reboot abrt says that new vmcore
is found. When user generates backtrace, he will see oops text
which starts with
"Machine Check Exception: BANK nnn ...".

(Yes, it's weird that kernel shows human-readable error messages
on fatal MCEs but doesn't do that for non-fatal ones.
This makes fetching MCE info significantly different...
I wish kernel would show human-readable MCEs in both cases,
we wouldn't need mcelog then... oh well.)

This change was run-tested on RHEL6 machine.

Signed-off-by: Denys Vlasenko dvlasenk@redhat.com
