### PR TITLE
abrt-auto-reporting: fix related to conditional compilation

### DIFF
--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -122,6 +122,11 @@ abrt_auto_reporting_CPPFLAGS = \
     -I$(srcdir)/../lib \
     $(LIBREPORT_CFLAGS) \
     -D_GNU_SOURCE
+
+if AUTHENTICATED_AUTOREPORTING
+abrt_auto_reporting_CPPFLAGS += -DAUTHENTICATED_AUTOREPORTING=1
+endif
+
 abrt_auto_reporting_LDADD = \
     ../lib/libabrt.la \
     $(LIBREPORT_LIBS)


### PR DESCRIPTION
We discovered that conditional compilation in abrt-auto-reporting does not
work. We forgot add -DAUTHENTICATED_AUTOREPORTING=1 flag if
AUTHENTICATED_AUTOREPORTING is enabled.

Related to rhbz#1191572