### PR TITLE
remove 'not needed' code

### DIFF
--- a/src/daemon/abrt-handle-event.c
+++ b/src/daemon/abrt-handle-event.c
@@ -89,18 +89,6 @@ static int core_backtrace_is_duplicate(struct sr_stacktrace *bt1,
         goto end;
     }
 
-    /* This is an ugly workaround for https://github.com/abrt/btparser/issues/6 */
-    /*
-    int length1 = sr_core_thread_get_frame_count(thread1);
-
-    if (length1 <= 2 || length2 <= 2)
-    {
-        log_notice("Backtraces too short, falling back on full comparison");
-        result = (sr_core_thread_cmp(thread1, thread2) == 0);
-        goto end;
-    }
-    */
-
     float distance = sr_distance(SR_DISTANCE_DAMERAU_LEVENSHTEIN, thread1, thread2);
     log_info("Distance between backtraces: %f", distance);
     result = (distance <= BACKTRACE_DUP_THRESHOLD);

--- a/src/lib/problem_api.c
+++ b/src/lib/problem_api.c
@@ -143,14 +143,12 @@ GList *get_problem_dirs_not_accessible_by_uid(uid_t uid, const char *dump_locati
 
 GList *get_problem_storages(void)
 {
-    GList *pths = NULL;
+    GList *paths = NULL;
     load_abrt_conf();
-    pths = g_list_append(pths, xstrdup(g_settings_dump_location));
-    //not needed, we don't steal directories anymore
-    pths = g_list_append(pths, concat_path_file(g_get_user_cache_dir(), "abrt/spool"));
+    paths = g_list_append(pths, xstrdup(g_settings_dump_location));
     free_abrt_conf_data();
 
-    return pths;
+    return paths;
 }
 
 int problem_dump_dir_is_complete(struct dump_dir *dd)


### PR DESCRIPTION
If the code is not needed then it might be a good idea
to actually get rid of it instead of adding a
notice that it is not needed...

Also fixes variable naming that saved stunning one character!