### PR TITLE
runtests: stick to new BZ password rules

### DIFF
--- a/tests/runtests/bugzilla-bt-reattach/bugzilla.conf
+++ b/tests/runtests/bugzilla-bt-reattach/bugzilla.conf
@@ -5,4 +5,4 @@ SSLVerify = no
 # your login has to exist, if you don have any, please create one
 Login = abrt@mailinator.com
 # your password
-Password = kokotice
+Password = k0k0TICE@

--- a/tests/runtests/bugzilla-comment-format/bugzilla.conf
+++ b/tests/runtests/bugzilla-comment-format/bugzilla.conf
@@ -5,4 +5,4 @@ SSLVerify = yes
 # your login has to exist, if you don have any, please create one
 Login = abrt@mailinator.com
 # your password
-Password = kokotice
+Password = k0k0TICE@

--- a/tests/runtests/bugzilla-dupe-search/bugzilla.conf
+++ b/tests/runtests/bugzilla-dupe-search/bugzilla.conf
@@ -5,6 +5,6 @@ SSLVerify = yes
 # your login has to exist, if you don have any, please create one
 Login = abrt@mailinator.com
 # your password
-Password = kokotice
+Password = k0k0TICE@
 
 DontMatchComponents = selinux-policy


### PR DESCRIPTION
With the recent bugzilla update, new more strict password rules are enforced. The testing account pw has been changed, thus the tests need to use it.