### PR TITLE
testsuite: abrt-auto-reporting-sanity - exclude one phase on RHEL

### DIFF
--- a/tests/runtests/abrt-auto-reporting-sanity/runtest.sh
+++ b/tests/runtests/abrt-auto-reporting-sanity/runtest.sh
@@ -67,6 +67,7 @@ rlJournalStart
         rlAssertEquals "Reads the configuration" "_$(abrt-auto-reporting)" "_$CONF_VALUE"
     rlPhaseEnd
 
+    if ! rlIsRHEL; then
     rlPhaseStartTest "missing rhtsupport.conf"
         [ -f /etc/libreport/plugins/rhtsupport.conf ] && rlRun "mv /etc/libreport/plugins/rhtsupport.conf ~" 0 "backup rhtsupport.conf"
         rlRun "abrt-auto-reporting"
@@ -75,6 +76,7 @@ rlJournalStart
         get_configured_value
         rlAssertEquals "Reads the configuration" "_$(abrt-auto-reporting)" "_$CONF_VALUE"
     rlPhaseEnd
+    fi
 
     rlPhaseStartTest "enabled"
         rlRun "abrt-auto-reporting enabled"


### PR DESCRIPTION
phase "missing rhtsupport.conf" is not relevant for RHEL