### PR TITLE
Fix typo in es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -104,7 +104,7 @@ msgid ""
 "want to report the issue."
 msgstr ""
 "Lo sentimos, parece que %s ha dejado de funcionar. Por favor, póngase en "
-"contacto con el desarrollados si quiere informar de este problema."
+"contacto con el desarrollador si quiere informar de este problema."
 
 #: ../src/applet/applet.c:607
 #, c-format


### PR DESCRIPTION
There is a misspelling in spanish translation. "developer" should be "desarrollador" instead of "desarrollados".