### PR TITLE
cli-ng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 src/applet/abrt-applet
 src/configuration-gui/system-config-abrt
 src/daemon/abrt-action-save-package-data
+src/daemon/abrt-action-save-container-data
 src/daemon/abrt-auto-reporting
 src/daemon/abrt-server
 src/daemon/abrtd
@@ -37,12 +38,14 @@ src/plugins/abrt-action-perform-ccpp-analysis
 src/plugins/abrt-action-trim-files
 src/plugins/abrt-watch-log
 src/plugins/abrt-dump-oops
-src/plugins/abrt-journal-dump-oops
+src/plugins/abrt-dump-journal-oops
+src/plugins/abrt-dump-journal-core
 src/plugins/abrt-dump-xorg
 src/plugins/abrt-retrace-client
 src/plugins/abrt-action-install-debuginfo
 src/plugins/abrt-action-generate-core-backtrace
 src/plugins/abrt-bodhi
+src/plugins/libabrt-journal.a
 src/python-problem/problem/config.py
 src/python-problem/tests/*.log
 src/python-problem/tests/*.trs
@@ -165,3 +168,9 @@ tests/package.m4
 # python API docs builddir
 src/python-problem/doc/_build/
 build/*
+
+# python tests and generated files
+*.trs
+.coverage
+toolswtf
+src/cli-ng/abrtcli/config.py

--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -88,6 +88,12 @@ BuildRequires: systemd-python
 BuildRequires: python3-systemd
 BuildRequires: augeas
 BuildRequires: libselinux-devel
+BuildRequires: python-argcomplete
+BuildRequires: python3-argcomplete
+BuildRequires: python-argh
+BuildRequires: python3-argh
+BuildRequires: python-humanize
+BuildRequires: python3-humanize
 
 Requires: libreport >= %{libreport_ver}
 Requires: satyr >= %{satyr_ver}
@@ -318,6 +324,22 @@ Requires: abrt-dbus
 %description tui
 This package contains a simple command line client for processing abrt reports
 in command line environment.
+
+%package cli-ng
+Summary: %{name}'s improved command line interface
+Group: User Interface/Desktops
+Requires: %{name} = %{version}-%{release}
+Requires: libreport-cli >= %{libreport_ver}
+Requires: abrt-libs = %{version}-%{release}
+Requires: abrt-dbus
+Requires: abrt-python
+Requires: abrt-addon-ccpp
+Requires: python-argh
+Requires: python-argcomplete
+Requires: python-humanize
+
+%description cli-ng
+New generation command line interface for ABRT
 
 %package cli
 Summary: Virtual package to make easy default installation on non-graphical environments
@@ -1021,6 +1043,13 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %defattr(-,root,root,-)
 %{_bindir}/abrt-cli
 %{_mandir}/man1/abrt-cli.1.gz
+
+%files cli-ng
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/bash_completion.d/abrt.bash_completion
+%{_bindir}/abrt
+%{python_sitearch}/abrtcli/
+%{_mandir}/man1/abrt.1.gz
 
 %files desktop
 %defattr(-,root,root,-)

--- a/configure.ac
+++ b/configure.ac
@@ -424,6 +424,10 @@ AC_CONFIG_FILES([
 	src/hooks/Makefile
 	src/applet/Makefile
 	src/cli/Makefile
+	src/cli-ng/Makefile
+	src/cli-ng/abrtcli/Makefile
+	src/cli-ng/tests/Makefile
+	src/cli-ng/tests/clitests/Makefile
 	src/configuration-gui/Makefile
 	src/configuration-gui/abrt_gui.pc
 	src/dbus/Makefile

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,6 +3,7 @@ SUBDIRS = problems-service dbus-configuration
 -include ../config.mak
 
 MAN1_TXT =
+MAN1_TXT += abrt.txt
 MAN1_TXT += abrt-action-analyze-c.txt
 MAN1_TXT += abrt-action-trim-files.txt
 MAN1_TXT += abrt-action-generate-backtrace.txt

--- a/doc/abrt.txt
+++ b/doc/abrt.txt
@@ -1,0 +1,125 @@
+abrt(1)
+=======
+
+NAME
+----
+abrt - Manage problems handled by ABRT
+
+SYNOPSIS
+--------
+'abrt' [OPTIONS...] SUBCOMMAND [MATCH]
+
+OPTIONS
+-------
+-a,--auth::
+   Authenticate and show all problems on this machine
+
+-v,--version::
+   Show program's version number and exit
+
+-h,--help::
+   Show help message
+
+
+SUBCOMMANDS
+-----------
+'list'::
+   List problems
+
+'info'::
+   Print information about a problem
+
+'report'::
+   Report problem
+
+'remove'::
+   Remove problem
+
+'backtrace'::
+  Show backtrace of a problem
+
+'retrace'::
+   Generate backtrace from coredump
+
+'gdb'::
+   Run GDB (GNU Project debugger) against a problem
+
+'debuginfo-install'::
+   Install required debuginfo packages for given problem
+
+'status'::
+   Print count of the recent crashes
+
+Use 'abrt help SUBCOMMAND' for detailed list of options for selected subcommand.
+
+MATCHING
+--------
+
+Subcommands requiring single problem like 'info' or 'backtrace' will use the last
+problem that happened on your system unless 'MATCH' is specified.
+
+'MATCH' can be either component name, short hash (from 'list' subcommand)
+or combination of both in form '<component>@<hash>'
+
+EXAMPLES
+--------
+
+*List all problems handled by ABRT*
+----
+$ abrt list
+----
+
+*List problems with built-in format*
+----
+$ abrt list --pretty=oneline
+----
+
+*List problems with custom format*
+----
+$ abrt list --fmt '{count}x {short_id} {what}'
+----
+
+*Display detailed information about a problem*
+----
+$ abrt info --pretty full kernel
+----
+
+*Install debuginfo packages and run GDB against last problem*
+----
+$ abrt gdb --debuginfo-install
+----
+
+*Generate backtrace from last problem's coredump and generated detailed mail report*
+----
+$ abrt retrace
+$ abrt info --pretty email
+----
+
+FORMATTING
+----------
+
+Fields usable for custom formatting::
+  \{what\};;
+    either component name or executable
+  \{count\};;
+    number of occurrences
+  \{time\};;
+    time of the last occurrence
+  \{short_id\};;
+    short hash
+  \{uid\};;
+    user ID
+  \{username\};;
+    username
+  \{uid_username\};;
+    combination of the above two fields
+  \{path\};;
+    full path to problem data directory
+  \{package\};;
+    affected package
+  \{cmdline\};;
+    command line used to start an application
+
+AUTHORS
+-------
+* ABRT team

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -60,6 +60,11 @@ src/cli/list.c
 src/cli/status.c
 src/cli/report.c
 src/cli/process.c
+src/cli/process.c
+
+src/cli-ng/abrtcli/cli.py
+src/cli-ng/abrtcli/match.py
+src/cli-ng/abrtcli/utils.py
 
 src/plugins/analyze_CCpp.xml.in
 src/plugins/analyze_VMcore.xml.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = include lib hooks daemon applet plugins cli dbus python-problem configuration-gui
+SUBDIRS = include lib hooks daemon applet plugins cli cli-ng dbus python-problem configuration-gui

--- a/src/cli-ng/Makefile.am
+++ b/src/cli-ng/Makefile.am
@@ -1,0 +1,8 @@
+SUBDIRS = abrtcli tests
+
+bin_SCRIPTS = abrt
+
+dist_bashcomp_DATA = abrt.bash_completion
+bashcompdir = $(sysconfdir)/bash_completion.d
+
+EXTRA_DIST = $(bin_SCRIPTS)

--- a/src/cli-ng/abrt
+++ b/src/cli-ng/abrt
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+import sys
+import subprocess
+from abrtcli.cli import main
+
+if __name__ == '__main__':
+    # call ourselves again in case of no subcommand
+    # and display oneline list
+    if len(sys.argv) == 1:
+        subprocess.call('{0} list --pretty oneline'.format(sys.argv[0]),
+                        shell=True)
+        sys.exit(0)
+
+    main()
+else:
+    raise NotImplementedError

--- a/src/cli-ng/abrt.bash_completion
+++ b/src/cli-ng/abrt.bash_completion
@@ -1,0 +1,1 @@
+eval "$(register-python-argcomplete abrt)"

--- a/src/cli-ng/abrtcli/Makefile.am
+++ b/src/cli-ng/abrtcli/Makefile.am
@@ -1,0 +1,20 @@
+PYFILES= \
+	__init__.py \
+	cli.py \
+	config.py \
+	filtering.py \
+	l18n.py \
+	match.py \
+	utils.py
+
+abrtcli_PYTHON = $(PYFILES)
+abrtclidir = $(pyexecdir)/abrtcli
+
+config.py: config.py.in
+	sed -e s,\@LOCALE_DIR\@,$(localedir),g \
+	-e s,\@VERSION\@,$(PACKAGE_VERSION),g \
+	$< >$@
+
+EXTRA_DIST = config.py.in
+
+all-local: config.py

--- a/src/cli-ng/abrtcli/cli.py
+++ b/src/cli-ng/abrtcli/cli.py
@@ -1,0 +1,318 @@
+import os
+import sys
+import subprocess
+
+import argcomplete
+from argh import ArghParser, named, arg, aliases, expects_obj
+import problem
+import report as libreport
+from reportclient import ask_yes_no
+
+from abrtcli import config, l18n
+from abrtcli.l18n import _
+from abrtcli.match import match_completer, match_get_problem
+
+from abrtcli.filtering import (filter_not_reported,
+                               filter_since_timestamp,
+                               filter_until_timestamp)
+
+from abrtcli.utils import (fmt_problems,
+                           remember_cwd,
+                           run_event,
+                           sort_problems)
+
+
+@aliases('bt')
+@expects_obj
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+def backtrace(args):
+    prob = match_get_problem(args.MATCH, auth=args.auth)
+    if hasattr(prob, 'backtrace'):
+        print(fmt_problems(prob, fmt=config.BACKTRACE_FMT))
+    else:
+        print(_('Problem has no backtrace'))
+        if isinstance(prob, problem.Ccpp):
+            ret = ask_yes_no(_('Start retracing process?'))
+            if ret:
+                retrace(args)
+                print(fmt_problems(prob, fmt=config.BACKTRACE_FMT))
+
+backtrace.__doc__ = _('Show backtrace of a problem')
+
+
+@named('debuginfo-install')
+@aliases('di')
+@expects_obj
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+def di_install(args):
+    prob = match_get_problem(args.MATCH, auth=args.auth)
+    if not isinstance(prob, problem.Ccpp):
+        which = _('This')
+        if args.MATCH == 'last':
+            which = _('Last')
+
+        print(_('{} problem is not of a C/C++ type. Can\'t install debuginfo')
+              .format(which))
+        sys.exit(1)
+
+    prob.chown()
+
+    with remember_cwd():
+        try:
+            os.chdir(prob.path)
+        except OSError:
+            print(_('Permission denied: \'{}\'\n'
+                    'If this is a system problem'
+                    ' try running this command as root')
+                  .format(prob.path))
+            sys.exit(1)
+        subprocess.call(config.DEBUGINFO_INSTALL_CMD, shell=True)
+
+di_install.__doc__ = _('Install required debuginfo for given problem')
+
+
+@expects_obj
+@arg('-d', '--debuginfo-install', help='Install debuginfo prior launching gdb')
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+def gdb(args):
+    prob = match_get_problem(args.MATCH, auth=args.auth)
+    if not isinstance(prob, problem.Ccpp):
+        which = 'This'
+        if args.MATCH == 'last':
+            which = 'Last'
+
+        print('{} problem is not of a C/C++ type. Can\'t run gdb'
+              .format(which))
+        sys.exit(1)
+
+    prob.chown()
+
+    if args.debuginfo_install:
+        di_install(args)
+
+    cmd = config.GDB_CMD.format(di_path=config.DEBUGINFO_PATH)
+
+    with remember_cwd():
+        try:
+            os.chdir(prob.path)
+        except OSError:
+            print(_('Permission denied: \'{}\'\n'
+                    'If this is a system problem'
+                    ' try running this command as root')
+                  .format(prob.path))
+            sys.exit(1)
+        subprocess.call(cmd, shell=True)
+
+gdb.__doc__ = _('Run GDB against a problem')
+
+
+@named('list')
+@aliases('ls')
+@expects_obj
+@arg('--since', type=int,
+     help=_('List only the problems more recent than specified timestamp'))
+@arg('--until', type=int,
+     help=_('List only the problems older than specified timestamp'))
+@arg('--fmt', type=str,
+     help=_('Output format'))
+@arg('--pretty', choices=config.FORMATS, default='medium',
+     help=_('Built-in output format'))
+@arg('-n', '--not-reported', default=False,
+     help=_('List only not-reported problems'))
+def list_problems(args):
+    probs = sort_problems(problem.list(auth=args.auth))
+
+    if args.since:
+        probs = filter_since_timestamp(probs, args.since)
+
+    if args.until:
+        probs = filter_until_timestamp(probs, args.until)
+
+    if args.not_reported:
+        probs = filter_not_reported(probs)
+
+    if not args.fmt:
+        fmt = config.MEDIUM_FMT
+
+    if args.pretty != 'medium':
+        fmt = getattr(config, '{}_FMT'.format(args.pretty.upper()))
+
+    out = fmt_problems(probs, fmt=fmt)
+
+    if out:
+        print(out)
+    else:
+        print(_('No problems'))
+
+list_problems.__doc__ = _('List problems')
+
+
+@aliases('show')
+@expects_obj
+@arg('--fmt', type=str,
+     help=_('Output format'))
+@arg('--pretty', choices=config.FORMATS, default='full',
+     help=_('Built-in output format'))
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+def info(args):
+    prob = match_get_problem(args.MATCH, allow_multiple=True, auth=args.auth)
+    if not args.fmt:
+        fmt = config.FULL_FMT
+
+    if args.pretty != 'full':
+        fmt = getattr(config, '{}_FMT'.format(args.pretty.upper()))
+
+    print(fmt_problems(prob, fmt=fmt))
+
+info.__doc__ = _('Print information about problem')
+
+
+@aliases('rm')
+@expects_obj
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+@arg('-i', help=_('Prompt before removal'), default=False)
+@arg('-f', help=_('Do not prompt before removal'), default=False)
+def remove(args):
+    prob = match_get_problem(args.MATCH, auth=args.auth)
+    print(fmt_problems(prob, fmt=config.FULL_FMT))
+
+    ret = True
+    if not args.f and (args.i or args.MATCH == 'last'):
+        # force prompt for last problem to avoid accidents
+        ret = ask_yes_no(_('Are you sure you want to delete this problem?'))
+
+    if ret:
+        prob.delete()
+        print(_('Removed'))
+
+remove.__doc__ = _('Remove problem')
+
+
+@expects_obj
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+def report(args):
+    prob = match_get_problem(args.MATCH, auth=args.auth)
+    libreport.report_problem_in_dir(prob.path,
+                                    libreport.LIBREPORT_WAIT |
+                                    libreport.LIBREPORT_RUN_CLI)
+
+report.__doc__ = _('Report problem')
+
+
+@expects_obj
+@arg('-l', '--local', action='store_true',
+     help=_('Perform local retracing'))
+@arg('-r', '--remote', action='store_true',
+     help=_('Perform remote retracing using retrace server'))
+@arg('-f', '--force', action='store_true',
+     help=_('Force retracing even if backtrace already exists'))
+@arg('MATCH', nargs='?', default='last', completer=match_completer)
+def retrace(args):
+    # we might not get these var if called from backtrace
+    local, remote, auth = False, False, False
+
+    if hasattr(args, 'local'):
+        local = args.local
+    if hasattr(args, 'remote'):
+        remote = args.remote
+    if hasattr(args, 'force'):
+        force = args.force
+
+    prob = match_get_problem(args.MATCH, auth=args.auth)
+    if hasattr(prob, 'backtrace') and not force:
+        print(_('Problem already has a backtrace'))
+        print(_('Run abrt retrace with -f/--force to retrace again'))
+        ret = ask_yes_no(_('Show backtrace?'))
+        if ret:
+            print(fmt_problems(prob, fmt=config.BACKTRACE_FMT))
+    elif not isinstance(prob, problem.Ccpp):
+        print(_('No retracing possible for this problem type'))
+    else:
+        if not (local or remote):  # ask..
+            ret = ask_yes_no(
+                _('Upload core dump and perform remote'
+                  ' retracing? (It may contain sensitive data).'
+                  ' If your answer is \'No\', a stack trace will'
+                  ' be generated locally. Local retracing'
+                  ' requires downloading potentially large amount'
+                  ' of debuginfo data'))
+
+            if ret:
+                remote = True
+            else:
+                local = True
+
+        prob.chown()
+
+        if remote:
+            print(_('Remote retracing'))
+            run_event('analyze_RetraceServer', prob)
+        else:
+            print(_('Local retracing'))
+            run_event('analyze_LocalGDB', prob)
+
+
+retrace.__doc__ = _('Generate backtrace from coredump')
+
+
+@expects_obj
+@arg('-b', '--bare',
+     help=_('Print only the problem count without any message'))
+@arg('-s', '--since', type=int,
+     help=_('Print only the problems more recent than specified timestamp'))
+@arg('-n', '--not-reported', default=False,
+     help=_('List only not-reported problems'))
+def status(args):
+    probs = problem.list(auth=args.auth)
+
+    since_append = ''
+    if args.since:
+        probs = filter_since_timestamp(probs, args.since)
+        since_append = ' --since {}'.format(args.since)
+
+    if args.not_reported:
+        probs = filter_not_reported(probs)
+
+    if args.bare:
+        print(len(probs))
+        return
+
+    print(_('ABRT has detected {} problem(s). For more info run: abrt list{}')
+          .format(len(probs), since_append))
+
+status.__doc__ = _('Print count of the recent crashes')
+
+
+def main():
+    l18n.init()
+
+    parser = ArghParser()
+    parser.add_argument('-a', '--auth',
+                        action='store_true',
+                        help=_('Authenticate and show all problems'
+                               ' on this machine'))
+
+    parser.add_argument('-v', '--version',
+                        action='version',
+                        version=config.VERSION)
+
+    parser.add_commands([
+        backtrace,
+        di_install,
+        gdb,
+        info,
+        list_problems,
+        remove,
+        report,
+        retrace,
+        status,
+    ])
+
+    argcomplete.autocomplete(parser)
+
+    try:
+        parser.dispatch()
+    except KeyboardInterrupt:
+        sys.exit(1)
+
+    sys.exit(0)

--- a/src/cli-ng/abrtcli/config.py.in
+++ b/src/cli-ng/abrtcli/config.py.in
@@ -1,0 +1,72 @@
+ONELINE_FMT = '''{short_id} {count}x {what} {time}'''
+
+SHORT_FMT = '''#table
+id,{short_id}
+{what_field},{what}
+count,{count}
+time,{time}
+'''
+
+MEDIUM_FMT = '''#table
+id,{short_id}
+{what_field},{what}
+count,{count}
+time,{time}
+user id,{uid_username}
+reported to,{reported_to}
+,{not_reportable}
+,{not_reportable_reason}
+'''
+
+FULL_FMT = '''#table
+id,{short_id}
+{what_field},{what}
+count,{count}
+time,{time}
+command line,{cmdline}
+package,{package}
+user id,{uid_username}
+path,{path}
+reported to,{reported_to}
+,{not_reportable}
+,{not_reportable_reason}
+'''
+
+BACKTRACE_FMT = '''{backtrace}'''
+
+EMAIL_FMT = '''Id:       {short_id}
+Offender: {what}
+Count:    {count}
+Time:     {time}
+Package:  {package}
+User:     {uid_username}
+Path:     {path}
+Reported: {reported_to}
+
+{not_reportable}
+{not_reportable_reason}
+
+Backtrace: {backtrace}
+'''
+
+FORMATS = ['oneline', 'short', 'medium', 'full', 'email']
+
+LOCALE_DIR = "@LOCALE_DIR@"
+VERSION = "abrt @VERSION@"
+
+DEBUGINFO_INSTALL_CMD = '''
+abrt-action-analyze-ccpp-local --without-bz --without-bodhi
+'''
+
+DEBUGINFO_PATH = '/usr/lib/debug:/var/cache/abrt-di/usr/lib/debug'
+
+GDB_CMD = '''
+gdb -iex "set debug-file-directory {di_path}" \
+    -iex "set add-auto-load-safe-path {di_path}" \
+    -iex "set add-auto-load-scripts-directory {di_path}" \
+    -ex "file $( cat executable )" \
+    -ex "core-file coredump" \
+    -ex "set height 0" \
+    -ex "info sharedlib" \
+    -ex "bt"
+'''

--- a/src/cli-ng/abrtcli/filtering.py
+++ b/src/cli-ng/abrtcli/filtering.py
@@ -1,0 +1,51 @@
+import datetime
+
+
+def filter_since(probs, since):
+    '''
+    Return problems that occurred `since` datetime
+    '''
+
+    return list(filter(lambda x: x.time > since, probs))
+
+
+def filter_since_timestamp(probs, since_ts):
+    '''
+    Return problems that occurred `since` timestamp
+    '''
+
+    since = datetime.datetime.fromtimestamp(float(since_ts))
+    return list(filter_since(probs, since))
+
+
+def filter_until(probs, until):
+    '''
+    Return problems that occurred `until` datetime
+    '''
+
+    return list(filter(lambda x: x.time < until, probs))
+
+
+def filter_until_timestamp(probs, until_ts):
+    '''
+    Return problems that occurred `until` timestamp
+    '''
+
+    until = datetime.datetime.fromtimestamp(float(until_ts))
+    return list(filter_until(probs, until))
+
+
+def filter_reported(probs):
+    '''
+    Return only reported problems
+    '''
+
+    return list(filter(lambda x: hasattr(x, 'reported_to'), probs))
+
+
+def filter_not_reported(probs):
+    '''
+    Return only non-reported problems
+    '''
+
+    return list(filter(lambda x: not hasattr(x, 'reported_to'), probs))

--- a/src/cli-ng/abrtcli/l18n.py
+++ b/src/cli-ng/abrtcli/l18n.py
@@ -1,0 +1,34 @@
+import gettext
+import locale
+import humanize
+import logging
+
+GETTEXT_PROGNAME = "abrt"
+
+_ = gettext.gettext
+ngettext = gettext.ngettext
+
+from .config import LOCALE_DIR
+
+
+def init():
+    progname = GETTEXT_PROGNAME
+    localedir = LOCALE_DIR
+
+    lcl = 'C'
+    try:
+        lcl = locale.setlocale(locale.LC_ALL, "")
+    except locale.Error:
+        import os
+        os.environ['LC_ALL'] = 'C'
+        lcl = locale.setlocale(locale.LC_ALL, "")
+
+    try:
+        humanize.i18n.activate(lcl)
+    except IOError as ex:
+        logging.debug("Unsupported locale '{0}': {1}".format(lcl, str(ex)))
+
+    gettext.bind_textdomain_codeset(progname,
+                                    locale.nl_langinfo(locale.CODESET))
+    gettext.bindtextdomain(progname, localedir)
+    gettext.textdomain(progname)

--- a/src/cli-ng/abrtcli/match.py
+++ b/src/cli-ng/abrtcli/match.py
@@ -1,0 +1,119 @@
+import sys
+import problem
+
+from abrtcli.l18n import _
+from abrtcli.utils import get_human_identifier, sort_problems
+
+
+def get_match_data(auth=False):
+    '''
+    Return tuple of two dictionaries: one with components as keys
+    and one with short_ids as keys
+
+    Utility function used by match_ functions
+    '''
+
+    by_human_id = {}
+    by_short_id = {}
+
+    for prob in problem.list(auth=auth):
+        comp_or_exe, val = get_human_identifier(prob)
+
+        if val in by_human_id:
+            by_human_id[val].append(prob)
+        else:
+            by_human_id[val] = [prob]
+
+        if prob.short_id in by_short_id:
+            by_short_id[prob.short_id].append(prob)
+        else:
+            by_short_id[prob.short_id] = [prob]
+
+    return by_human_id, by_short_id
+
+
+def match_completer(prefix, parsed_args, **kwargs):
+    '''
+    Completer generator used by cli commands using problem lookup
+    '''
+
+    by_human_id, by_short_id = get_match_data()
+
+    for short_id in by_short_id.keys():
+        yield short_id
+
+    for human_id, probs in by_human_id.items():
+        if len(probs) == 1:
+            yield '{0}'.format(human_id)
+        else:
+            for prob in probs:
+                yield '{0}@{1}'.format(human_id, prob.short_id)
+
+
+def match_lookup(in_arg, auth=False):
+    '''
+    Return problems that match `in_arg` passed on command line
+    '''
+
+    by_human_id, by_short_id = get_match_data(auth=auth)
+
+    res = None
+
+    if in_arg in by_human_id:
+        res = by_human_id[in_arg]
+    elif in_arg in by_short_id:
+        res = by_short_id[in_arg]
+    elif '@' in in_arg:
+        human_id, short_id = in_arg.split('@', 1)
+
+        if human_id in by_human_id:
+            probs = by_human_id[human_id]
+
+            res = list(filter(lambda p: p.short_id == short_id, probs))
+
+    return res
+
+
+def match_get_problem(problem_match, allow_multiple=False, auth=False):
+    '''
+    Return problem matching `problem_match` pattern
+    or exit if there are no such problems or pattern
+    results in multiple problems (unless `allow_multiple` is set
+    to True).
+    '''
+
+    prob = None
+    if problem_match == 'last':
+        probs = sort_problems(problem.list(auth=auth))
+        if not probs:
+            print(_('No problems'))
+            sys.exit(0)
+
+        prob = probs[0]
+    else:
+        probs = match_lookup(problem_match, auth=auth)
+        if not probs:
+            print(_('No problem(s) matched'))
+            sys.exit(1)
+        elif len(probs) > 1:
+            if allow_multiple:
+                return probs
+
+            match_collision(probs)
+            sys.exit(1)
+        else:
+            prob = probs[0]
+
+    return prob
+
+
+def match_collision(probs):
+    '''
+    Handle matches that result in multiple problems by telling user
+    to be more specific
+    '''
+
+    print(_('Ambiguous match specified resulting in multiple problems:'))
+    for prob in probs:
+        field, val = get_human_identifier(prob)
+        print('- {}@{} ({})'.format(val, prob.short_id, prob.time))

--- a/src/cli-ng/abrtcli/utils.py
+++ b/src/cli-ng/abrtcli/utils.py
@@ -1,0 +1,246 @@
+import os
+import re
+import sys
+import contextlib
+from functools import reduce
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+from abrtcli.l18n import _
+from abrtcli.config import MEDIUM_FMT
+import report
+
+braces_re = re.compile(r'\{([^}]+)\}')
+
+
+def as_table(data, margin=2, separator=' '):
+    '''
+    Return `data` formatted as table.
+    '''
+
+    data = list(map(lambda x: list(map(str, x)), data))
+
+    widths = reduce(
+        lambda x, y: list(map(
+            lambda t: max(t[0], t[1]), zip(x, y)
+        )),
+        map(lambda x: map(len, x), data),
+        map(lambda _: 0, data))
+
+    fmt = ''
+    for num, width in enumerate(widths):
+        if num != 0:
+            width = 0
+        fmt += '{{{0}:<{1}}}{2}'.format(num, width, separator * margin)
+    fmt += '\n'
+
+    return ''.join(map(lambda row: fmt.format(*row), data))[:-1]
+
+
+def fmt_problems(probs, fmt=MEDIUM_FMT):
+    '''
+    Return preformatted problem data of `prob` according to `fmt`
+    '''
+
+    if probs is None:
+        return ''
+
+    if not isinstance(probs, list):
+        probs = [probs]
+
+    fmt = fmt.replace('|', '\n')
+    tabular = '#table' in fmt
+    oneline = '\n' not in fmt
+
+    out = ''
+    for prob in probs:
+        what_field, what = get_human_identifier(prob)
+
+        context_vars = {
+            'what': what,
+            'what_field': what_field,
+        }
+
+        uid = get_problem_field(prob, 'uid')
+        if uid:
+            username = get_problem_field(prob, 'username')
+            if username:
+                uid_username = ('{0} ({1})'
+                                .format(uid, username))
+            else:
+                uid_username = str(uid)
+
+            context_vars['uid_username'] = uid_username
+
+        if prob.not_reportable:
+            context_vars['not_reportable'] = _('Not reportable')
+            reason = prob.not_reportable_reason.rstrip()
+
+            if tabular:
+                reason = reason.replace('\n', '\n,')
+
+            context_vars['not_reportable_reason'] = reason
+
+        if hasattr(prob, 'reported_to'):
+            r_out = ''
+            rtl = prob.reported_to.splitlines()
+
+            # each reported to line item as separate row
+            # except for BTHASH
+            for rline in rtl:
+                if 'BTHASH' in rline:
+                    continue
+
+                if 'URL=' in rline:
+                    rep_to, url = rline.split('URL=', 1)
+                    if ': ' in rep_to:
+                        rep_to, rest = rep_to.split(': ')
+
+                    if tabular:
+                        r_out += '\n{},{}'.format(rep_to, url)
+
+            if r_out:
+                context_vars['reported_to'] = r_out
+
+        if hasattr(prob, 'backtrace'):
+            if not oneline:
+                context_vars['backtrace'] = '\n' + prob.backtrace
+
+        if not hasattr(prob, 'count'):
+            context_vars['count'] = 1
+
+        sfmt = fmt.splitlines()
+        for line in sfmt:
+            if not line.rstrip():
+                if tabular:
+                    out += ',\n'
+                elif not oneline:
+                    out += '\n'
+                continue
+
+            if line[0] == '#':  # output mode selector or comment
+                continue
+
+            template_vars = braces_re.findall(line)
+
+            missing_var = False
+            for var in template_vars:
+                # try looking up missing context var in problem items
+                if var not in context_vars:
+                    val = get_problem_field(prob, var)
+                    if val:
+                        context_vars[var] = val
+                    else:
+                        missing_var = True
+                        context_vars[var] = ''
+
+            if not missing_var or oneline:
+                fmtline = line.format(**context_vars)
+                if not oneline:
+                    fmtline = upcase_first_letter(fmtline)
+
+                out += fmtline + '\n'
+
+        # separator
+        if tabular:
+            out += ',\n'
+        elif not oneline:
+            out += '\n'
+
+    if tabular:
+        rows = out.splitlines()
+        rows = map(lambda x: x.split(',', 1), rows)
+        out = as_table(list(rows)[:-1])
+    else:
+        out = out.replace('\n\n', '\n')
+
+    return out.rstrip()
+
+
+def get_problem_field(prob, field):
+    '''
+    Return problem field `field` or None
+    '''
+
+    try:
+        return getattr(prob, field)
+    except AttributeError:
+        return
+
+
+def get_human_identifier(prob):
+    '''
+    Return first found problem field from list of candidate fields
+    that will be used as a problem identifier for humans
+    '''
+
+    candidates = ['component', 'executable', 'type']
+
+    for c in candidates:
+        val = get_problem_field(prob, c)
+        if val:
+            return c, val
+
+    return None, None
+
+
+def sort_problems(probs, recent_first=True):
+    '''
+    Sort problems by time, `recent_first` by default
+    '''
+
+    return sorted(probs, key=lambda p: p.time, reverse=recent_first)
+
+
+def upcase_first_letter(s):
+    '''
+    UC First
+    '''
+    return s[0].upper() + s[1:]
+
+
+def run_event(event_name, prob):
+    '''
+    Run event with `event_name` on problem `prob`
+    '''
+
+    state = report.run_event_state()
+    ret = state.run_event_on_dir_name(prob.path, event_name)
+
+    if ret == 0 and state.children_count == 0:
+        sys.stderr.write('No actions were found for event {}'
+                         .format(event_name))
+        return False
+
+    return True
+
+
+@contextlib.contextmanager
+def remember_cwd():
+    curdir = os.getcwd()
+    try:
+        yield
+    finally:
+        os.chdir(curdir)
+
+
+@contextlib.contextmanager
+def captured_output():
+    """
+    Capture stdout and stderr output of the executed block
+
+    Example:
+
+    with captured_output() as (out, err):
+        foo()
+    """
+
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err

--- a/src/cli-ng/test
+++ b/src/cli-ng/test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+which nosetests &> /dev/null
+if [ $? -ne 0 ]; then
+    echo 'python-nose package required'
+    exit 1
+fi
+
+nosetests --with-coverage --cover-package=abrtcli --nocapture --no-skip --verbose tests/*.py

--- a/src/cli-ng/tests/Makefile.am
+++ b/src/cli-ng/tests/Makefile.am
@@ -1,0 +1,16 @@
+SUBDIRS = clitests
+
+TESTS = test_cli.py test_filtering.py test_match.py test_utils.py
+check_SCRIPTS = $(TESTS)
+
+EXTRA_DIST = $(check_SCRIPTS)
+
+if BUILD_PYTHON3
+check-local:
+	echo "Running tests with python3"; \
+	exc=0; \
+	for test in $(TESTS); do \
+		python3 $$test || exc=1; \
+	done; \
+	exit $$exc
+endif

--- a/src/cli-ng/tests/clitests/Makefile.am
+++ b/src/cli-ng/tests/clitests/Makefile.am
@@ -1,0 +1,1 @@
+EXTRA_DIST = __init__.py fake_problems.py

--- a/src/cli-ng/tests/clitests/__init__.py
+++ b/src/cli-ng/tests/clitests/__init__.py
@@ -1,0 +1,50 @@
+import os
+import sys
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import contextlib
+
+cpath = os.path.dirname(os.path.realpath(__file__))
+# alter path so we can import cli
+abrtcli_path = os.path.abspath(os.path.join(cpath, "../.."))
+problem_path = os.path.abspath(os.path.join(cpath, "../../../python-problem"))
+pyabrt_path = os.path.join(problem_path, "problem/.libs")  # because of _pyabrt
+sys.path.insert(0, abrtcli_path)
+sys.path.insert(0, problem_path)
+sys.path.insert(0, pyabrt_path)
+os.environ["PATH"] = "{0}:{1}".format(abrtcli_path, os.environ["PATH"])
+
+import problem
+from .fake_problems import get_fake_problems
+
+problem.list = get_fake_problems
+
+
+
+@contextlib.contextmanager
+def monkey_patch(owner, attr, value):
+    """
+    Limited scope monkey patch context manager
+
+    Example:
+
+    with monkey_patch(sys, 'exit', myexit):
+        sys.exit()
+    """
+
+    old = getattr(owner, attr)
+    setattr(owner, attr, value)
+    try:
+        yield getattr(owner, attr)
+    finally:
+        setattr(owner, attr, old)
+
+
+class TestCase(unittest.TestCase):
+    """
+    Class that initializes required configuration variables.
+    """
+
+    pass

--- a/src/cli-ng/tests/clitests/fake_problems.py
+++ b/src/cli-ng/tests/clitests/fake_problems.py
@@ -1,0 +1,90 @@
+import problem
+import datetime
+
+# contains two problems with the same hash
+# one problem of users app
+# one unknown problem
+
+_rt = '''uReport: BTHASH=3505a6db8a6bd51a3d690f1553b309a0d7eda948
+ABRT Server: URL=https://retrace.fedoraproject.org/faf/reports/bthash/3505a6db8a6bd51a3d690f1553b309a0d7eda948
+Bugzilla: URL=https://bugzilla.redhat.com/show_bug.cgi?id=1223349'''
+
+
+_data = [
+    {
+        'type': problem.CCPP,
+        'reason': 'pavucontrol killed by SIGSEGV',
+        '_id': 'bc60a5cbddb4e3667511e718ceecac16133acc97',
+        'path': '/var/tmp/abrt/ccpp-2015-05-16-14:41:47-7729',
+        'count': 15,
+        'time': datetime.datetime(2015, 5, 16, 14, 41, 47),
+        'component': 'pavucontrol',
+        'reported_to': _rt,
+    },
+    {
+        'type': problem.CCPP,
+        'reason': 'polkit killed by SIGSEGV',
+        '_id': 'bc60a5cbddb4e3667511e718ceecac16133acc97',
+        'path': '/var/tmp/abrt/ccpp-2015-06-16-14:41:47-7729',
+        'count': 1,
+        'time': datetime.datetime(2015, 6, 16, 14, 41, 47),
+        'component': 'polkitd',
+    },
+    {
+        'type': problem.CCPP,
+        'reason': 'pavucontrol killed by SIGSEGV',
+        '_id': 'acbea5cbddb4e3667511e718ceecac16133acc97',
+        'path': '/var/tmp/abrt/ccpp-2015-06-16-14:41:47-7729',
+        'count': 3,
+        'time': datetime.datetime(2013, 6, 16, 14, 41, 47),
+        'component': 'pavucontrol',
+    },
+    {
+        'type': problem.CCPP,
+        'reason': 'user_app killed by SIGSEGV',
+        '_id': 'ffe635cbdd54e3667511e718ceecac16133acc97',
+        'path': '/var/tmp/abrt/ccpp-2015-03-16-14:41:47-7729',
+        'count': 1,
+        'time': datetime.datetime(2015, 6, 17, 14, 41, 47),
+        'executable': '/home/user/bin/user_app',
+        'uid': 1234,
+    },
+    {
+        'type': 'unknown_problem',
+        'reason': 'something wrong happened',
+        '_id': 'ccacca5cbdd54e3667511e718ceecac16133acc97',
+        'path': '/var/tmp/abrt/ccpp-2014-03-16-14:41:47-7729',
+        'count': 1,
+        'time': datetime.datetime(2014, 6, 16, 14, 41, 47),
+        'not-reportable': 'Not reportable reason',
+    },
+]
+
+
+class FakeProxy():
+    ''' To be sure no dbus api calls are made during tests '''
+    def connect():
+        pass
+
+    def get_item(*args, **kwargs):
+        return None
+
+
+def get_fake_problems(*args, **kwargs):
+    res = []
+    for pdata in _data:
+        p = problem.Problem(pdata['type'], pdata['reason'])
+
+        for field in set(pdata.keys()) - set(['type', 'reason']):
+            if field == 'path':  # path is immutable
+                continue
+
+            setattr(p, field, pdata[field])
+
+        setattr(p, '_persisted', True)
+        setattr(p, '_probdir',  pdata['path'])
+        setattr(p, '_proxy',  FakeProxy())
+
+        res.append(p)
+
+    return res

--- a/src/cli-ng/tests/test_cli.py
+++ b/src/cli-ng/tests/test_cli.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+import logging
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import clitests
+
+from abrtcli.utils import captured_output
+
+
+class CliTestCase(clitests.TestCase):
+    '''
+    Tests for cli functions
+    '''
+
+    def test_cli_sanity(self):
+        '''
+        Test if main works and there are no import/decorator errors
+        '''
+
+        with captured_output() as (cap_stdout, cap_stderr):
+
+            # we have to import here
+            # otherwise argh.dispatch stores sys.std* on import
+            # and ignores our override
+
+            from abrtcli.cli import main
+            with self.assertRaises(SystemExit):
+                main()
+
+        out = cap_stderr.getvalue()
+        out += cap_stdout.getvalue()
+        self.assertIn("usage", out)
+        self.assertIn("debuginfo-install", out)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/src/cli-ng/tests/test_filtering.py
+++ b/src/cli-ng/tests/test_filtering.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+import logging
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import datetime
+
+import clitests
+import problem
+
+from abrtcli.filtering import (filter_reported,
+                               filter_not_reported,
+                               filter_since,
+                               filter_since_timestamp,
+                               filter_until,
+                               filter_until_timestamp)
+
+
+class FilteringTestCase(clitests.TestCase):
+    '''
+    Test filtering functionality
+    '''
+
+    def test_filter_since(self):
+        pl = problem.list()
+        since = datetime.datetime(2015, 1, 1, 1, 1, 1)
+        res = filter_since(pl, since)
+        self.assertEqual(len(res), 3)
+
+    def test_filter_since_timestamp(self):
+        pl = problem.list()
+        since = datetime.datetime(2015, 1, 1, 1, 1, 1)
+        since_ts = since.strftime('%s')
+        res = filter_since_timestamp(pl, since_ts)
+        self.assertEqual(len(res), 3)
+
+    def test_filter_until(self):
+        pl = problem.list()
+        until = datetime.datetime(2015, 1, 1, 1, 1, 1)
+        res = filter_until(pl, until)
+        self.assertEqual(len(res), 2)
+
+    def test_filter_until_timestamp(self):
+        pl = problem.list()
+        until = datetime.datetime(2015, 1, 1, 1, 1, 1)
+        until_ts = until.strftime('%s')
+        res = filter_until_timestamp(pl, until_ts)
+        self.assertEqual(len(res), 2)
+
+    def test_filter_reported(self):
+        pl = problem.list()
+        res = filter_reported(pl)
+        self.assertEqual(len(res), 1)
+
+    def test_filter_not_reported(self):
+        pl = problem.list()
+        res = filter_not_reported(pl)
+        self.assertEqual(len(res), 4)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/src/cli-ng/tests/test_match.py
+++ b/src/cli-ng/tests/test_match.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+import logging
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import clitests
+
+from abrtcli.match import (get_match_data,
+                           match_completer,
+                           match_get_problem,
+                           match_lookup)
+
+from abrtcli.utils import captured_output
+
+
+class MatchTestCase(clitests.TestCase):
+    '''
+    Simple test to check if database creation & access
+    works as expected.
+    '''
+
+    hashes = ['ccacca5', 'bc60a5c', 'acbea5c', 'ffe635c']
+    collision_hash = 'bc60a5c'
+    human = ['/home/user/bin/user_app', 'unknown_problem', 'polkitd']
+    collision_human = 'pavucontrol'
+    combined = ['pavucontrol@bc60a5c', 'pavucontrol@acbea5c']
+
+    def test_get_match_data(self):
+        '''
+        Test get_match_data returns correctly merged data
+        '''
+
+        by_human_id, by_short_id = get_match_data()
+        self.assertEqual(len(by_human_id), 4)
+
+        self.assertEqual(len(by_short_id), 4)
+
+    def test_match_completer(self):
+        '''
+        Test that match_completer yields properly formatted candidates
+        '''
+
+        pm = match_completer(None, None)
+        self.assertEqual(set(pm), set(self.hashes + self.human + self.combined))
+
+    def test_match_lookup_hash(self):
+        '''
+        Test match lookup by hash
+        '''
+
+        for h in self.hashes:
+            m = match_lookup(h)
+            self.assertTrue(len(m) >= 1)
+
+    def test_match_lookup_human_id(self):
+        '''
+        Test match lookup by human id
+        '''
+
+        for h in self.human:
+            m = match_lookup(h)
+            self.assertTrue(len(m) == 1)
+
+    def test_match_lookup_combined(self):
+        '''
+        Test match lookup by human id
+        '''
+
+        for h in self.combined:
+            m = match_lookup(h)
+            self.assertTrue(len(m) == 1)
+
+    def test_match_lookup_collisions(self):
+        '''
+        Test match lookup handles collisions
+        '''
+
+        m = match_lookup(self.collision_hash)
+        self.assertTrue(len(m) == 2)
+
+        m = match_lookup(self.collision_human)
+        self.assertTrue(len(m) == 2)
+
+    def test_match_lookup_nonexistent(self):
+        '''
+        Test match lookup handles empty input
+        '''
+
+        m = match_lookup('')
+        self.assertEqual(m, None)
+
+    def test_match_get_problem_simple(self):
+        '''
+        Test that match_get_problem matches unique pattern
+        '''
+
+        p = match_get_problem('polkitd')
+        self.assertEqual(p.component, 'polkitd')
+
+    def test_match_get_problem_last(self):
+        '''
+        Test that match_get_problem matches last problem
+        '''
+
+        p = match_get_problem('last')
+        self.assertEqual(p.uid, 1234)
+
+    def test_match_get_problem_multiple(self):
+        '''
+        Test that match_get_problem fails when multiple problems match
+        '''
+
+        with captured_output() as (cap_stdout, cap_stderr):
+            with self.assertRaises(SystemExit):
+                match_get_problem('pavucontrol')
+
+        stdout = cap_stdout.getvalue()
+        self.assertIn("Ambiguous", stdout)
+        self.assertIn("pavucontrol@bc60a5c", stdout)
+        self.assertIn("pavucontrol@acbea5c", stdout)
+
+    def test_match_get_problem_multiple_allowed(self):
+        '''
+        Test that match_get_problem matches multiple problems when allowed
+        '''
+
+        p = match_get_problem('pavucontrol', allow_multiple=True)
+        self.assertEqual(len(p), 2)
+
+    def test_match_get_problem_empty_database(self):
+        '''
+        Test that match_get_problem handles no problems in database
+        '''
+
+        import problem
+
+        with clitests.monkey_patch(problem, 'list', lambda *args, **kwargs: []):
+            with captured_output() as (cap_stdout, cap_stderr):
+                with self.assertRaises(SystemExit):
+                    match_get_problem('nope')
+
+            stdout = cap_stdout.getvalue()
+            self.assertIn("No problem(s) matched", stdout)
+
+            # Similar with last
+            with captured_output() as (cap_stdout, cap_stderr):
+                with self.assertRaises(SystemExit):
+                    match_get_problem('last')
+
+            stdout = cap_stdout.getvalue()
+            self.assertIn("No problems", stdout)
+
+    def test_match_get_problem_nonexistent(self):
+        '''
+        Test that match_get_problem exits on non-existent problem
+        '''
+
+        with self.assertRaises(SystemExit):
+            match_get_problem('nope')
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/src/cli-ng/tests/test_utils.py
+++ b/src/cli-ng/tests/test_utils.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+import logging
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import os
+
+import clitests
+
+import problem
+
+from abrtcli.config import ONELINE_FMT
+
+from abrtcli.utils import (captured_output,
+                           fmt_problems,
+                           get_problem_field,
+                           get_human_identifier,
+                           remember_cwd,
+                           sort_problems,
+                           upcase_first_letter)
+
+
+class UtilsTestCase(clitests.TestCase):
+    '''
+    Tests for utility functions
+    '''
+
+    def test_fmt_problems(self):
+        '''
+        Test default problem formatting
+        '''
+
+        pl = problem.list()
+        res = fmt_problems(pl)
+
+        for prob in pl:
+            self.assertIn(prob.short_id, res)
+            field, value = get_human_identifier(prob)
+            self.assertIn(value, res)
+            self.assertIn(str(prob.count), res)
+
+        self.assertIn('Bugzilla', res)
+        self.assertIn('https://bugzilla.redhat.com/show_bug.cgi?id=1223349',
+                      res)
+
+        self.assertIn('ABRT Server', res)
+        furl = 'https://retrace.fedoraproject.org/faf/reports/bthash/' \
+               '3505a6db8a6bd51a3d690f1553b'
+        self.assertIn(furl, res)
+
+        self.assertIn('Not reportable', res)
+        self.assertIn('Not reportable reason', res)
+
+    def test_fmt_problems_oneline(self):
+        '''
+        Test oneline problem formatting
+        '''
+
+        pl = problem.list()
+        res = fmt_problems(pl, fmt=ONELINE_FMT)
+
+        self.assertIn('bc60a5c 15x pavucontrol', res)
+        self.assertIn('ffe635c 1x /home/user/bin/user_app', res)
+
+    def test_fmt_problems_custom(self):
+        '''
+        Test custom problem formatting
+        '''
+
+        pl = problem.list()
+        fmt = '''#table|id,{short_id}|user id,{uid_username}| '''
+        res = fmt_problems(pl, fmt=fmt)
+
+        self.assertIn('User id', res)
+        self.assertIn('1234', res)
+        self.assertTrue(len(res.splitlines()) > len(pl))
+
+    def test_fmt_problems_custom_oneline(self):
+        '''
+        Test custom problem formatting
+        '''
+
+        pl = problem.list()
+        fmt = '''{short_id} {uid_username}'''
+        res = fmt_problems(pl, fmt=fmt)
+
+        self.assertIn('1234', res)
+        self.assertTrue(len(res.splitlines()) == len(pl))
+
+    def test_fmt_problems_empty_input(self):
+        '''
+        Test that fmt_problems handles None as problem list
+        '''
+
+        self.assertEqual(fmt_problems(None), '')
+
+    def test_get_problem_field(self):
+        p = problem.list()[0]
+        self.assertTrue(get_problem_field(p, 'count'), p.count)
+        self.assertEqual(get_problem_field(p, 'notavail'), None)
+
+    def test_get_human_identifier(self):
+        p0 = problem.list()[0]
+        p3 = problem.list()[3]
+        p4 = problem.list()[4]
+        p0_t, p0_v = get_human_identifier(p0)
+        p3_t, p3_v = get_human_identifier(p3)
+        p4_t, p4_v = get_human_identifier(p4)
+        self.assertEqual(p0_t, 'component')
+        self.assertEqual(p0_v,  p0.component)
+        self.assertEqual(p3_t, 'executable')
+        self.assertEqual(p3_v,  p3.executable)
+        self.assertEqual(p4_t, 'type')
+        self.assertEqual(p4_v,  p4.type)
+
+    def test_sort_problems(self):
+        '''
+        Test if problems are sotred by time
+        '''
+
+        pl = problem.list()
+        spl = sort_problems(pl)
+        self.assertTrue(spl[-1] == pl[2])
+        self.assertTrue(spl[0] == pl[3])
+
+    def test_upcase_first_letter(self):
+        self.assertEqual('LaLa', upcase_first_letter('laLa'))
+
+    def test_remember_cwd(self):
+        cwd = os.getcwd()
+        with remember_cwd():
+            os.chdir('/tmp')
+        self.assertEqual(os.getcwd(), cwd)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -28,7 +28,6 @@ if $INSTALL_DI; then
     else
         abrt-action-analyze-core --core=coredump -o build_ids && @LIBEXEC_DIR@/abrt-action-install-debuginfo-to-abrt-cache --size_mb=4096
     fi
-    rm -f build_ids
 fi
 
 if [ $? = 0 ]; then

--- a/src/python-problem/problem/__init__.py
+++ b/src/python-problem/problem/__init__.py
@@ -280,6 +280,11 @@ class Problem(object):
             self._probdir = None
             self._dirty_data = {}
 
+    def chown(self):
+        ''' Assures ownership of a problem for the caller '''
+        if self._persisted:
+            self._proxy.chown(self._probdir)
+
 
 class Java(Problem):
     ''' Java problem '''

--- a/src/python-problem/problem/proxies.py
+++ b/src/python-problem/problem/proxies.py
@@ -84,6 +84,9 @@ class DBusProxy(object):
     def delete(self, dump_dir):
         return self._dbus_call('DeleteProblem', [dump_dir])
 
+    def chown(self, dump_dir):
+        return self._dbus_call('ChownProblemDir', dump_dir)
+
     def list(self):
         return [str(prob) for prob in self._dbus_call('GetProblems')]
 

--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -27,6 +27,7 @@ python3-addon
 
 # - tools tests
 cli-sanity
+cli-ng-sanity
 cli-status
 cli-authentication
 console-notifications

--- a/tests/runtests/cli-ng-sanity/PURPOSE
+++ b/tests/runtests/cli-ng-sanity/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of cli-ng-sanity
+Description: does sanity on abrt-cli-ng
+Author: Richard Marko <rmarko@redhat.com>

--- a/tests/runtests/cli-ng-sanity/runtest.sh
+++ b/tests/runtests/cli-ng-sanity/runtest.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of cli-ng-sanity
+#   Description: does sanity on abrt-cli-ng
+#   Author: Richard Marko <rmarko@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2015 Red Hat, Inc. All rights reserved.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+. ../aux/lib.sh
+
+TEST="cli-ng-sanity"
+PACKAGE="abrt"
+
+rlJournalStart
+    rlPhaseStartSetup
+
+        LANG=""
+        export LANG
+        check_prior_crashes
+
+        TmpDir=$(mktemp -d)
+        pushd $TmpDir
+    rlPhaseEnd
+
+    rlPhaseStartTest "--version"
+        rlRun "abrt -v 2>&1 | grep 'abrt'"
+        rlRun "abrt --version 2>&1 | grep 'abrt'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "--help"
+        rlRun "abrt --help" 0
+        rlRun "abrt --help 2>&1 | grep 'usage: abrt'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "list"
+        generate_crash
+        get_crash_path
+        wait_for_hooks
+
+        rlRun "abrt list | grep -i 'Id'"
+        rlRun "abrt list | grep -i 'Component'"
+        rlRun "abrt list --pretty full | grep -i 'Command line'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "list -n" # list not-reported
+        rlRun "abrt list -n | grep -i 'Id'"
+        rlRun "abrt list -n | grep -i 'Component'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "status"
+        rlRun "abrt status | grep 'has detected 1 problem'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "report NONEXISTENT"
+        rlRun "abrt report NONEXISTENT" 1
+    rlPhaseEnd
+
+    rlPhaseStartTest "report not-reportable"
+        rlRun "touch $crash_PATH/not-reportable"
+
+        cp $crash_PATH/{type,analyzer} ./
+
+        echo "cli_sanity_test_not_reportable" > $crash_PATH/type
+        echo "cli_sanity_test_not_reportable" > $crash_PATH/analyzer
+
+        rlRun "abrt report 2>&1 | tee abrt-cli-report-not-reportable.log" 0
+        rlAssertGrep "Problem '$crash_PATH' cannot be reported" abrt-cli-report-not-reportable.log
+
+        cp -f type analyzer $crash_PATH
+
+        rlRun "rm -f $crash_PATH/not-reportable"
+    rlPhaseEnd
+
+    rlPhaseStartTest "info DIR"
+        rlRun "abrt info"
+        rlRun "abrt info --pretty email > info.out"
+    rlPhaseEnd
+
+    rlPhaseStartTest "list (after reporting)"
+        DIR=$( abrt list --pretty full | grep 'Path' | head -n1 | awk '{ print $2 }' )
+
+        # this should ensure that ABRT will consider the problem as reported
+        rlRun "reporter-print -r -d $DIR -o /dev/null"
+
+        # this expects that reporter-print works and adds an URL to
+        # the output file to the problem's data
+        rlRun "abrt list | grep -i 'file:///dev/null'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "list -n (after reporting)" # list not-reported
+        rlRun "abrt list -n | grep 'No problems'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "info NONEXISTENT"
+        rlRun "abrt info NONEXISTENT" 1
+    rlPhaseEnd
+
+    rlPhaseStartTest "remove NONEXISTENT"
+        rlRun "abrt remove NONEXISTENT" 1
+    rlPhaseEnd
+
+    rlPhaseStartTest "remove DIR"
+        rlRun "abrt remove -f"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        popd # TmpDir
+        rm -rf $TmpDir
+    rlPhaseEnd
+    rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
abrt-cli rewrite adding additional functionality like abrt gdb, abrt debuginfo-install, tab-completion and custom formatting. Feature parity with old cli remains almost unchanged.

Should replace old cli in the future.

Depends on #975. (cli-ng branch contains commits from both pull requests).

Missing stuff:
- abrt-cli process (do we want this one? it does interactive processing of all problems like git add -i)
- man page
- i18n
- not all variables (paths) in config.py.in replaced during build