### PR TITLE
Fix acquiring of D-Bus name in abrtd

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -692,6 +692,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_bindir}/abrt-watch-log
 %{_bindir}/abrt-action-analyze-python
 %{_bindir}/abrt-action-analyze-xorg
+%config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.freedesktop.problems.daemon.conf
 %config(noreplace) %{_sysconfdir}/%{name}/abrt.conf
 %{_datadir}/%{name}/conf.d/abrt.conf
 %config(noreplace) %{_sysconfdir}/%{name}/abrt-action-save-package-data.conf

--- a/init-scripts/abrtd.service
+++ b/init-scripts/abrtd.service
@@ -6,6 +6,8 @@ Description=ABRT Automated Bug Reporting Tool
 After=livesys.service
 
 [Service]
+Type=dbus
+BusName=org.freedesktop.problems.daemon
 ExecStart=/usr/sbin/abrtd -d -s
 
 [Install]

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -119,6 +119,9 @@ dist_daemonconf_DATA = \
 defaultdaemonconfdir = $(DEFAULT_CONF_DIR)
 dist_defaultdaemonconf_DATA = $(dist_daemonconf_DATA)
 
+dbusabrtconfdir = ${sysconfdir}/dbus-1/system.d/
+dist_dbusabrtconf_DATA = org.freedesktop.problems.daemon.conf
+
 EXTRA_DIST = abrt-handle-upload.in
 
 DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@

--- a/src/daemon/abrtd.c
+++ b/src/daemon/abrtd.c
@@ -44,6 +44,8 @@
 
 #define IN_DUMP_LOCATION_FLAGS (IN_DELETE_SELF | IN_MOVE_SELF)
 
+#define ABRTD_DBUS_NAME ABRT_DBUS_NAME".daemon"
+
 /* Daemon initializes, then sits in glib main loop, waiting for events.
  * Events can be:
  * - inotify: something new appeared under /var/tmp/abrt or /var/spool/abrt-upload
@@ -430,6 +432,28 @@ static void mark_unprocessed_dump_dirs_not_reportable(const char *path)
     closedir(dp);
 }
 
+static void on_bus_acquired(GDBusConnection *connection,
+                 const gchar     *name,
+                 gpointer         user_data)
+{
+    log_debug("Going to own bus '%s'", name);
+}
+
+static void on_name_acquired (GDBusConnection *connection,
+                  const gchar     *name,
+                  gpointer         user_data)
+{
+    log_debug("Acquired the name '%s' on the system bus", name);
+}
+
+static void on_name_lost(GDBusConnection *connection,
+                      const gchar *name,
+                      gpointer user_data)
+{
+    error_msg_and_die(_("The name '%s' has been lost, please check if other "
+                        "service owning the name is not running.\n"), name);
+}
+
 int main(int argc, char** argv)
 {
     /* I18n */
@@ -578,11 +602,13 @@ int main(int argc, char** argv)
     }
 
     /* Own a name on D-Bus */
-    name_id = g_bus_own_name (G_BUS_TYPE_SYSTEM,
-                              "org.freedesktop.problems.daemon",
-                              G_BUS_NAME_OWNER_FLAGS_NONE,
-                              NULL, NULL, NULL,
-                              NULL, NULL);
+    name_id = g_bus_own_name(G_BUS_TYPE_SYSTEM,
+                             ABRTD_DBUS_NAME,
+                             G_BUS_NAME_OWNER_FLAGS_NONE,
+                             on_bus_acquired,
+                             on_name_acquired,
+                             on_name_lost,
+                             NULL, NULL);
 
     start_idle_timeout();
 

--- a/src/daemon/org.freedesktop.problems.daemon.conf
+++ b/src/daemon/org.freedesktop.problems.daemon.conf
@@ -1,0 +1,14 @@
+<!-- This configuration file specifies the required security policies
+     for abrt core daemon to work. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- ../system.conf have denied everything, so we just punch some holes -->
+
+  <policy user="root">
+    <allow own="org.freedesktop.problems.daemon"/>
+  </policy>
+
+</busconfig>


### PR DESCRIPTION
It does not work because own main loop ignores `g_bus_own_name`.
I have found out this unpleasant state of abrtd when I was working on the first patch in this pull request.