### PR TITLE
C/C++: Thread ID

### DIFF
--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -606,10 +606,11 @@ int main(int argc, char** argv)
     const char *global_pid_str = argv[8];
     pid_t pid = xatoi_positive(argv[8]);
 
-    pid_t tid = 0;
-    if (argv[9])
+    pid_t tid = -1;
+    const char *tid_str = argv[9];
+    if (tid_str)
     {
-        tid = xatoi_positive(argv[8]);
+        tid = xatoi_positive(tid_str);
     }
 
     char path[PATH_MAX];

--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -834,6 +834,8 @@ int main(int argc, char** argv)
         dd_save_text(dd, FILENAME_PROC_PID_STATUS, proc_pid_status);
         if (user_pwd)
             dd_save_text(dd, FILENAME_PWD, user_pwd);
+        if (tid_str)
+            dd_save_text(dd, FILENAME_TID, tid_str);
 
         if (rootdir)
         {

--- a/src/plugins/abrt-action-analyze-backtrace.c
+++ b/src/plugins/abrt-action-analyze-backtrace.c
@@ -121,6 +121,10 @@ int main(int argc, char **argv)
         return 0;
     }
 
+    uint32_t tid = -1;
+    if (dd_load_uint32(dd, FILENAME_TID, &tid) == 0)
+        sr_gdb_stacktrace_set_crash_tid(backtrace, tid);
+
     /* Compute duplication hash. */
     struct sr_thread *crash_thread =
         (struct sr_thread *)sr_gdb_stacktrace_find_crash_thread(backtrace);


### PR DESCRIPTION
Save TID and use it do get the crash thread. Requires: abrt/libreport#369