### PR TITLE
Allow to disable vmcore plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,9 +50,12 @@ if HAVE_SYSTEMD
                                   init-scripts/abrt-ccpp.service \
                                   init-scripts/abrt-oops.service \
                                   init-scripts/abrt-xorg.service \
-                                  init-scripts/abrt-vmcore.service \
                                   init-scripts/abrt-pstoreoops.service \
                                   init-scripts/abrt-upload-watch.service
+
+if BUILD_ADDON_VMCORE
+    dist_systemdsystemunit_DATA += init-scripts/abrt-vmcore.service
+endif
 
     systemdtmpfilesdir = $(prefix)/lib/tmpfiles.d
     systemdtmpfiles_DATA = init-scripts/abrt.conf
@@ -65,6 +68,11 @@ else
                         init-scripts/abrt-vmcore \
                         init-scripts/abrt-pstoreoops \
                         init-scripts/abrt-upload-watch
+
+if BUILD_ADDON_VMCORE
+    sysv_init_SCRIPTS += init-scripts/abrt-vmcore
+endif
+
 endif
 
 RPM_DIRS = --define "_sourcedir `pwd`" \

--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,18 @@ AC_ARG_ENABLE([native-unwinder],
     AC_DEFINE([ENABLE_NATIVE_UNWINDER], [1], [Use elfutils/libunwind for unwinding instead of GDB.])
 [fi]
 
+AC_ARG_ENABLE([addon-vmcore],
+    AS_HELP_STRING([--enable-addon-vmcore],
+        [allow to disable vmcore addon (for architectures without kexec/kdump) (default is yes)]),
+    [], [enable_addon_vmcore=yes])
+
+[if test "$enable_addon_vmcore" = "yes"]
+[then]
+    AC_DEFINE([ENABLE_ADDON_VMCORE], [1], [Disable vmcore addon (for architectures without kexec/kdump).])
+	AM_CONDITIONAL(BUILD_ADDON_VMCORE, true)
+[else]
+	AM_CONDITIONAL(BUILD_ADDON_VMCORE, false)
+[fi]
 
 AC_SUBST(CONF_DIR)
 AC_SUBST(DEFAULT_CONF_DIR)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,15 +25,12 @@ MAN1_TXT += abrt-auto-reporting.txt
 MAN1_TXT += abrt-retrace-client.txt
 MAN1_TXT += abrt-handle-upload.txt
 MAN1_TXT += abrt-harvest-pstoreoops.txt
-MAN1_TXT += abrt-harvest-vmcore.txt
 MAN1_TXT += abrt-merge-pstoreoops.txt
 MAN1_TXT += abrt-server.txt
 MAN1_TXT += abrt-cli.txt
 MAN1_TXT += abrt-action-save-package-data.txt
 MAN1_TXT += abrt-action-save-kernel-data.txt
 MAN1_TXT += abrt-install-ccpp-hook.txt
-MAN1_TXT += abrt-action-analyze-vmcore.txt
-MAN1_TXT += abrt-action-check-oops-for-hw-error.txt
 MAN1_TXT += abrt-action-analyze-ccpp-local.txt
 MAN1_TXT += abrt-watch-log.txt
 MAN1_TXT += abrt-upload-watch.txt
@@ -41,6 +38,7 @@ MAN1_TXT += system-config-abrt.txt
 if BUILD_BODHI
 MAN1_TXT += abrt-bodhi.txt
 endif
+
 
 MAN5_TXT =
 MAN5_TXT += abrt.conf.txt
@@ -51,7 +49,6 @@ MAN5_TXT += abrt-python3.conf.txt
 MAN5_TXT += abrt-CCpp.conf.txt
 MAN5_TXT += abrt-oops.conf.txt
 MAN5_TXT += gpg_keys.conf.txt
-MAN5_TXT += abrt-vmcore.conf.txt
 
 MAN5_PREFORMATTED =
 MAN5_PREFORMATTED += abrt_event.conf.5
@@ -63,8 +60,15 @@ MAN5_PREFORMATTED += python_event.conf.5
 MAN5_PREFORMATTED += python3_event.conf.5
 MAN5_PREFORMATTED += smart_event.conf.5
 MAN5_PREFORMATTED += vimrc_event.conf.5
-MAN5_PREFORMATTED += vmcore_event.conf.5
 MAN5_PREFORMATTED += xorg_event.conf.5
+
+if BUILD_ADDON_VMCORE
+MAN1_TXT += abrt-harvest-vmcore.txt
+MAN1_TXT += abrt-action-analyze-vmcore.txt
+MAN1_TXT += abrt-action-check-oops-for-hw-error.txt
+MAN5_TXT += abrt-vmcore.conf.txt
+MAN5_PREFORMATTED += vmcore_event.conf.5
+endif
 
 MAN8_TXT =
 MAN8_TXT += abrtd.txt abrt-dbus.txt abrt-configuration.txt

--- a/doc/dbus-configuration/Makefile.am
+++ b/doc/dbus-configuration/Makefile.am
@@ -10,7 +10,11 @@ dist_dbusabrtinterfaces_DATA = \
 	com.redhat.problems.configuration.ccpp.xml \
 	com.redhat.problems.configuration.oops.xml \
 	com.redhat.problems.configuration.python.xml \
-	com.redhat.problems.configuration.vmcore.xml \
 	com.redhat.problems.configuration.xorg.xml
+
+if BUILD_ADDON_VMCORE
+dist_dbusabrtinterfaces_DATA += \
+	com.redhat.problems.configuration.vmcore.xml
+endif
 
 EXTRA_DIST = ${INTERFACES_DIST_FILES}

--- a/src/hooks/Makefile.am
+++ b/src/hooks/Makefile.am
@@ -8,7 +8,6 @@ dist_pluginsconf_DATA = \
     CCpp.conf \
     python.conf \
     python3.conf \
-    vmcore.conf \
     oops.conf
 
 defaultpluginsconfdir = $(DEFAULT_PLUGINS_CONF_DIR)
@@ -16,7 +15,6 @@ dist_defaultpluginsconf_DATA = $(dist_pluginsconf_DATA)
 
 sbin_SCRIPTS = \
     abrt-install-ccpp-hook \
-    abrt-harvest-vmcore \
     abrt-harvest-pstoreoops
 
 bin_PROGRAMS = \
@@ -69,8 +67,16 @@ py3hook_PYTHON = \
 EXTRA_DIST = abrt_exception_handler.py.in \
 	abrt_exception_handler3.py.in \
 	abrt-install-ccpp-hook.in \
-	abrt_harvest_vmcore.py.in \
 	abrt-harvest-pstoreoops.in
+
+if BUILD_ADDON_VMCORE
+sbin_SCRIPTS += \
+    abrt-harvest-vmcore
+dist_pluginsconf_DATA += \
+    vmcore.conf
+EXTRA_DIST +=  \
+	abrt_harvest_vmcore.py.in
+endif
 
 CLEANFILES := $(notdir $(wildcard *~)) $(notdir $(wildcard *\#)) $(notdir $(wildcard \.\#*)) $(notdir $(wildcard *.pyc)) $(man1_MANS)
 

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -4,8 +4,6 @@ bin_SCRIPTS = \
     abrt-action-install-debuginfo \
     abrt-action-analyze-core \
     abrt-action-analyze-vulnerability \
-    abrt-action-analyze-vmcore \
-    abrt-action-check-oops-for-hw-error \
     abrt-action-list-dsos \
     abrt-action-perform-ccpp-analysis \
     abrt-action-save-kernel-data \
@@ -48,7 +46,6 @@ dist_events_DATA = \
     analyze_CCpp.xml \
     analyze_LocalGDB.xml \
     analyze_RetraceServer.xml \
-    analyze_VMcore.xml \
     collect_xsession_errors.xml \
     collect_GConf.xml \
     collect_vimrc_user.xml \
@@ -64,7 +61,6 @@ dist_eventsconf_DATA = \
     ccpp_retrace_event.conf \
     koops_event.conf \
     xorg_event.conf \
-    vmcore_event.conf \
     python_event.conf \
     python3_event.conf \
     smart_event.conf \
@@ -77,7 +73,6 @@ PYTHON_FILES = \
     abrt-action-list-dsos \
     abrt-action-analyze-core \
     abrt-action-analyze-vulnerability \
-    abrt-action-analyze-vmcore.in \
     abrt-action-check-oops-for-hw-error.in \
     abrt-action-perform-ccpp-analysis.in \
     abrt-action-notify
@@ -91,11 +86,8 @@ EXTRA_DIST = \
     analyze_CCpp.xml.in \
     analyze_LocalGDB.xml.in \
     analyze_RetraceServer.xml.in \
-    analyze_VMcore.xml.in \
     abrt-action-analyze-core.in \
-    abrt-action-analyze-vmcore \
     abrt-action-generate-machine-id \
-    abrt-action-check-oops-for-hw-error \
     abrt-action-save-kernel-data \
     abrt-action-ureport \
     abrt-gdb-exploitable \
@@ -104,6 +96,26 @@ EXTRA_DIST = \
     abrt-journal.h \
     post_report.xml.in \
     abrt-action-analyze-ccpp-local.in
+
+if BUILD_ADDON_VMCORE
+bin_SCRIPTS += \
+    abrt-action-analyze-vmcore \
+    abrt-action-check-oops-for-hw-error
+
+dist_events_DATA += \
+    analyze_VMcore.xml
+
+dist_eventsconf_DATA += \
+    vmcore_event.conf
+
+PYTHON_FILES += \
+    abrt-action-analyze-vmcore.in
+
+EXTRA_DIST += \
+    analyze_VMcore.xml.in \
+    abrt-action-analyze-vmcore \
+    abrt-action-check-oops-for-hw-error
+endif
 
 confdir = $(PLUGINS_CONF_DIR)
 dist_conf_DATA = \


### PR DESCRIPTION
On AArch64 architecture there is no kexec/kdump support yet. Disabling
vmcore plugin allows to install Fedora there.

Signed-off-by: Marcin Juszkiewicz mjuszkiewicz@redhat.com
