### PR TITLE
limit ourselves to *.conf in /etc/abrt

### DIFF
--- a/augeas/abrt.aug
+++ b/augeas/abrt.aug
@@ -3,7 +3,7 @@ module Abrt =
 
     let lns = Libreport.lns
 
-    let filter = (incl "/etc/abrt/*" )
+    let filter = (incl "/etc/abrt/*.conf" )
                . (incl "/etc/abrt/plugins/*")
                . (incl "/usr/share/abrt/conf.d/*")
                . (incl "/usr/share/abrt/conf.d/plugins/*")


### PR DESCRIPTION
rhel6 (for example) ships /etc/abrt/gpg_keys, which makes augeas initialization
fail since that file isn't an abrt-style config file
