### PR TITLE
Speed up journalctl --system support detection

### DIFF
--- a/src/plugins/ccpp_event.conf
+++ b/src/plugins/ccpp_event.conf
@@ -30,7 +30,7 @@ EVENT=post-create analyzer=CCpp
             executable=`cat executable` &&
             base_executable=${executable##*/} &&
             # Test if the current version of journalctl has --system switch
-            journalctl --system >/dev/null
+            journalctl -h | grep "\-\-system" >/dev/null
             if [ $? -ne 0 ];
             then
                 # It's not an error if /var/log/messages isn't readable:


### PR DESCRIPTION
If journalctl supports --system then abrt process grabs the whole
system journal slowing down the machine significantly.

This checks if help message contains "--system" flag to do this.

Tested on F19:

```
$ time journalctl -h | grep "\-\-system" > /dev/null; echo $?
journalctl -h  0.00s user 0.00s system 82% cpu 0.002 total
grep --color=auto "\-\-system" > /dev/null  0.00s user 0.00s system 71% cpu 0.001 total
0
```

and F18:

```
$ time journalctl -h | grep "\-\-system"; echo $?

real    0m0.003s
user    0m0.001s
sys 0m0.003s
1

```
