### PR TITLE
cli: add option remove crash dirs after reporting

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -53,6 +53,7 @@ src/cli/abrt-cli-core.c
 src/cli/abrt-cli.c
 src/cli/list.c
 src/cli/status.c
+src/cli/report.c
 
 src/plugins/analyze_CCpp.xml.in
 src/plugins/analyze_VMcore.xml.in


### PR DESCRIPTION
Add option -d to abrt-cli report which allows delete dump dir after the problem
was successfully reported.

Related to rhbz#1067545

Signed-off-by: Matej Habrnal mhabrnal@redhat.com
