### PR TITLE
abrt-action-list-dsos: dirty packages don't have a RPMTAG_VENDOR item

### DIFF
--- a/src/plugins/abrt-action-list-dsos
+++ b/src/plugins/abrt-action-list-dsos
@@ -82,10 +82,15 @@ if __name__ == "__main__":
                         if outname:
                             outfile = xopen(outname, "w")
                             outname = None
+
+                        vendor = h[rpm.RPMTAG_VENDOR]
+                        if vendor != None:
+                            verdor = vendor.decode('utf-8')
+
                         outfile.write("%s %s (%s) %s\n" %
                                     (path,
                                      h[rpm.RPMTAG_NEVRA].decode('utf-8'),
-                                     h[rpm.RPMTAG_VENDOR].decode('utf-8'),
+                                     verdor,
                                      h[rpm.RPMTAG_INSTALLTIME])
                                     )
 


### PR DESCRIPTION
In case there are installed some dirty packages the abrt-action-list-dsos failed.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>