### PR TITLE
Python 3 fixes

### DIFF
--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -70,7 +70,7 @@ def extract_info_from_core(coredump_name):
     EXECUTABLE = 4
 
     log(_("Analyzing coredump '%s'") % coredump_name)
-    eu_unstrip_OUT = Popen(["eu-unstrip","--core=%s" % coredump_name, "-n"], stdout=PIPE, bufsize=-1).communicate()[0]
+    eu_unstrip_OUT = Popen(["eu-unstrip","--core=%s" % coredump_name, "-n"], stdout=PIPE, bufsize=-1, universal_newlines=True).communicate()[0]
     # parse eu_unstrip_OUT and return the list of build_ids
 
     # eu_unstrip_OUT = (

--- a/src/plugins/abrt-action-list-dsos
+++ b/src/plugins/abrt-action-list-dsos
@@ -84,8 +84,8 @@ if __name__ == "__main__":
                             outname = None
                         outfile.write("%s %s (%s) %s\n" %
                                     (path,
-                                     h[rpm.RPMTAG_NEVRA],
-                                     h[rpm.RPMTAG_VENDOR],
+                                     h[rpm.RPMTAG_NEVRA].decode('utf-8'),
+                                     h[rpm.RPMTAG_VENDOR].decode('utf-8'),
                                      h[rpm.RPMTAG_INSTALLTIME])
                                     )
 


### PR DESCRIPTION
Fixes two places where `bytes` are used instead `unicode` in python3 (or vice versa?).

With this patch + shebangs replaced with `#!/usr/bin/python3` the basic functionality of ABRT seems to work under Fedora 22. Dependencies in spec file will have to be adujsted as well for the migration (e.g. add `rpm-python3` and `python3-augeas` (currently only in F22)).