### PR TITLE
testsuite: use rpm to remove packages

### DIFF
--- a/tests/runtests/aux/pre.sh
+++ b/tests/runtests/aux/pre.sh
@@ -10,7 +10,8 @@ yum clean metadata
 if [ "${REINSTALL_PRE}" = "1" ]; then
     echo 'REINSTALL_PRE set'
 
-    yum -y remove abrt\* libreport\*
+    rpm -qa abrt\* libreport\* satyr\* will-crash\* \
+        | xargs rpm -e --nodeps
 
     rm -rf /etc/abrt/
     rm -rf /etc/libreport/


### PR DESCRIPTION
dnf dependens on libreport-filesystem
and uninstall itself when trying to remove libreport-filesystem.

Signed-off-by: Richard Marko <rmarko@fedoraproject.org>