### PR TITLE
dbus: Fix invalid dbus policy file

### DIFF
--- a/src/dbus/dbus-abrt.conf
+++ b/src/dbus/dbus-abrt.conf
@@ -16,11 +16,6 @@
     <allow send_interface="com.redhat.problems.configuration"/>
   </policy>
 
-  <policy at_console="true">
-    <allow send_destination="org.freedesktop.org"/>
-    <allow send_destination="com.redhat.problems.configuration"/>
-  </policy>
-
   <!-- Allow anyone to invoke methods on abrt server -->
   <policy context="default">
     <allow send_destination="org.freedesktop.problems"/>


### PR DESCRIPTION
The use of at_console is a bit of a relic from times before polkit.

But more importantly I've removed a section that has no effect, and
opens up the dbus policy for an invalid name: org.freedesktop.org
