### PR TITLE
Add build/ to POTFILES.skip

### DIFF
--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,2 +1,3 @@
 contrib/command-not-found/pk-tools-common.c
 src/python-problem/
+build/


### PR DESCRIPTION
If build/ exists (after running make rpm) it confuses intltool-update
which causes make check to fail.

Signed-off-by: Martin Milata mmilata@redhat.com
