### PR TITLE
koops: don't analyze MCEs like standard oopses

### DIFF
--- a/src/plugins/abrt-action-check-oops-for-hw-error.in
+++ b/src/plugins/abrt-action-check-oops-for-hw-error.in
@@ -4,6 +4,8 @@ import sys
 import os
 import locale
 import gettext
+import hashlib
+import re
 
 GETTEXT_PROGNAME = "abrt"
 
@@ -82,6 +84,23 @@ if __name__ == "__main__":
                 "This is most likely not a software problem.\n"
     ))
     f.close()
+
+    oops_hash = hashlib.sha1()
+    with open("backtrace", "r") as btfile:
+        for line in btfile:
+            oops_hash.update(line)
+
+    with open_or_die("uuid", "w") as f:
+        f.write(oops_hash.hexdigest())
+
+    with open_or_die("duphash", "w") as f:
+        f.write(oops_hash.hexdigest())
+
+    res = tail_with_search("dmesg", "Linux version", 1)
+    if res:
+        kernel = re.sub(r"^.*Linux version ([^ ]+) .*$", r"\1", res[0]);
+        with open_or_die("kernel", "w") as krnlfile:
+            krnlfile.write(kernel)
 
     # vmcore MCEs already have good backtrace element, nothing more to do
     if vmcore_mce:

--- a/src/plugins/koops_event.conf
+++ b/src/plugins/koops_event.conf
@@ -1,23 +1,22 @@
 # Analyze
 EVENT=post-create analyzer=Kerneloops
         # >> instead of > is due to bugzilla.redhat.com/show_bug.cgi?id=854266
-        abrt-action-analyze-oops &&
-        dmesg >>dmesg &&
-        {
-        # action-analyze-oops tries to save kernel version,
-        # but for some oopses it can't do that (e.g. MCEs).
-        # If it failed, try to extract version from dmesg:
-        test -f kernel ||
-            {
-            k=`sed -n '/Linux version/ s/.*Linux version \([^ ]*\) .*/\1/p' dmesg | tail -n1`
-            test "$k" != "" && printf "%s" "$k" >kernel
-            true   # ignore possible failures in previous command
-            }
-        } &&
-        abrt-action-save-kernel-data &&
+        # 'dmesg' file is required by check-oops-for-hw-error
+        dmesg >>dmesg
         # Do not fail the event (->do not delete problem dir)
         # if check-oops-for-hw-error exits nonzero:
-        { abrt-action-check-oops-for-hw-error || true; }
+        {
+        abrt-action-check-oops-for-hw-error || true
+        } &&
+        {
+        # run abrt-action-analyze-oops only if check-hw-error didn't create the
+        # required files
+        if test ! -f uuid -a ! -f duphash; then
+             abrt-action-analyze-oops || exit 1
+        fi
+        } &&
+        abrt-action-save-kernel-data
+
 
 # If you want behavior similar to one provided by kerneloops daemon
 # distributed by kerneloops.org - that is, if you want


### PR DESCRIPTION
MCEs are not kernel oopses as we know them, MCEs do not have stacktrace
and ABRT drops oopses without meaningful stack trace frames for hashing.
The required files are generated by abrt-action-check-oops-for-hw-errror
because that executable understands the format of MCE data.
- uuid    (sha1 of backtrace file)
- duphash (sha1 of backtrace file)
- kernel  (from dmesg)

Signed-off-by: Jakub Filak jfilak@redhat.com
