### PR TITLE
spec: --enable-dump-time-unwind by default

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -518,6 +518,7 @@ CFLAGS="%{optflags} -Werror" %configure \
 %endif
         --with-defaultdumplocation=/var/%{var_base_dir}/abrt \
         --enable-doxygen-docs \
+        --enable-dump-time-unwind \
         --disable-silent-rules
 
 make %{?_smp_mflags}


### PR DESCRIPTION
Signed-off-by: Richard Marko <rmarko@fedoraproject.org>