### PR TITLE
ccpp: fix comment related to 'MakeCompatCore' option in CCpp.conf

### DIFF
--- a/doc/abrt-CCpp.conf.txt
+++ b/doc/abrt-CCpp.conf.txt
@@ -11,8 +11,13 @@ The configuration file consists of items in the format "Option = Value".
 Ithe following items are recognized:
 
 MakeCompatCore = 'yes' / 'no' ...::
-   If you also want to dump file named "core"
-   in crashed process' current dir, set to "yes".
+   CCpp hook writes its template to the "/proc/sys/kernel/core_pattern" file
+   and stores the original template in the "/var/run/abrt/saved_core_pattern"
+   file. If you want CCpp hook to create a core dump file named according to
+   the original template as well, set 'MakeCompatCore' to 'yes'.
+   If the original template string starts with "|", the string "core" is used
+   instead of the template.
+   For more information about naming core dump files see 'man 5 core'.
 
 SaveBinaryImage = 'yes' / 'no' ...::
    Do you want a copy of crashed binary be saved?

--- a/src/hooks/CCpp.conf
+++ b/src/hooks/CCpp.conf
@@ -1,7 +1,12 @@
 # Configuration file for CCpp hook
 
-# If you also want to dump file named "core"
-# in crashed process' current dir, set to "yes"
+# CCpp hook writes its template to the "/proc/sys/kernel/core_pattern" file
+# and stores the original template in the "/var/run/abrt/saved_core_pattern"
+# file. If you want CCpp hook to create a core dump file named according to
+# the original template as well, set 'MakeCompatCore' to 'yes'.
+# If the original template string starts with "|", the string "core" is used
+# instead of the template.
+# For more information about naming core dump files see 'man 5 core'.
 MakeCompatCore = yes
 
 # Do you want a copy of crashed binary be saved?


### PR DESCRIPTION
The comment fits only on the default core_pattern template.
If the core_pattern is not default, the comment does not fit.

Related to rhbz#1252384

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>