### PR TITLE
Support handling crashes in lxc containers

### DIFF
--- a/src/hooks/abrt-install-ccpp-hook.in
+++ b/src/hooks/abrt-install-ccpp-hook.in
@@ -9,7 +9,7 @@ verbose=false
 PATTERN_FILE="/proc/sys/kernel/core_pattern"
 SAVED_PATTERN_DIR="@VAR_RUN@/abrt"
 SAVED_PATTERN_FILE="@VAR_RUN@/abrt/saved_core_pattern"
-HOOK_BIN="@libexecdir@/abrt-hook-ccpp"
+HOOK_BIN="/usr/sbin/chroot /proc/%P/root @libexecdir@/abrt-hook-ccpp"
 # Must match percent_specifiers[] order in abrt-hook-ccpp.c:
 PATTERN="|$HOOK_BIN %s %c %p %u %g %t %e"
 # Same, but with bogus "executable name" parameter


### PR DESCRIPTION
This changes the behaviour of ccpp-hook to respect
global PID. Now it chroots into the container environment
before attempting to save data about the crashing process
and contacting abrtd running in guest.

Previously, the crash was handled by ccpp-hook on the host
which saved data about incorrect process due to global/local
PID mismatch.

Closes #809.

Signed-off-by: Richard Marko rmarko@fedoraproject.org
