### PR TITLE
journal-oops: use the length result of sd_journal_get_data()

### DIFF
--- a/src/plugins/abrt-dump-journal-oops.c
+++ b/src/plugins/abrt-dump-journal-oops.c
@@ -38,8 +38,8 @@ static GList* abrt_journal_extract_kernel_oops(abrt_journal_t *journal)
 
     do
     {
-        const char *line = NULL;
-        if (abrt_journal_get_log_line(journal, &line) < 0)
+        char *line = abrt_journal_get_log_line(journal);
+        if (line == NULL)
             error_msg_and_die(_("Cannot read journal data."));
 
         if (lines_info_count == lines_info_size)
@@ -48,10 +48,13 @@ static GList* abrt_journal_extract_kernel_oops(abrt_journal_t *journal)
             lines_info = xrealloc(lines_info, lines_info_size * sizeof(lines_info[0]));
         }
 
-        lines_info[lines_info_count].level = koops_line_skip_level(&line);
-        koops_line_skip_jiffies(&line);
+        char *orig_line = line;
+        lines_info[lines_info_count].level = koops_line_skip_level((const char **)&line);
+        koops_line_skip_jiffies((const char **)&line);
 
-        lines_info[lines_info_count].ptr = xstrdup(line);
+        memmove(orig_line, line, strlen(line) + 1);
+
+        lines_info[lines_info_count].ptr = orig_line;
 
         ++lines_info_count;
     }

--- a/src/plugins/abrt-journal.h
+++ b/src/plugins/abrt-journal.h
@@ -40,11 +40,13 @@ int abrt_journal_get_field(abrt_journal_t *journal,
                            const void **value,
                            size_t *value_len);
 
-int abrt_journal_get_string_field(abrt_journal_t *journal,
+/* Returns allocated memory if value is NULL; otherwise makes copy of journald
+ * field to memory pointed by value arg. */
+char *abrt_journal_get_string_field(abrt_journal_t *journal,
                                   const char *field,
-                                  const char **value);
+                                  char *value);
 
-int abrt_journal_get_log_line(abrt_journal_t *journal, const char **line);
+char *abrt_journal_get_log_line(abrt_journal_t *journal);
 
 int abrt_journal_get_cursor(abrt_journal_t *journal, char **cursor);
 


### PR DESCRIPTION
journald doesn't guarantee NULL terminated strings returned from
sd_journal_get_data(). It usually works but not always.

This patch fixes the issue by using the length of field data instead of
assuming that string is NULL terminated.

Resolves: #1141549

Signed-off-by: Jakub Filak jfilak@redhat.com
