### PR TITLE
python: support exceptions without traceback

### DIFF
--- a/src/hooks/abrt_exception_handler.py.in
+++ b/src/hooks/abrt_exception_handler.py.in
@@ -55,12 +55,14 @@ def write_dump(tb_text, tb):
         executable = sys.argv[0]
 
     dso_list = None
-    try:
-        import rpm
-        dso_list = get_dso_list(tb)
-    except ImportError as imperr:
-        syslog("RPM module not available, cannot query RPM db for package "\
-               "names")
+    # Trace back is None in case of SyntaxError exception.
+    if tb:
+        try:
+            import rpm
+            dso_list = get_dso_list(tb)
+        except ImportError as imperr:
+            syslog("RPM module not available, cannot query RPM db for package "\
+                   "names")
 
     # Open ABRT daemon's socket and write data to it
     try:


### PR DESCRIPTION
e.g. SyntaxError (python-2.7.5-13.fc20, python-2.7.7-2.fc21)

Please be aware of abrt/satyr#168
