### PR TITLE
simplify Analyze C/C++ event configuration

### DIFF
--- a/src/plugins/analyze_CCpp.xml.in
+++ b/src/plugins/analyze_CCpp.xml.in
@@ -17,25 +17,7 @@
          user dismisses the analyze_RetraceServer event. -->
     <sending-sensitive-data>no</sending-sensitive-data>
 
-    <!-- The following options are taken from analyze_RetraceServer
-         event configuration because the analyze ccpp event internally runs
-         the analyze_RetraceServer.  The current implementation of the event
-         and libreport's run event framework can't load configuration of an
-         internally executed event.  This causes that user can be forced to
-         configure remote analysis on two different places. -->
     <options>
-        <option type="text" name="RETRACE_SERVER_URL">
-           <_label>Retrace server URL</_label>
-           <default-value>retrace.fedoraproject.org</default-value>
-           <allow-empty>no</allow-empty>
-           <_description>Address of the retrace server</_description>
-       </option>
-       <option type="text" name="RETRACE_SERVER_INSECURE">
-           <_label>Insecure</_label>
-           <allow-empty>yes</allow-empty>
-           <_description>Whether or not to use insecure connection</_description>
-           <_note-html>Write "insecure" to allow insecure connection &lt;a href="https://fedorahosted.org/abrt/wiki/AbrtRetraceServerInsecureConnection" &gt;(warning)&lt;/a&gt;</_note-html>
-       </option>
-
+        <import-event-options event="analyze_RetraceServer"/>
     </options>
 </event>


### PR DESCRIPTION
There is no other configuration that the one for Retrace Server event
which is redundant. The redundat options can be replaced with
import-event-options element which is supported since libreport 2.2.0.

See libreport commit 5f491a3de842bcaea6cec33beab5e4f60c3bb5fe

Signed-off-by: Jakub Filak jfilak@redhat.com
