### PR TITLE
a-d-journal-core: set root owner for created dump directory

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -926,6 +926,7 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_mandir}/man*/abrt-action-analyze-core.*
 %{_mandir}/man*/abrt-action-analyze-vulnerability.*
 %{_mandir}/man*/abrt-action-perform-ccpp-analysis.*
+%{_mandir}/man1/abrt-dump-journal-core.1*
 
 %files addon-upload-watch
 %defattr(-,root,root,-)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -20,6 +20,7 @@ MAN1_TXT += abrt-action-perform-ccpp-analysis.txt
 MAN1_TXT += abrt-action-notify.txt
 MAN1_TXT += abrt-applet.txt
 MAN1_TXT += abrt-dump-oops.txt
+MAN1_TXT += abrt-dump-journal-core.txt
 MAN1_TXT += abrt-dump-journal-oops.txt
 MAN1_TXT += abrt-dump-xorg.txt
 MAN1_TXT += abrt-auto-reporting.txt

--- a/doc/abrt-dump-journal-core.txt
+++ b/doc/abrt-dump-journal-core.txt
@@ -1,0 +1,65 @@
+abrt-dump-journal-core(1)
+=========================
+
+NAME
+----
+abrt-dump-journal-core - Extract coredumps from systemd-journal
+
+SYNOPSIS
+--------
+'abrt-dump-journal-core' [-vsf] [-e]/[-c CURSOR] [-t INT]/[-T] [-d DIR]/[-D]
+
+DESCRIPTION
+-----------
+This tool creates problem directory from coredumps extracted from
+systemd-journal.
+The tool can follow systemd-journal and extract coredumps in time of their
+occurrence.
+
+The following start from the last seen cursor. If the last seen cursor file
+does not exist, the following start by scanning the entire sytemd-journal or
+from the end if '-e' option is specified.
+
+-c and -e options conflicts because both specifies the first read message.
+
+-e is useful only for -f because the following of journal starts by reading
+the entire journal if the last seen possition is not available.
+
+FILES
+-----
+/var/lib/abrt/abrt-dump-journal-core.state::
+   State file where systemd-journal cursor to the last seen message is saved
+
+OPTIONS
+-------
+-v, --verbose::
+   Be more verbose. Can be given multiple times.
+
+-s::
+   Log to syslog
+
+-d DIR::
+   Create new problem directory in DIR for every coredump
+
+-D::
+   Same as -d DumpLocation, DumpLocation is specified in abrt.conf
+
+-e::
+   Starts following systemd-journal from the end
+
+-t INT::
+   Throttle problem directory creation to 1 per INT second
+
+-T::
+   Same as -t INT, INT is specified in plugins/CCpp.conf
+
+-f::
+   Follow systemd-journal from the last seen position (if available)
+
+SEE ALSO
+--------
+abrt.conf(5), journalctl(1)
+
+AUTHORS
+-------
+* ABRT team

--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -302,7 +302,7 @@ save_systemd_coredump_in_dump_directory(struct dump_dir *dd, struct crash_info *
 static int
 abrt_journal_core_to_abrt_problem(struct crash_info *info, const char *dump_location)
 {
-    struct dump_dir *dd = create_dump_dir(dump_location, "ccpp", info->ci_uid,
+    struct dump_dir *dd = create_dump_dir(dump_location, "ccpp", /*fs owner*/0,
             (save_data_call_back)save_systemd_coredump_in_dump_directory, info);
 
     if (dd != NULL)

--- a/tests/runtests/abrt-dump-journal-core/PURPOSE
+++ b/tests/runtests/abrt-dump-journal-core/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of abrt-dump-journal-core
+Description: Verify abrt-dump-journal-core funcionality
+Author: Matej Habrnal <mhabrnal@redhat.com>

--- a/tests/runtests/abrt-dump-journal-core/runtest.sh
+++ b/tests/runtests/abrt-dump-journal-core/runtest.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of abrt-dump-journal-core
+#   Description: test for abrt-dump-journal-core
+#   Author: Matej Habrnal <mhabrnal@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2015 Red Hat, Inc. All rights reserved.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+. ../aux/lib.sh
+
+TEST="abrt-dump-journal-core"
+PACKAGE="abrt"
+CORE_REQUIRED_FILES="abrt_version analyzer architecture cmdline component core_backtrace count dso_list environ executable hostname kernel last_occurrence limits maps open_fds os_info os_release package pid pkg_arch pkg_epoch pkg_name pkg_release pkg_version reason time type uid username"
+
+rlJournalStart
+    rlPhaseStartSetup
+        check_prior_crashes
+
+        rlRun "systemctl stop abrt-ccpp.service"
+        rlRun "systemctl start abrt-journal-core.service"
+
+        TmpDir=$(mktemp -d)
+        pushd $TmpDir
+    rlPhaseEnd
+
+    rlPhaseStartTest "generate crash as root"
+        prepare
+        generate_crash
+        wait_for_hooks
+        get_crash_path
+
+        check_dump_dir_attributes $crash_PATH
+
+        for f in $CORE_REQUIRED_FILES; do
+            rlAssertExists "$crash_PATH/$f"
+        done
+
+        uid=$(cat ${crash_PATH}/uid)
+        rlAssertEquals "uid file contains the same id as user who causes the crash" $uid 0
+
+        rlRun "abrt-cli remove $crash_PATH"
+    rlPhaseEnd
+
+    rlPhaseStartTest "generate crash as abrt-journal-core-test user"
+        rlRun "useradd -c \"dump journal core test\" -M abrt_core_test"
+        abrt_user_id=$(id -u abrt_core_test)
+
+        prepare
+        generate_crash abrt_core_test
+        wait_for_hooks
+        get_crash_path
+
+        check_dump_dir_attributes $crash_PATH
+
+        for f in $CORE_REQUIRED_FILES; do
+            rlAssertExists "$crash_PATH/$f"
+        done
+
+        uid=$(cat ${crash_PATH}/uid)
+        rlAssertEquals "uid file contains the same id as user who causes the crash" $uid $abrt_user_id
+
+        rlRun "userdel -r -f abrt_core_test"
+        rlRun "abrt-cli remove $crash_PATH"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "systemctl stop abrt-journal-core.service"
+        rlRun "systemctl start abrt-ccpp.service"
+
+        rlRun "popd"
+        rlLog "$TmpDir"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+    rlJournalPrintText
+rlJournalEnd

--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -45,6 +45,7 @@ oops-processing
 oops-sanity
 oops-alt-components
 journal-oops-processing
+abrt-dump-journal-core
 abrt-python
 abrt-python3
 python-bindings


### PR DESCRIPTION
Without this commit abrt-server fails during check the right owner and group of
dump dirs.

Related to rhbz#1269827