### PR TITLE
Fix a spelling error in a configuration GUI tooltip.

### DIFF
--- a/src/configuration-gui/abrt-config-widget.ui
+++ b/src/configuration-gui/abrt-config-widget.ui
@@ -262,7 +262,7 @@
           <object class="GtkImage" id="image6">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes"> With this option enabled ABRT always create bug ticket with restricted access if possibly sensitive data are dected.</property>
+            <property name="tooltip_text" translatable="yes"> With this option enabled ABRT always create bug ticket with restricted access if possibly sensitive data are detected.</property>
             <property name="halign">end</property>
             <property name="margin_left">5</property>
             <property name="stock">gtk-dialog-question</property>


### PR DESCRIPTION
This is a two-byte change to the .ui file.
