### PR TITLE
bodhi: introduce wrapper for 'reporter-bugzilla -h' and 'abrt-bodhi'

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -1041,7 +1041,9 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %files plugin-bodhi
 %defattr(-,root,root,-)
 %{_bindir}/abrt-bodhi
+%{_bindir}/abrt-action-find-bodhi-update
 %{_mandir}/man1/abrt-bodhi.1.gz
+%{_mandir}/man1/abrt-action-find-bodhi-update.1.gz
 %endif
 
 %files dbus

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -37,6 +37,7 @@ MAN1_TXT += abrt-upload-watch.txt
 MAN1_TXT += system-config-abrt.txt
 if BUILD_BODHI
 MAN1_TXT += abrt-bodhi.txt
+MAN1_TXT += abrt-action-find-bodhi-update.txt
 endif
 
 

--- a/doc/abrt-action-find-bodhi-update.txt
+++ b/doc/abrt-action-find-bodhi-update.txt
@@ -1,0 +1,40 @@
+abrt-action-find-bodhi-update(1)
+================================
+
+NAME
+----
+abrt-action-find-bodhi-update - find bodhi update based on ABRT's problem dir
+
+SYNOPSIS
+--------
+'abrt-action-notify' [-v] [-d PROBLEM_DIR] [-b]
+
+DESCRIPTION
+-----------
+The tool reads 'duphash' file in problem directory and searches for a new
+updates according to the crash.
+
+OPTIONS
+-------
+-v, --verbose::
+   Be verbose
+
+-b, --without-bodhi::
+   Run without abrt-bodhi. Prints only Bugzilla bug id of duplicate bug, if exists.
+
+-d, --problem-dir PROBLEM_DIR::
+   Problem directory [Default: current directory]
+
+ENVIRONMENT VARIABLES
+---------------------
+'Bugzilla_Product'::
+   Product bug field value. Useful if you needed different product than
+   specified in PROBLEM_DIR/os_info
+
+SEE ALSO
+--------
+abrt-bodhi(1), reporter-bugzilla(1)
+
+AUTHORS
+-------
+* ABRT team

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -30,6 +30,7 @@ src/plugins/abrt-action-analyze-xorg.c
 src/plugins/abrt-action-analyze-python.c
 src/plugins/abrt-action-analyze-vmcore.in
 src/plugins/abrt-action-check-oops-for-hw-error.in
+src/plugins/abrt-action-find-bodhi-update
 src/plugins/abrt-action-generate-backtrace.c
 src/plugins/abrt-action-generate-core-backtrace.c
 src/plugins/abrt-action-install-debuginfo.in

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -10,6 +10,11 @@ bin_SCRIPTS = \
     abrt-action-analyze-ccpp-local \
     abrt-action-notify
 
+if BUILD_BODHI
+bin_SCRIPTS += \
+    abrt-action-find-bodhi-update
+endif
+
 bin_PROGRAMS = \
     abrt-watch-log \
     abrt-dump-oops \
@@ -78,6 +83,11 @@ PYTHON_FILES = \
     abrt-action-check-oops-for-hw-error.in \
     abrt-action-perform-ccpp-analysis.in \
     abrt-action-notify
+
+if BUILD_BODHI
+PYTHON_FILES += \
+    abrt-action-find-bodhi-update
+endif
 
 EXTRA_DIST = \
     $(PYTHON_FILES) \

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 INSTALL_DI=true
-WITH_BODHI=true
+FIND_BODHI_UPDATE_ARGS=""
 # if bz is set to false it also disables bodhi, because it needs it's result
 WITH_BUGZILLA=true
 for opt in "$@"; do
@@ -14,7 +14,7 @@ for opt in "$@"; do
     fi
 
     if [ x"$opt" = x"--without-bodhi" ]; then
-        WITH_BODHI=false
+        FIND_BODHI_UPDATE_ARGS="--without-bodhi"
     fi
 done
 
@@ -36,12 +36,7 @@ if [ $? = 0 ]; then
     abrt-action-analyze-backtrace
     if [ "$?" == "0" ]; then
         if $WITH_BUGZILLA; then
-            bug_id=$(reporter-bugzilla -h "`cat duphash`")
-            if $WITH_BODHI; then
-                if test -n "$bug_id"; then
-                    abrt-bodhi -r -b $bug_id || :
-                fi
-            fi
+            abrt-action-find-bodhi-update $FIND_BODHI_UPDATE_ARGS
         fi
     fi
 fi

--- a/src/plugins/abrt-action-find-bodhi-update
+++ b/src/plugins/abrt-action-find-bodhi-update
@@ -1,0 +1,148 @@
+#!/usr/bin/python3 -u
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+abrt-action-find-bodhi-update - find bodhi update based on ABRT's problem dir
+
+The tool reads duphash file in problem directory and searches for a new updates
+according to the crash.
+
+OPTIONS
+    -v, --verbose
+        Be verbose
+
+    -b, --without-bodhi
+        Run without abrt-bodhi. Prints only Bugzilla bug id of duplicate bug,
+        if exists.
+
+    -d, --problem-dir PROBLEM_DIR
+        Problem directory [Default: current directory]
+
+ENVIRONMENT VARIABLES
+    Bugzilla_Product
+        Product bug field value. Useful if you needed different product than
+        specified in PROBLEM_DIR/os_info
+"""
+import os
+import sys
+from argparse import ArgumentParser
+from subprocess import Popen, PIPE
+
+from reportclient import (_, log, log1, set_verbosity, verbose, RETURN_OK,
+                          RETURN_FAILURE, error_msg)
+import report
+
+FILENAME_DUPHASH = "duphash"
+FILENAME_OSINFO = "os_info"
+OSINFO_BUGZILLA_PRODUCT = "REDHAT_BUGZILLA_PRODUCT="
+OSINFO_BUGZILLA_PRODUCT_VERSION = "REDHAT_BUGZILLA_PRODUCT_VERSION="
+
+def parse_os_release_line(l):
+    """Parse key-value line and returns value"""
+    return l.split('=')[1]
+
+if __name__ == "__main__":
+    CMDARGS = ArgumentParser(
+            description=("Search bodhi updates based on ABRT's problem dir"))
+    CMDARGS.add_argument("-d", "--problem-dir",
+            type=str, default=".",
+            help="Path to problem directory")
+    CMDARGS.add_argument("-b", "--without-bodhi",
+            action="store_true", dest="without_bodhi", default=False,
+            help="Run without abrt-bohi")
+    CMDARGS.add_argument("-v", "--verbose",
+            action="count", dest="verbose", default=0,
+            help="Be verbose")
+
+    OPTIONS = CMDARGS.parse_args()
+    DIR_PATH = os.path.abspath(OPTIONS.problem_dir)
+
+    verbose = 0
+    ABRT_VERBOSE = os.getenv("ABRT_VERBOSE")
+    if ABRT_VERBOSE:
+        try:
+            verbose = int(ABRT_VERBOSE)
+        #pylint: disable=bare-except
+        except:
+            pass
+
+    verbose += OPTIONS.verbose
+    set_verbosity(verbose)
+    os.environ["ABRT_VERBOSE"] = str(verbose)
+
+    try:
+        dump_dir = report.dd_opendir(DIR_PATH, report.DD_OPEN_READONLY)
+        if not dump_dir:
+            raise ValueError(_("cannot open problem directory '{0}'").format(DIR_PATH))
+
+        dd_load_flag = (report.DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE |
+                        report.DD_FAIL_QUIETLY_ENOENT)
+
+        duphash_content = dump_dir.load_text(FILENAME_DUPHASH, dd_load_flag)
+        if not duphash_content:
+            raise ValueError("problem directory misses '{0}'".format(FILENAME_DUPHASH))
+
+        os_info = dump_dir.load_text(FILENAME_OSINFO, dd_load_flag)
+        if not os_info:
+            raise ValueError("problem directory misses '{0}'" .format(FILENAME_OSINFO))
+
+    except ValueError as ex:
+        error_msg(_("Problem directory error: {0}").format(ex))
+        sys.exit(RETURN_FAILURE)
+    finally:
+        dump_dir.close()
+
+    # get Bugzilla Product and Version from os_info
+    product = os.getenv("Bugzilla_Product") or ""
+    version = ""
+    for line in os_info.split("\n"):
+        if (OSINFO_BUGZILLA_PRODUCT in line) and (product == ""):
+            product = parse_os_release_line(line)
+        if OSINFO_BUGZILLA_PRODUCT_VERSION in line:
+            version = parse_os_release_line(line)
+
+    if product == "":
+        log1(_("Using product '{0}' from /etc/os-release.").format(OSINFO_BUGZILLA_PRODUCT))
+    else:
+        log1(_("Using product {0}.").format(product))
+    if version != "":
+        log1(_("Using product version {0}.").format(version))
+
+    # Find bugzilla bug with abrt_hash: == $duphash_content and product ==
+    # $product, if OSINFO_BUGZILLA_PRODUCT from crash's os_info doesn't exist,
+    # the OSINFO_BUGZILLA_PRODUCT from /etc/os-release is used
+    with Popen(["reporter-bugzilla -h {0} -p{1}".format(duphash_content, product)],
+             shell=True,
+             stdout=PIPE,
+             bufsize=-1) as proc:
+        bug_id = proc.stdout.read().rstrip().decode("utf-8", "ignore")
+
+    if bug_id:
+        log(_("Duplicate bugzilla bug '#{0}' was found").format(bug_id))
+    else:
+        log1(_("There is no bugzilla bug with 'abrt_hash:{0}'").format(duphash_content))
+        sys.exit(RETURN_OK)
+
+    # abrt-bodhi do not support rawhide, because there are no updates for rawhide in Bodhi
+    if "rawhide" in version.lower():
+        log1(_("Warning: abrt-bodhi do not support Product version 'Rawhide'"))
+        sys.exit(RETURN_OK)
+
+    if not OPTIONS.without_bodhi:
+        Popen(["abrt-bodhi -r -b {0} -d {1}".format(bug_id, DIR_PATH)],
+                shell=True,
+                bufsize=-1).wait()
+
+    sys.exit(RETURN_OK)

--- a/src/plugins/ccpp_retrace_event.conf
+++ b/src/plugins/ccpp_retrace_event.conf
@@ -1,9 +1,4 @@
 EVENT=analyze_RetraceServer type=CCpp
         abrt-retrace-client batch --dir "$DUMP_DIR" --status-delay 10 &&
         abrt-action-analyze-backtrace &&
-        (
-            bug_id=$(reporter-bugzilla -h `cat duphash`) &&
-            if test -n "$bug_id"; then
-                abrt-bodhi -r -b $bug_id
-            fi
-        )
+        abrt-action-find-bodhi-update

--- a/tests/runtests/abrt-action-find-bodhi-update/PURPOSE
+++ b/tests/runtests/abrt-action-find-bodhi-update/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of abrt-action-find-bodhi-update
+Description: Verify abrt-action-find-bodhi-update sanity
+Author: Matej Habrnal <mhabrnal@redhat.com>

--- a/tests/runtests/abrt-action-find-bodhi-update/runtest.sh
+++ b/tests/runtests/abrt-action-find-bodhi-update/runtest.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of abrt-action-find-bodhi-update
+#   Description: Verify abrt-action-find-bodhi-update sanity
+#   Author: Matej Habrnal <mhabrnal@redhat.com
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2011 Red Hat, Inc. All rights reserved.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+. ../aux/lib.sh
+
+TEST="abrt-action-find-bodhi-update"
+PACKAGE="abrt"
+
+FILENAME_DUPHASH="duphash"
+FILENAME_OSINFO="os_info"
+OSINFO_BUGZILLA_PRODUCT="REDHAT_BUGZILLA_PRODUCT="
+OSINFO_BUGZILLA_PRODUCT_VERSION="REDHAT_BUGZILLA_PRODUCT_VERSION="
+
+rlJournalStart
+    rlPhaseStartSetup
+        check_prior_crashes
+        TmpDir=$(mktemp -d)
+        pushd $TmpDir
+    rlPhaseEnd
+
+    rlPhaseStartTest "sanity"
+        rlRun "abrt-action-find-bodhi-update --help"
+        rlRun "abrt-action-find-bodhi-update --help 2>&1 | grep 'usage: abrt-action-find-bodhi-update'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Not problem directory"
+        rlRun "abrt-action-find-bodhi-update &> not_problem_directory.log" 2 "Not problem directory"
+        rlAssertGrep "Problem directory error: cannot open problem directory" not_problem_directory.log
+        rlAssertGrep "is not a problem directory" not_problem_directory.log
+
+        rlRun "abrt-action-find-bodhi-update -d . &> not_problem_directory_with_d.log" 2 "Not problem directory"
+        rlAssertGrep "Problem directory error: cannot open problem directory" not_problem_directory_with_d.log
+        rlAssertGrep "is not a problem directory" not_problem_directory_with_d.log
+    rlPhaseEnd
+
+    rlPhaseStartTest "Loading files from problem directory - missing duphash file"
+        prepare
+        generate_crash
+        wait_for_hooks
+        get_crash_path
+
+        rlRun "abrt-action-find-bodhi-update -d $crash_PATH &> missing_duphas.log" 2 "Missing duphash file"
+        rlAssertGrep "Problem directory error: problem directory misses 'duphash'" missing_duphas.log
+    rlPhaseEnd
+
+    rlPhaseStartTest "Loading files from problem directory - missing os_info file"
+        # create duphash file in problem dir
+        rlRun "abrt-action-generate-backtrace -d $crash_PATH" 0 "Generate backtrace in problem dir"
+        rlRun "abrt-action-analyze-backtrace -d $crash_PATH" 0 "Analyze backtrace in problem dir"
+
+        # teporarily erase os_info file
+        rlRun "mv -f ${crash_PATH}/${FILENAME_OSINFO} ${crash_PATH}/${FILENAME_OSINFO}.backup" 0
+
+        rlRun "abrt-action-find-bodhi-update -d $crash_PATH &> missing_os_info.log" 2 "Missing os_info file"
+        rlAssertGrep "Problem directory error: problem directory misses 'os_info'" missing_os_info.log
+
+        # restore os_info file
+        rlRun "cp -f ${crash_PATH}/${FILENAME_OSINFO}.backup ${crash_PATH}/${FILENAME_OSINFO}" 0
+    rlPhaseEnd
+
+    rlPhaseStartTest "Loading files from problem directory - testing_product in os_info"
+        # set $OSINFO_BUGZILLA_PRODUCT to "testing_product" in os_info
+        bugzilla_product=$(grep "$OSINFO_BUGZILLA_PRODUCT" "${crash_PATH}/${FILENAME_OSINFO}")
+        sed -i "s/${bugzilla_product}/${OSINFO_BUGZILLA_PRODUCT}\"testing_product\"/g" "${crash_PATH}/${FILENAME_OSINFO}"
+        rlAssertGrep "${OSINFO_BUGZILLA_PRODUCT}\"testing_product\"" "${crash_PATH}/${FILENAME_OSINFO}"
+
+        rlRun "abrt-action-find-bodhi-update -vvv -d $crash_PATH &> testing_product.log" 0 "os_info product 'testing_product'"
+        rlAssertGrep "Using product \"testing_product\"" testing_product.log
+    rlPhaseEnd
+
+    rlPhaseStartTest "Loading files from problem directory - no product in os_info"
+        # erase $OSINFO_BUGZILLA_PRODUCT from os_info, using product from /etc/os-release
+        sed -i "s/${OSINFO_BUGZILLA_PRODUCT}\"testing_product\"//g" "${crash_PATH}/${FILENAME_OSINFO}"
+        rlAssertNotGrep "${OSINFO_BUGZILLA_PRODUCT}" "${crash_PATH}/${FILENAME_OSINFO}"
+        rlRun "abrt-action-find-bodhi-update -vvv -d $crash_PATH &> os_release_product.log" 0 "Product from /etc/os-release"
+        rlAssertGrep "Using product '${OSINFO_BUGZILLA_PRODUCT}' from /etc/os-release." os_release_product.log
+    rlPhaseEnd
+
+    rlPhaseStartTest "Loading files from problem directory - rawhide product version"
+        # rawhide product version -> do not run abrt-bodhi
+        # set $OSINFO_BUGZILLA_PRODUCT_VERSION to "rawhide" in os_info
+        bugzilla_version=$(grep "$OSINFO_BUGZILLA_PRODUCT_VERSION" "${crash_PATH}/${FILENAME_OSINFO}")
+        sed -i "s/${bugzilla_version}/${OSINFO_BUGZILLA_PRODUCT_VERSION}\"rawhide\"/g" "${crash_PATH}/${FILENAME_OSINFO}"
+        rlAssertGrep "${OSINFO_BUGZILLA_PRODUCT_VERSION}\"rawhide\"" "${crash_PATH}/${FILENAME_OSINFO}"
+
+        rlRun "abrt-action-find-bodhi-update -vvv -d $crash_PATH &> rawhide_version.log" 0 "Product from /etc/os-release"
+        rlAssertGrep "Using product '${OSINFO_BUGZILLA_PRODUCT}' from /etc/os-release." rawhide_version.log
+        rlAssertGrep "Warning: abrt-bodhi do not support Product version 'Rawhide'" rawhide_version.log
+    rlPhaseEnd
+
+    rlPhaseStartTest "Loading files from problem directory - product from environment variable"
+        # set product via environment variable 'Bugzilla_Product'
+        rlRun "export Bugzilla_Product=\"foo\""
+        rlRun "abrt-action-find-bodhi-update -vvv -d $crash_PATH &> env_product.log" 0 "Product from env"
+        rlAssertGrep "Using product foo" env_product.log
+        rlRun "unset Bugzilla_Product"
+    lPhaseEnd
+
+    rlPhaseStartCleanup
+        rm -rf $crash_PATH
+        rlBundleLogs abrt $(ls *.log)
+        popd # TmpDir
+        rm -rf $TmpDir
+    rlPhaseEnd
+    rlJournalPrintText
+rlJournalEnd

--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -48,6 +48,7 @@ abrt-python3
 python-bindings
 kernel-vmcore-harvest
 abrt-action-install-debuginfo
+abrt-action-find-bodhi-update
 
 # - problem data tests
 duptest-occurrence


### PR DESCRIPTION
The tool 'abrt-action-search-bodhi-updates' takes one parameter DUMP_DIR path,
reads duphash file in problem directory and searches for a new updates
according to the crash using abrt-bodhi client.

Related to rhbz#1268218