### PR TITLE
abrt-applet: get new problems over DBus

### DIFF
--- a/src/applet/applet.c
+++ b/src/applet/applet.c
@@ -1245,6 +1245,8 @@ int main(int argc, char** argv)
      */
     new_dir_exists(/* new dirs list */ NULL);
 
+    g_object_unref(g_problems_proxy);
+
     if (notify_is_initted())
         notify_uninit();
 


### PR DESCRIPTION
Without this pull request, abrt-applet cannot single out problems to notify at start-up because the current approach is to iterate through `ls DUMP_LOCATION` but the dump location is not accessible for regular users.