### PR TITLE
Python 3 compatibility

### DIFF
--- a/src/daemon/abrt-handle-upload.in
+++ b/src/daemon/abrt-handle-upload.in
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     delete_archive = False
     for opt, arg in opts:
         if opt in ("-h", "--help"):
-            print help_text
+            print(help_text)
             sys.exit(0)
         if opt == "-v":
             verbose += 1

--- a/src/hooks/abrt-harvest-pstoreoops.in
+++ b/src/hooks/abrt-harvest-pstoreoops.in
@@ -26,7 +26,7 @@ if __name__ == "__main__":
 
     try:
         os.chdir(pstoredir)
-    except OSError, ex:
+    except OSError as ex:
         # silently ignore if the pstore doesn't exist, because that usually
         # means that we're on the system where pstore boot is not supported
         sys.stderr.write("Can't chdir to {0}: {1}".format(pstoredir, ex))

--- a/src/hooks/abrt_harvest_vmcore.py.in
+++ b/src/hooks/abrt_harvest_vmcore.py.in
@@ -127,12 +127,12 @@ def change_mode_rec(dest):
     dest - path to the directory
     """
 
-    os.chmod(dest, 0700)
+    os.chmod(dest, 0o700)
     for root, dirs, files in os.walk(dest):
         for i in dirs:
-            os.chmod(os.path.join(root, i), 0700)
+            os.chmod(os.path.join(root, i), 0o700)
         for i in files:
-            os.chmod(os.path.join(root, i), 0600)
+            os.chmod(os.path.join(root, i), 0o600)
 
 
 def create_abrtd_info(dest):
@@ -192,7 +192,7 @@ def harvest_vmcore():
         sys.exit(1)
 
     # Wait for abrtd to start. Give it at least 1 second to initialize.
-    for i in xrange(10):
+    for i in range(10):
         if i is 9:
             sys.exit(1)
         elif os.system('pidof abrtd >/dev/null'):
@@ -200,7 +200,7 @@ def harvest_vmcore():
         else:
             break
 
-    os.umask(077)
+    os.umask(0o077)
 
     # Check abrt config files for copy/move settings and
     try:

--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -38,7 +38,7 @@ def error_msg_and_die(s):
 def xopen(name, mode):
     try:
         r = open(name, mode)
-    except IOError, ex:
+    except IOError as ex:
         error_msg_and_die("Can't open '%s': %s" % (name, ex))
     return r
 
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     help_text = _("Usage: %s [-v] [-o OUTFILE] -c COREFILE") % progname
     try:
         opts, args = getopt.getopt(sys.argv[1:], "vhc:o:", ["help", "core="])
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         error_msg(err) # prints something like "option -a not recognized"
         error_msg_and_die(help_text)
 
@@ -151,7 +151,7 @@ if __name__ == "__main__":
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
-            print help_text
+            print(help_text)
             exit(0)
         elif opt == "-v":
             verbose += 1
@@ -172,7 +172,7 @@ if __name__ == "__main__":
         outfile = sys.stdout
         outname = opt_o
         # Make sure the file is readable for all
-        oldmask = os.umask(0002)
+        oldmask = os.umask(0o002)
         for bid in b_ids:
             if outname:
                 outfile = xopen(outname, "w")
@@ -180,7 +180,7 @@ if __name__ == "__main__":
             outfile.write("%s\n" % bid)
         outfile.close()
         os.umask(oldmask)
-    except IOError, e:
+    except IOError as e:
         if not opt_o:
             opt_o = "<stdout>"
         error_msg_and_die("Error writing to '%s': %s" % (opt_o, e))

--- a/src/plugins/abrt-action-analyze-vmcore.in
+++ b/src/plugins/abrt-action-analyze-vmcore.in
@@ -52,22 +52,22 @@ if __name__ == "__main__":
     help_text = _("Usage: {0} [-v[v]] [--core=VMCORE]").format(PROGNAME)
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hvd", ["help", "core="])
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         error_msg(str(err))  # prints something like "option -a not recognized"
         error_msg_and_die(help_text)
     usercache = False
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
-            print help_text
+            print(help_text)
             exit(0)
         elif opt == "-v":
             verbose += 1
         elif opt in ("-d"):
             try:
                 os.chdir(arg)
-            except OSError, ex:
-                print str(ex)
+            except OSError as ex:
+                print(ex)
                 sys.exit(RETURN_FAILURE)
 
     if not vmcore:
@@ -76,10 +76,10 @@ if __name__ == "__main__":
     set_verbosity(verbose)
 
     if not os.path.exists(vmcore):
-        print _("File {0} doesn't exist").format(vmcore)
+        print(_("File {0} doesn't exist").format(vmcore))
         sys.exit(RETURN_FAILURE)
 
-    print _("Extracting the oops text from core")
+    print(_("Extracting the oops text from core"))
     crash = Popen(["makedumpfile", "--dump-dmesg", "-f", vmcore, dmesg_log], stdout=PIPE, stderr=PIPE, bufsize=-1)
     out, err = crash.communicate()
 
@@ -92,8 +92,8 @@ if __name__ == "__main__":
     backtrace_file.close()
     ret = dump_oops.returncode
     if dump_oops.returncode != 0:
-        print _("Can't extract the oops message: '{0}'").format(err)
+        print(_("Can't extract the oops message: '{0}'").format(err))
         sys.exit(ret)
 
-    print _("Oops text extracted successfully")
+    print(_("Oops text extracted successfully"))
     sys.exit(ret)

--- a/src/plugins/abrt-action-generate-machine-id
+++ b/src/plugins/abrt-action-generate-machine-id
@@ -133,7 +133,7 @@ def print_result(ids, outfile, prefixed):
     if len(ids) > 1:
         fmt += '\n'
 
-    for sd, mid in ids.iteritems():
+    for sd, mid in ids.items():
         outfile.write(fmt.format(sd,mid))
 
 
@@ -147,7 +147,7 @@ def print_generators(outfile=None):
     if outfile is None:
         outfile = sys.stdout
 
-    for sd in GENERATORS.iterkeys():
+    for sd in GENERATORS.keys():
         outfile.write("{0}\n".format(sd))
 
 
@@ -175,7 +175,7 @@ if __name__ == '__main__':
     if ARGS['generators']:
         requested_generators = ARGS['generators']
     else:
-        requested_generators = GENERATORS.keys()
+        requested_generators = list(GENERATORS.keys())
 
     machineids = generate_machine_id(requested_generators)
 
@@ -192,4 +192,4 @@ if __name__ == '__main__':
         if len(machineids) == 1:
             sys.stdout.write('\n')
 
-    sys.exit(len(requested_generators) - len(machineids.keys()))
+    sys.exit(len(requested_generators) - len(machineids))

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -48,7 +48,7 @@ def sigterm_handler(signum, frame):
 
 def sigint_handler(signum, frame):
     clean_up()
-    print "\n", _("Exiting on user command")
+    print("\n{0}".format(_("Exiting on user command")))
     sys.stdout.flush()
     # ??! without "sys.", I am getting segv!
     sys.exit(RETURN_OK)
@@ -109,13 +109,13 @@ if __name__ == "__main__":
         opts, args = getopt.getopt(sys.argv[1:], "vyhe",
                 ["help", "ids=", "cache=", "size_mb=", "tmpdir=", "keeprpms",
                  "exact=", "repo="])
-    except getopt.GetoptError, err:
-        print str(err) # prints something like "option -a not recognized"
+    except getopt.GetoptError as err:
+        print(err) # prints something like "option -a not recognized"
         exit(RETURN_FAILURE)
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
-            print help_text
+            print(help_text)
             exit(0)
         elif opt == "-v":
             verbose += 1
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         try:
             conf = problem.load_plugin_conf_file("CCpp.conf")
         except OSError as ex:
-            print str(ex)
+            print(ex)
         else:
             cachedirs = conf.get("DebuginfoLocation", None)
 
@@ -165,7 +165,7 @@ if __name__ == "__main__":
         if fbuild_ids != "-":
             try:
                 fin = open(fbuild_ids, "r")
-            except IOError, ex:
+            except IOError as ex:
                 error_msg_and_die(_("Can't open {0}: {1}").format(fbuild_ids, ex))
         for line in fin.readlines():
             b_ids.append(line.strip('\n'))
@@ -193,7 +193,7 @@ if __name__ == "__main__":
                 error_msg_and_die("Can't execute '%s'", "abrt-action-trim-files");
             if pid > 0:
                 os.waitpid(pid, 0);
-        except Exception, e:
+        except Exception as e:
             error_msg("Can't execute abrt-action-trim-files: %s", e);
 
         missing = filter_installed_debuginfos(b_ids, cachedirs)
@@ -203,10 +203,10 @@ if __name__ == "__main__":
     if missing:
         log2("%s", missing)
         if len(b_ids) > 0:
-            print _("Coredump references {0} debuginfo files, {1} of them are not installed").format(len(b_ids), len(missing))
+            print(_("Coredump references {0} debuginfo files, {1} of them are not installed").format(len(b_ids), len(missing)))
         else:
             # Only --exact FILE[:FILE2]... was specified
-            print _("{0} of debuginfo files are not installed").format(len(missing))
+            print(_("{0} of debuginfo files are not installed").format(len(missing)))
 
         # TODO: should we pass keep_rpms=keeprpms to DebugInfoDownload here??
         downloader = DebugInfoDownload(cache=cachedirs[0], tmp=tmpdir,
@@ -214,21 +214,21 @@ if __name__ == "__main__":
                                        repo_pattern=repo_pattern)
         try:
             result = downloader.download(missing, download_exact_files=exact_fls)
-        except Exception, ex:
+        except Exception as ex:
             error_msg_and_die("Can't download debuginfos: %s", ex)
 
         if exact_fls:
             for bid in missing:
                 if not os.path.isfile(bid):
-                    print _("Missing requested file: {0}").format(bid)
+                    print(_("Missing requested file: {0}").format(bid))
                     exact_file_missing = True
 
         missing = filter_installed_debuginfos(b_ids, cachedirs)
         for bid in missing:
-            print _("Missing debuginfo file: {0}").format(bid)
+            print(_("Missing debuginfo file: {0}").format(bid))
 
     if not missing and not exact_file_missing:
-        print _("All debuginfo files are available")
+        print(_("All debuginfo files are available"))
 
     if exact_file_missing:
         result = RETURN_FAILURE

--- a/src/plugins/abrt-action-list-dsos
+++ b/src/plugins/abrt-action-list-dsos
@@ -20,7 +20,7 @@ def error_msg_and_die(s):
 def xopen(name, mode):
     try:
         r = open(name, mode)
-    except IOError, e:
+    except IOError as e:
         error_msg_and_die("Can't open '%s': %s" % (name, e))
     return r
 
@@ -37,7 +37,7 @@ def parse_maps(maps_path):
         files = [x[x.find('/'):].split()[0] for x in f.readlines() if x.find('/') > -1]
         # set() uniqifies the list of filenames
         return set(files)
-    except IOError, e:
+    except IOError as e:
         error_msg_and_die("Can't read '%s': %s" % (maps_path, e))
 
 if __name__ == "__main__":
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     help_text = ("Usage: %s [-o OUTFILE] -m PROC_PID_MAP_FILE") % progname
     try:
         opts, args = getopt.getopt(sys.argv[1:], "o:m:h", ["help"])
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         error_msg(err) # prints something like "option -a not recognized"
         error_msg_and_die(help_text)
 
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
-            print help_text
+            print(help_text)
             exit(0)
         #elif opt == "-v":
         #    verbose += 1
@@ -89,7 +89,7 @@ if __name__ == "__main__":
                                      h[rpm.RPMTAG_INSTALLTIME])
                                     )
 
-        except Exception, ex:
+        except Exception as ex:
             error_msg_and_die("Can't get the DSO list: %s" % ex)
 
         outfile.close()

--- a/src/plugins/abrt-action-perform-ccpp-analysis.in
+++ b/src/plugins/abrt-action-perform-ccpp-analysis.in
@@ -36,7 +36,7 @@ def handle_event(event_name, problem_dir):
     ret = state.run_event_on_dir_name(problem_dir, event_name)
 
     if ret == 0 and state.children_count == 0:
-        print "No actions are found for event '%s'" % event_name
+        print("No actions are found for event '%s'" % event_name)
         return RETURN_FAILURE
 
     return ret

--- a/src/plugins/abrt-action-ureport
+++ b/src/plugins/abrt-action-ureport
@@ -99,13 +99,13 @@ if __name__ == "__main__":
     help_text = _("Usage: %s [-v]") % progname
     try:
         opts, args = getopt.getopt(sys.argv[1:], "vh", ["help"])
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         error_msg(err)  # prints something like "option -a not recognized"
         error_msg_and_die(help_text)
 
     for opt, arg in opts:
         if opt in ("-h", "--help"):
-            print help_text
+            print(help_text)
             sys.exit(0)
         if opt == "-v":
             verbose += 1
@@ -148,7 +148,7 @@ if __name__ == "__main__":
                 log(_("A bug was already filed about this problem:"))
                 bugs = sorted(bugs)
                 for bug in bugs:
-                    print bug
+                    print(bug)
                 sys.exit(70)  # EXIT_STOP_EVENT_RUN
             log1("Bug for '%s' not yet filed. Continuing.", dirname)
             sys.exit(0)


### PR DESCRIPTION
This patch just applies what 2to3 found so that the scripts can run both
under python 2 and python 3. More work is needed to fully switch to
python 3.

Related to rhbz#1192080.

Signed-off-by: Martin Milata <mmilata@redhat.com>