### PR TITLE
use gettext instead of lgettext in all python scripts

### DIFF
--- a/src/daemon/abrt-handle-upload.in
+++ b/src/daemon/abrt-handle-upload.in
@@ -18,7 +18,7 @@ GETTEXT_PROGNAME = "abrt"
 import locale
 import gettext
 
-_ = lambda x: gettext.lgettext(x)
+_ = lambda x: gettext.gettext(x)
 
 def init_gettext():
     try:

--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -12,7 +12,7 @@ GETTEXT_PROGNAME = "@PACKAGE@"
 import locale
 import gettext
 
-_ = lambda x: gettext.lgettext(x)
+_ = lambda x: gettext.gettext(x)
 
 
 verbose = 0

--- a/src/plugins/abrt-action-analyze-vmcore.in
+++ b/src/plugins/abrt-action-analyze-vmcore.in
@@ -14,7 +14,7 @@ GETTEXT_PROGNAME = "abrt"
 import locale
 import gettext
 
-_ = lambda x: gettext.lgettext(x)
+_ = lambda x: gettext.gettext(x)
 
 def init_gettext():
     try:

--- a/src/plugins/abrt-action-check-oops-for-alt-component.in
+++ b/src/plugins/abrt-action-check-oops-for-alt-component.in
@@ -9,7 +9,7 @@ import re
 
 GETTEXT_PROGNAME = "abrt"
 
-_ = gettext.lgettext
+_ = gettext.gettext
 
 tags = [
 "WARNING:",

--- a/src/plugins/abrt-action-check-oops-for-hw-error.in
+++ b/src/plugins/abrt-action-check-oops-for-hw-error.in
@@ -9,7 +9,7 @@ import re
 
 GETTEXT_PROGNAME = "abrt"
 
-_ = gettext.lgettext
+_ = gettext.gettext
 
 def file_has_string(filename, string):
     try:

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -26,7 +26,7 @@ GETTEXT_PROGNAME = "abrt"
 import locale
 import gettext
 
-_ = lambda x: gettext.lgettext(x)
+_ = lambda x: gettext.gettext(x)
 
 def init_gettext():
     try:

--- a/src/plugins/abrt-action-perform-ccpp-analysis.in
+++ b/src/plugins/abrt-action-perform-ccpp-analysis.in
@@ -19,7 +19,7 @@ from reportclient import (ask_yes_no_yesforever,
 
 GETTEXT_PROGNAME = "abrt"
 
-_ = gettext.lgettext
+_ = gettext.gettext
 
 def handle_event(event_name, problem_dir):
     """Helper function handling a single event

--- a/src/plugins/abrt-action-ureport
+++ b/src/plugins/abrt-action-ureport
@@ -17,7 +17,7 @@ GETTEXT_PROGNAME = "abrt"
 import locale
 import gettext
 
-_ = lambda x: gettext.lgettext(x)
+_ = lambda x: gettext.gettext(x)
 
 def init_gettext():
     try:

--- a/src/plugins/abrt-gdb-exploitable
+++ b/src/plugins/abrt-gdb-exploitable
@@ -14,7 +14,7 @@ import locale
 import gdb
 
 GETTEXT_PROGNAME = "abrt"
-_ = gettext.lgettext
+_ = gettext.gettext
 
 def init_gettext():
     try:


### PR DESCRIPTION
lgettext returns bytes but we require string.
Without this patch the scripts exit with 'TypeError' exception ('must be str,
not bytes').

Related to rhbz#1245600

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>