### PR TITLE
abrt-dump-xorg: support Xorg log backtraces prefixed by (EE)

### DIFF
--- a/tests/runtests/dumpxorg/crash_bz1264739.right
+++ b/tests/runtests/dumpxorg/crash_bz1264739.right
@@ -1,0 +1,16 @@
+0: /usr/libexec/Xorg (OsLookupColor+0x139) [0x59add9]
+1: /lib64/libc.so.6 (__restore_rt+0x0) [0x7f61be425b1f]
+2: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0xa9fc) [0x7f61b903116c]
+3: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0xbe27) [0x7f61b90339a7]
+4: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0x31060) [0x7f61b907db00]
+5: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0x3fb73) [0x7f61b909b0c3]
+6: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0x3fe1a) [0x7f61b909b77a]
+7: /usr/libexec/Xorg (DamageRegionAppend+0x3783) [0x525003]
+8: /usr/libexec/Xorg (SendGraphicsExpose+0xeb3) [0x4340b3]
+9: /usr/libexec/Xorg (SendErrorToClient+0x2df) [0x43684f]
+10: /usr/libexec/Xorg (remove_fs_handlers+0x453) [0x43a893]
+11: /lib64/libc.so.6 (__libc_start_main+0xf0) [0x7f61be411580]
+12: /usr/libexec/Xorg (_start+0x29) [0x424b79]
+13: ? (?+0x29) [0x29]
+Segmentation fault at address 0x7f61d93f6160
+

--- a/tests/runtests/dumpxorg/crash_bz1264739.test
+++ b/tests/runtests/dumpxorg/crash_bz1264739.test
@@ -1,0 +1,30 @@
+[ 60244.259] (EE) 
+[ 60244.259] (EE) Backtrace:
+[ 60244.262] (EE) 0: /usr/libexec/Xorg (OsLookupColor+0x139) [0x59add9]
+[ 60244.264] (EE) 1: /lib64/libc.so.6 (__restore_rt+0x0) [0x7f61be425b1f]
+[ 60244.266] (EE) 2: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0xa9fc) [0x7f61b903116c]
+[ 60244.267] (EE) 3: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0xbe27) [0x7f61b90339a7]
+[ 60244.268] (EE) 4: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0x31060) [0x7f61b907db00]
+[ 60244.269] (EE) 5: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0x3fb73) [0x7f61b909b0c3]
+[ 60244.270] (EE) 6: /usr/lib64/xorg/modules/drivers/intel_drv.so (_init+0x3fe1a) [0x7f61b909b77a]
+[ 60244.270] (EE) 7: /usr/libexec/Xorg (DamageRegionAppend+0x3783) [0x525003]
+[ 60244.270] (EE) 8: /usr/libexec/Xorg (SendGraphicsExpose+0xeb3) [0x4340b3]
+[ 60244.270] (EE) 9: /usr/libexec/Xorg (SendErrorToClient+0x2df) [0x43684f]
+[ 60244.271] (EE) 10: /usr/libexec/Xorg (remove_fs_handlers+0x453) [0x43a893]
+[ 60244.272] (EE) 11: /lib64/libc.so.6 (__libc_start_main+0xf0) [0x7f61be411580]
+[ 60244.272] (EE) 12: /usr/libexec/Xorg (_start+0x29) [0x424b79]
+[ 60244.273] (EE) 13: ? (?+0x29) [0x29]
+[ 60244.273] (EE) 
+[ 60244.273] (EE) Segmentation fault at address 0x7f61d93f6160
+[ 60244.273] (EE) 
+Fatal server error:
+[ 60244.273] (EE) Caught signal 11 (Segmentation fault). Server aborting
+[ 60244.273] (EE) 
+[ 60244.273] (EE) 
+Please consult the Fedora Project support 
+     at http://wiki.x.org
+ for help. 
+[ 60244.273] (EE) Please also check the log file at "/home/mikhail/.local/share/xorg/Xorg.0.log" for additional information.
+[ 60244.273] (EE) 
+[ 60244.274] (II) AIGLX: Suspending AIGLX clients for VT switch
+[ 60244.289] (EE) Server terminated with error (1). Closing log file.


### PR DESCRIPTION
The backtraces looks like
    [ 60244.259] (EE) Backtrace
    [ 60244.262] (EE) 0: /usr/libexec/Xorg (OsLookupColor+0x139) [0x59add9]
    [ 60244.264] (EE) 1: /lib64/libc.so.6 (__restore_rt+0x0) [0x7f61be425b1f]
    ...
    [ 60244.273] (EE) 13: ? (?+0x29) [0x29]
    [ 60244.273] (EE)
    [ 60244.273] (EE) Segmentation fault at address 0x7f61d93f6160

This format of Xorg log files was not supported by abrt-dump-xorg tool.

Related to rhbz#1264739