### PR TITLE
testsuite: make oops-processing distro specific

### DIFF
--- a/tests/runtests/aux/test_order.rhel7
+++ b/tests/runtests/aux/test_order.rhel7
@@ -40,7 +40,7 @@ dbus-elements-handling
 dbus-configuration
 distro_specific/rhel7/dbus-argument-validation/
 #bodhi
-oops-processing
+distro_specific/rhel7/oops-processing
 abrt-python
 kernel-vmcore-harvest
 abrt-action-install-debuginfo

--- a/tests/runtests/distro_specific/rhel7/oops-processing/PURPOSE
+++ b/tests/runtests/distro_specific/rhel7/oops-processing/PURPOSE
@@ -1,0 +1,4 @@
+PURPOSE of oops_processing
+Description: test for required files in dump directory of koops
+Author: Richard Marko <rmarko@redhat.com>
+

--- a/tests/runtests/distro_specific/rhel7/oops-processing/runtest.sh
+++ b/tests/runtests/distro_specific/rhel7/oops-processing/runtest.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of oops_processing
+#   Description: test for required files in dump directory of koops
+#   Author: Richard Marko <rmarko@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2011 Red Hat, Inc. All rights reserved.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+. ../../../aux/lib.sh
+
+TEST="oops_processing"
+PACKAGE="abrt"
+OOPS_REQUIRED_FILES="kernel uuid duphash
+pkg_name pkg_arch pkg_epoch pkg_release pkg_version"
+EXAMPLES_PATH="../../../../../examples"
+
+rlJournalStart
+    rlPhaseStartSetup
+        load_abrt_conf
+        LANG=""
+        export LANG
+        check_prior_crashes
+
+        TmpDir=$(mktemp -d)
+        sed "s/2.6.27.9-159.fc10.i686/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops1.test > \
+            $TmpDir/oops1.test
+
+        sed "s/3.0.0-1.fc16.i686/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops5.test > \
+            $TmpDir/oops5.test
+
+        sed "s/3.10.0-33.el7.ppc64/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops8_ppc64.test > \
+            $TmpDir/oops8_ppc64.test
+
+        sed "s/3.69.69-69.0.fit.s390x/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops10_s390x.test > \
+            $TmpDir/oops10_s390x.test
+
+        sed "s/3.10.0-41.el7.x86_64/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops_unsupported_hw.test > \
+            $TmpDir/oops_not_reportable_unsupported_hw.test
+
+        sed "s/2.6.35.6-45.fc14.x86_64/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops_broken_bios.test > \
+            $TmpDir/oops_not_reportable_broken_bios.test
+
+        pushd $TmpDir
+    rlPhaseEnd
+
+    rlPhaseStartTest OOPS
+        for oops in oops*.test; do
+            prepare
+
+            installed_kernel="$( rpm -q kernel | tail -n1 )"
+            kernel_version="$( rpm -q --qf "%{version}" $installed_kernel )"
+            sed -i "s/<KERNEL_VERSION>/$installed_kernel/g" $oops
+            rlRun "abrt-dump-oops $oops -xD 2>&1 | grep 'abrt-dump-oops: Found oopses: [1-9]'" 0 "[$oops] Found OOPS"
+
+            wait_for_hooks
+            get_crash_path
+
+            ls $crash_PATH > crash_dir_ls
+
+            for f in $OOPS_REQUIRED_FILES; do
+                rlAssertExists "$crash_PATH/$f"
+            done
+
+            check_dump_dir_attributes $crash_PATH
+
+            if [[ "$oops" == *not_reportable* ]]; then
+                rlAssertExists "$crash_PATH/not-reportable"
+            else
+                rlAssertNotExists "$crash_PATH/not-reportable"
+            fi
+
+            rlAssertGrep "kernel" "$crash_PATH/pkg_name"
+            rlAssertGrep "kernel" "$crash_PATH/component"
+            rlAssertGrep "$kernel_version" "$crash_PATH/pkg_version"
+
+            rlRun "abrt-cli rm $crash_PATH" 0 "Remove crash directory"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlBundleLogs abrt $(echo *_ls)
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+    rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
There is no "DropNotReportableOopses" option in oops.conf on rhel, so we remove
the test cases related to this.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>