### PR TITLE
abrtd: de-prioritize post-create event scripts

### DIFF
--- a/doc/abrtd.txt
+++ b/doc/abrtd.txt
@@ -36,6 +36,13 @@ OPTIONS
 -p::
    Add program names to log.
 
+ENVIRONMENT
+-----------
+ABRT_EVENT_NICE::
+  'abrtd' runs its post-mortem processing with the nice value incremented by 10
+  in order to not take too much resources and keep the computer responsive.  If
+  you want to adjust the increment value, use the ABRT_EVENT_NICE environment
+  variable.
 
 CAVEATS
 -------

--- a/src/daemon/abrt-server.c
+++ b/src/daemon/abrt-server.c
@@ -126,15 +126,17 @@ static int delete_path(const char *dump_dir_name)
 
 static pid_t spawn_event_handler_child(const char *dump_dir_name, const char *event_name, int *fdp)
 {
-    char *args[7];
+    char *args[9];
     args[0] = (char *) LIBEXEC_DIR"/abrt-handle-event";
     /* Do not forward ASK_* messages to parent*/
     args[1] = (char *) "-i";
-    args[2] = (char *) "-e";
-    args[3] = (char *) event_name;
-    args[4] = (char *) "--";
-    args[5] = (char *) dump_dir_name;
-    args[6] = NULL;
+    args[2] = (char *) "--nice";
+    args[3] = (char *) "10";
+    args[4] = (char *) "-e";
+    args[5] = (char *) event_name;
+    args[6] = (char *) "--";
+    args[7] = (char *) dump_dir_name;
+    args[8] = NULL;
 
     int pipeout[2];
     int flags = EXECFLG_INPUT_NUL | EXECFLG_OUTPUT | EXECFLG_QUIET | EXECFLG_ERR2OUT;


### PR DESCRIPTION
The crash processing should not make the computer unusable. It sometimes
happens that the captured data causes abrt scripts to take an inadequate
amount of resources and the computer becomes less responsive.

This patch increases the nice value of post-create processes by 10 (I took
10 because it is the default value of command 'nice'), so those
processes will be scheduled after the more valuable processes.

Related: rhbz#1236422

Signed-off-by: Jakub Filak <jfilak@redhat.com>