### PR TITLE
dbus: Fix desktop centric polkit policy file

### DIFF
--- a/src/dbus/abrt_polkit.policy
+++ b/src/dbus/abrt_polkit.policy
@@ -19,9 +19,9 @@ Copyright (c) 2012 ABRT Team <crash-catcher@fedorahosted.com>
     <description>Get problems from all users</description>
     <message>Reading others problems requires authentication</message>
     <defaults>
-      <allow_any>no</allow_any>
+      <allow_any>auth_admin</allow_any>
       <allow_active>auth_admin_keep</allow_active>
-      <allow_inactive>no</allow_inactive>
+      <allow_inactive>auth_admin</allow_inactive>
     </defaults>
   </action>
 
@@ -30,9 +30,9 @@ Copyright (c) 2012 ABRT Team <crash-catcher@fedorahosted.com>
     <description>Set value of configuration properties</description>
     <message>Update configuration values reuquires authentication</message>
     <defaults>
-      <allow_any>no</allow_any>
+      <allow_any>auth_admin</allow_any>
       <allow_active>auth_admin_keep</allow_active>
-      <allow_inactive>no</allow_inactive>
+      <allow_inactive>auth_admin</allow_inactive>
     </defaults>
   </action>
 


### PR DESCRIPTION
In order to allow use of ABRT's DBus API on servers, the polkit
policy should allow admin usage even when not logged in an active
seat (ie: monitor and keyboard). Otherwise use from ssh logins and
Cockpit is prevented.
