### PR TITLE
abrt-auto-reporting-sanity: added test for missing rhtsupport.conf

### DIFF
--- a/tests/runtests/abrt-auto-reporting-sanity/runtest.sh
+++ b/tests/runtests/abrt-auto-reporting-sanity/runtest.sh
@@ -67,6 +67,15 @@ rlJournalStart
         rlAssertEquals "Reads the configuration" "_$(abrt-auto-reporting)" "_$CONF_VALUE"
     rlPhaseEnd
 
+    rlPhaseStartTest "missing rhtsupport.conf"
+        [ -f /etc/libreport/plugins/rhtsupport.conf ] && rlRun "mv /etc/libreport/plugins/rhtsupport.conf ~" 0 "backup rhtsupport.conf"
+        rlRun "abrt-auto-reporting"
+        [ -f ~/rhtsupport.conf ] && rlRun "mv ~/rhtsupport.conf /etc/libreport/plugins/rhtsupport.conf" 0 "restore rhtsupport.conf"
+
+        get_configured_value
+        rlAssertEquals "Reads the configuration" "_$(abrt-auto-reporting)" "_$CONF_VALUE"
+    rlPhaseEnd
+
     rlPhaseStartTest "enabled"
         rlRun "abrt-auto-reporting enabled"
 


### PR DESCRIPTION
covering https://bugzilla.redhat.com/show_bug.cgi?id=1191572
test tested