### PR TITLE
a-a-s-p-d: add firefox on the package blacklist

### DIFF
--- a/src/daemon/abrt-action-save-package-data.conf
+++ b/src/daemon/abrt-action-save-package-data.conf
@@ -7,7 +7,7 @@ OpenGPGCheck = yes
 
 # Blacklisted packages
 #
-BlackList = nspluginwrapper, valgrind, strace, mono-core
+BlackList = nspluginwrapper, valgrind, strace, mono-core, firefox
 
 # Process crashes in executables which do not belong to any package?
 #
@@ -15,7 +15,7 @@ ProcessUnpackaged = no
 
 # Blacklisted executable paths (shell patterns)
 #
-BlackListedPaths = /usr/share/doc/*, */example*, /usr/bin/nspluginviewer, /usr/lib/xulrunner-*/plugin-container
+BlackListedPaths = /usr/share/doc/*, */example*, /usr/bin/nspluginviewer
 
 # interpreters names
 Interpreters = python2, python2.7, python, python3, python3.3, perl, perl5.16.2


### PR DESCRIPTION
And drop the path to plugins-container from the path blacklist because:
- the path belongs to firefox package
- the path is invalid, the correct path is:
  /usr/lib(64)/firefox/plugin-container

Resolves rhbz#1132018

Signed-off-by: Jakub Filak jfilak@redhat.com
