### PR TITLE
WIP: The wheel group members are allowed to see all problems without password

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -1044,6 +1044,7 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_datadir}/dbus-1/system-services/org.freedesktop.problems.service
 %{_datadir}/dbus-1/system-services/com.redhat.problems.configuration.service
 %{_datadir}/polkit-1/actions/abrt_polkit.policy
+%{_datadir}/polkit-1/rules.d/org.freedesktop.problems.rules
 %dir %{_defaultdocdir}/%{name}-dbus%{docdirversion}/
 %dir %{_defaultdocdir}/%{name}-dbus%{docdirversion}/html/
 %{_defaultdocdir}/%{name}-dbus%{docdirversion}/html/*.html

--- a/src/dbus/Makefile.am
+++ b/src/dbus/Makefile.am
@@ -47,6 +47,9 @@ DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@
 polkitconfdir = ${datadir}/polkit-1/actions
 dist_polkitconf_DATA = abrt_polkit.policy
 
+polkitrulesdir = ${datadir}/polkit-1/rules.d
+dist_polkitrules_DATA = org.freedesktop.problems.rules
+
 dbusabrtconfdir = ${sysconfdir}/dbus-1/system.d/
 dist_dbusabrtconf_DATA = dbus-abrt.conf
 

--- a/src/dbus/org.freedesktop.problems.rules
+++ b/src/dbus/org.freedesktop.problems.rules
@@ -1,0 +1,8 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.problems.getall" &&
+        subject.active == true &&
+        subject.local == true &&
+        subject.isInGroup("wheel")) {
+            return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
Originally submitted by @hadess : https://lists.fedorahosted.org/pipermail/crash-catcher/2015-February/005583.html. The current implementation has been proposed by @Catanzaro.
