### PR TITLE
abrtd.service: Don't order after syslog.target

### DIFF
--- a/init-scripts/abrtd.service
+++ b/init-scripts/abrtd.service
@@ -3,7 +3,7 @@ Description=ABRT Automated Bug Reporting Tool
 # livesys.service has been added because of live distributions mounting tmpfs
 # to /var/tmp after abrtd.service was started which was hiding /var/tmp/abrt
 # which was created before the mount to tmpfs happened
-After=syslog.target livesys.service
+After=livesys.service
 
 [Service]
 ExecStart=/usr/sbin/abrtd -d -s


### PR DESCRIPTION
http://www.freedesktop.org/wiki/Software/systemd/syslog/
https://fedorahosted.org/fpc/ticket/177#comment:2
http://lists.opensuse.org/archive/opensuse-packaging/2013-05/msg00102.html
