### PR TITLE
a-a-s-p-d: add new known interpreter to conf file

### DIFF
--- a/src/daemon/abrt-action-save-package-data.conf
+++ b/src/daemon/abrt-action-save-package-data.conf
@@ -18,4 +18,4 @@ ProcessUnpackaged = yes
 BlackListedPaths = /usr/share/doc/*, */example*, /usr/bin/nspluginviewer
 
 # interpreters names
-Interpreters = python2, python2.7, python, python3, python3.3, perl, perl5.16.2
+Interpreters = python2, python2.7, python, python3, python3.3, python3.4, python3.5, perl, perl5.16.2


### PR DESCRIPTION
There were new bugzillas opened with wrong component 'python3' because of a new
version of python (3.4). We don't want to blame the interpreters but the
running scripts.

close #965

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>