### PR TITLE
add BlackListedPaths option to abrt-hook-ccpp

### DIFF
--- a/doc/abrt-CCpp.conf.txt
+++ b/doc/abrt-CCpp.conf.txt
@@ -41,6 +41,10 @@ SaveFullCore = 'yes' / 'no' ...::
    directory.
    Default is 'yes'.
 
+IgnoredPaths = /path/to/ignore/*, */another/ignored/path* ...::
+   ABRT will ignore crashes in executables whose absolute path matches one of
+   specified patterns.
+
 VerboseLog = NUM::
    Used to make the hook more verbose
 

--- a/src/daemon/abrt-server.c
+++ b/src/daemon/abrt-server.c
@@ -757,7 +757,10 @@ static int perform_http_xact(void)
         int repeating_crash = check_recent_crash_file(last_file, executable);
         free(last_file);
         if (repeating_crash) /* Only pretend that we saved it */
+        {
+            error_msg("Not saving repeating crash in '%s'", executable);
             goto out; /* ret is 0: "success" */
+        }
     }
 
 #if 0

--- a/src/hooks/CCpp.conf
+++ b/src/hooks/CCpp.conf
@@ -49,3 +49,8 @@ SaveFullCore = yes
 # is not running.
 #
 # StandaloneHook = yes
+
+# ABRT will ignore crashes in executables whose absolute path matches one of
+# specified patterns.
+#
+#IgnoredPaths =

--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -511,7 +511,7 @@ static int save_crashing_binary(pid_t pid, struct dump_dir *dd)
     return fsync(dst_fd) != 0 || close(dst_fd) != 0 || sz < 0;
 }
 
-static void error_msg_not_process_crash(const char *pid_str, const char *process_str,
+static void error_msg_process_crash(const char *pid_str, const char *process_str,
         long unsigned uid, int signal_no, const char *signame, const char *message, ...)
 {
     va_list p;
@@ -528,6 +528,20 @@ static void error_msg_not_process_crash(const char *pid_str, const char *process
 
     free(message_full);
 
+    return;
+}
+
+static void error_msg_ignore_crash(const char *pid_str, const char *process_str,
+        long unsigned uid, int signal_no, const char *signame, const char *message, ...)
+{
+    va_list p;
+    va_start(p, message);
+    char *message_full = xvasprintf(message, p);
+    va_end(p);
+
+    error_msg_process_crash(pid_str, process_str, uid, signal_no, signame, "ignoring (%s)", message_full);
+
+    free(message_full);
     return;
 }
 
@@ -620,17 +634,27 @@ int main(int argc, char** argv)
     errno = 0;
     const char* signal_str = argv[1];
     int signal_no = xatoi_positive(signal_str);
-    const char *signame = NULL;
-    bool signal_is_fatal_bool = signal_is_fatal(signal_no, &signame);
     off_t ulimit_c = strtoull(argv[2], NULL, 10);
     if (ulimit_c < 0) /* unlimited? */
     {
         /* set to max possible >0 value */
         ulimit_c = ~((off_t)1 << (sizeof(off_t)*8-1));
     }
+    const char *signame = NULL;
+    bool signal_is_fatal_bool = signal_is_fatal(signal_no, &signame);
+    const char *global_pid_str = argv[8];
+    pid_t pid = xatoi_positive(argv[8]);
+
+    char *executable = get_executable(pid);
+
     const char *pid_str = argv[3];
     pid_t local_pid = xatoi_positive(argv[3]);
+
     uid_t uid = xatoi_positive(argv[4]);
+
+    user_pwd = get_cwd(pid); /* may be NULL on error */
+    log_notice("user_pwd:'%s'", user_pwd);
+
     if (errno || local_pid <= 0)
     {
         perror_msg_and_die("PID '%s' or limit '%s' is bogus", argv[3], argv[2]);
@@ -644,35 +668,8 @@ int main(int argc, char** argv)
         else
             free(s);
     }
-    const char *global_pid_str = argv[8];
-    pid_t pid = xatoi_positive(argv[8]);
-
-    pid_t tid = -1;
-    const char *tid_str = argv[9];
-    if (tid_str)
-    {
-        tid = xatoi_positive(tid_str);
-    }
 
     char path[PATH_MAX];
-
-    char *executable = get_executable(pid);
-    if (executable && strstr(executable, "/abrt-hook-ccpp"))
-    {
-        error_msg_and_die("PID %lu is '%s', not dumping it to avoid recursion",
-                        (long)pid, executable);
-    }
-
-    if (executable && is_path_ignored(setting_ignored_paths, executable))
-    {
-        error_msg_not_process_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
-                signame, "ignoring (listed in 'IgnoredPaths')");
-
-        return 0;
-    }
-
-    user_pwd = get_cwd(pid); /* may be NULL on error */
-    log_notice("user_pwd:'%s'", user_pwd);
 
     sprintf(path, "/proc/%lu/status", (long)pid);
     char *proc_pid_status = xmalloc_xopen_read_close(path, /*maxsz:*/ NULL);
@@ -700,11 +697,94 @@ int main(int argc, char** argv)
         }
     }
 
+    snprintf(path, sizeof(path), "%s/last-ccpp", g_settings_dump_location);
+
     /* Open a fd to compat coredump, if requested and is possible */
     int user_core_fd = -1;
     if (setting_MakeCompatCore && ulimit_c != 0)
         /* note: checks "user_pwd == NULL" inside; updates core_basename */
         user_core_fd = open_user_core(uid, fsuid, fsgid, pid, &argv[1]);
+
+    /* ignoring crashes */
+    if (executable && is_path_ignored(setting_ignored_paths, executable))
+    {
+        error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "listed in 'IgnoredPaths'");
+
+        return 0;
+    }
+    /* do not dump abrt-hook-ccpp crashes */
+    if (executable && strstr(executable, "/abrt-hook-ccpp"))
+    {
+        error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "avoid recursion");
+
+        xfunc_die();
+    }
+    /* Check /var/tmp/abrt/last-ccpp marker, do not dump repeated crashes
+     * if they happen too often. Else, write new marker value.
+     */
+    if (check_recent_crash_file(path, executable))
+    {
+        error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "repeated crash");
+
+        /* It is a repeating crash */
+        return create_user_core(user_core_fd, pid, ulimit_c);
+    }
+    const char *last_slash = strrchr(executable, '/');
+    const bool abrt_crash = (last_slash && (strncmp(++last_slash, "abrt", 4) == 0));
+    if (abrt_crash && g_settings_debug_level == 0)
+    {
+        error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "'DebugLevel' == 0");
+
+        goto cleanup_and_exit;
+    }
+    /* unsupported signal */
+    if (!signal_is_fatal_bool)
+    {
+        error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "unsupported signal");
+
+        return create_user_core(user_core_fd, pid, ulimit_c); // not a signal we care about
+
+    }
+    const int abrtd_running = daemon_is_ok();
+    if (!setting_StandaloneHook && !abrtd_running)
+    {
+        error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "abrtd is not running");
+
+        /* not an error, exit with exit code 0 */
+        log("If abrtd crashed, "
+            "/proc/sys/kernel/core_pattern contains a stale value, "
+            "consider resetting it to 'core'"
+        );
+        return create_user_core(user_core_fd, pid, ulimit_c);
+    }
+    /* low free space */
+    if (g_settings_nMaxCrashReportsSize > 0)
+    {
+        /* If free space is less than 1/4 of MaxCrashReportsSize... */
+        if (low_free_space(g_settings_nMaxCrashReportsSize, g_settings_dump_location))
+        {
+            error_msg_ignore_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                                    signame, "low free space");
+            return create_user_core(user_core_fd, pid, ulimit_c);
+        }
+    }
+
+    // processing crash - inform user about it
+    error_msg_process_crash(pid_str, argv[7], (long unsigned)uid,
+                signal_no, signame, "dumping core");
+
+    pid_t tid = -1;
+    const char *tid_str = argv[9];
+    if (tid_str)
+    {
+        tid = xatoi_positive(tid_str);
+    }
 
     if (executable == NULL)
     {
@@ -713,50 +793,11 @@ int main(int argc, char** argv)
         return create_user_core(user_core_fd, pid, ulimit_c);
     }
 
-    if (!signal_is_fatal_bool)
-        return create_user_core(user_core_fd, pid, ulimit_c); // not a signal we care about
-
-    const int abrtd_running = daemon_is_ok();
-    if (!setting_StandaloneHook && !abrtd_running)
-    {
-        /* not an error, exit with exit code 0 */
-        log("abrtd is not running. If it crashed, "
-            "/proc/sys/kernel/core_pattern contains a stale value, "
-            "consider resetting it to 'core'"
-        );
-        return create_user_core(user_core_fd, pid, ulimit_c);
-    }
-
     if (setting_StandaloneHook)
         ensure_writable_dir(g_settings_dump_location, DEFAULT_DUMP_LOCATION_MODE, "abrt");
 
-    if (g_settings_nMaxCrashReportsSize > 0)
+    if (abrt_crash)
     {
-        /* If free space is less than 1/4 of MaxCrashReportsSize... */
-        if (low_free_space(g_settings_nMaxCrashReportsSize, g_settings_dump_location))
-            return create_user_core(user_core_fd, pid, ulimit_c);
-    }
-
-    /* Check /var/tmp/abrt/last-ccpp marker, do not dump repeated crashes
-     * if they happen too often. Else, write new marker value.
-     */
-    snprintf(path, sizeof(path), "%s/last-ccpp", g_settings_dump_location);
-    if (check_recent_crash_file(path, executable))
-    {
-        /* It is a repeating crash */
-        return create_user_core(user_core_fd, pid, ulimit_c);
-    }
-
-    const char *last_slash = strrchr(executable, '/');
-    if (last_slash && strncmp(++last_slash, "abrt", 4) == 0)
-    {
-        if (g_settings_debug_level == 0)
-        {
-            log_warning("Ignoring crash of %s (SIG%s).",
-                        executable, signame ? signame : signal_str);
-            goto cleanup_and_exit;
-        }
-
         /* If abrtd/abrt-foo crashes, we don't want to create a _directory_,
          * since that can make new copy of abrtd to process it,
          * and maybe crash again...

--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -18,6 +18,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+#include <fnmatch.h>
 #include <sys/utsname.h>
 #include "libabrt.h"
 #include <selinux/selinux.h>
@@ -457,6 +458,19 @@ finito:
     return err;
 }
 
+static bool is_path_ignored(const GList *list, const char *path)
+{
+    const GList *li;
+    for (li = list; li != NULL; li = g_list_next(li))
+    {
+        if (fnmatch((char*)li->data, path, /*flags:*/ 0) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 static int test_configuration(bool setting_SaveFullCore, bool setting_CreateCoreBacktrace)
 {
     if (!setting_SaveFullCore && !setting_CreateCoreBacktrace)
@@ -497,6 +511,26 @@ static int save_crashing_binary(pid_t pid, struct dump_dir *dd)
     return fsync(dst_fd) != 0 || close(dst_fd) != 0 || sz < 0;
 }
 
+static void error_msg_not_process_crash(const char *pid_str, const char *process_str,
+        long unsigned uid, int signal_no, const char *signame, const char *message, ...)
+{
+    va_list p;
+    va_start(p, message);
+    char *message_full = xvasprintf(message, p);
+    va_end(p);
+
+    if (signame)
+        error_msg("Process %s (%s) of user %lu killed by SIG%s - %s", pid_str,
+                        process_str, uid, signame, message_full);
+    else
+        error_msg("Process %s (%s) of user %lu killed by signal %d - %s", pid_str,
+                        process_str, uid, signal_no, message_full);
+
+    free(message_full);
+
+    return;
+}
+
 int main(int argc, char** argv)
 {
     /* Kernel starts us with all fd's closed.
@@ -522,6 +556,7 @@ int main(int argc, char** argv)
     bool setting_CreateCoreBacktrace;
     bool setting_SaveContainerizedPackageData;
     bool setting_StandaloneHook;
+    GList *setting_ignored_paths = NULL;
     {
         map_string_t *settings = new_map_string();
         load_abrt_plugin_conf_file("CCpp.conf", settings);
@@ -534,6 +569,9 @@ int main(int argc, char** argv)
         setting_SaveFullCore = value ? string_to_bool(value) : true;
         value = get_map_string_item_or_NULL(settings, "CreateCoreBacktrace");
         setting_CreateCoreBacktrace = value ? string_to_bool(value) : true;
+        value = get_map_string_item_or_NULL(settings, "IgnoredPaths");
+        if (value)
+            setting_ignored_paths = parse_list(value);
 
         value = get_map_string_item_or_NULL(settings, "SaveContainerizedPackageData");
         setting_SaveContainerizedPackageData = value && string_to_bool(value);
@@ -582,6 +620,8 @@ int main(int argc, char** argv)
     errno = 0;
     const char* signal_str = argv[1];
     int signal_no = xatoi_positive(signal_str);
+    const char *signame = NULL;
+    bool signal_is_fatal_bool = signal_is_fatal(signal_no, &signame);
     off_t ulimit_c = strtoull(argv[2], NULL, 10);
     if (ulimit_c < 0) /* unlimited? */
     {
@@ -621,6 +661,14 @@ int main(int argc, char** argv)
     {
         error_msg_and_die("PID %lu is '%s', not dumping it to avoid recursion",
                         (long)pid, executable);
+    }
+
+    if (executable && is_path_ignored(setting_ignored_paths, executable))
+    {
+        error_msg_not_process_crash(pid_str, argv[7], (long unsigned)uid, signal_no,
+                signame, "ignoring (listed in 'IgnoredPaths')");
+
+        return 0;
     }
 
     user_pwd = get_cwd(pid); /* may be NULL on error */
@@ -665,8 +713,7 @@ int main(int argc, char** argv)
         return create_user_core(user_core_fd, pid, ulimit_c);
     }
 
-    const char *signame = NULL;
-    if (!signal_is_fatal(signal_no, &signame))
+    if (!signal_is_fatal_bool)
         return create_user_core(user_core_fd, pid, ulimit_c); // not a signal we care about
 
     const int abrtd_running = daemon_is_ok();

--- a/src/lib/check_recent_crash_file.c
+++ b/src/lib/check_recent_crash_file.c
@@ -44,7 +44,6 @@ int check_recent_crash_file(const char *filename, const char *executable)
             buf[sz] = '\0';
             if (strcmp(executable, buf) == 0)
             {
-                error_msg("Not saving repeating crash in '%s'", executable);
                 close(fd);
                 return 1;
             }

--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -35,6 +35,7 @@ cli-status
 cli-authentication
 console-notifications
 check-hook-install
+hook-ccpp-ignoring
 dumpoops
 dumpxorg
 dbus-api

--- a/tests/runtests/ccpp-plugin-hook-ignoring/PURPOSE
+++ b/tests/runtests/ccpp-plugin-hook-ignoring/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of ccpp-plugin-hook-ignoring
+Description: Test ignoring in abrt-hook-ccpp
+Author: Matej Habrnal <mhabrnal@redhat.com>

--- a/tests/runtests/ccpp-plugin-hook-ignoring/failing_code.c
+++ b/tests/runtests/ccpp-plugin-hook-ignoring/failing_code.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    puts(NULL);
+    return 0;
+}

--- a/tests/runtests/ccpp-plugin-hook-ignoring/runtest.sh
+++ b/tests/runtests/ccpp-plugin-hook-ignoring/runtest.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of ccpp-plugin-hook-ignoring
+#   Description: Test ignoring in abrt-hook-ccpp
+#   Author: Matej Habrnal <mhabrnal@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2015 Red Hat, Inc. All rights reserved.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+. ../aux/lib.sh
+
+TEST="ccpp-plugin-hook-ignoring"
+PACKAGE="abrt"
+
+function test_create_dir {
+
+    journal_time=$(date +%R:%S)
+    prepare
+    generate_crash
+    wait_for_hooks
+    # get_crash_path checks if the crash was created
+    get_crash_path
+
+    journalctl --since="$journal_time" >abrt_journal.log
+
+    rlAssertNotGrep "Process [0-9][0-9]* \(will_segfault\) of user [0-9][0-9]* killed by SIGSEGV - ignoring \(listed in 'IgnoredPaths'\)" abrt_journal.log -E
+
+    rlAssertGrep "Process [0-9][0-9]* \(will_segfault\) of user [0-9][0-9]* killed by SIGSEGV - dumping core" abrt_journal.log -E
+
+
+    rlRun "abrt-cli rm $crash_PATH" 0 "Removing problem dirs"
+}
+
+function test_not_create_dir {
+
+    journal_time=$(date +%R:%S)
+    prepare
+    generate_crash
+    sleep 3
+
+    journalctl -b --since="$journal_time" >abrt_journal.log
+
+    rlAssertGrep "Process [0-9][0-9]* \(will_segfault\) of user [0-9][0-9]* killed by SIGSEGV - ignoring \(listed in 'IgnoredPaths'\)" abrt_journal.log -E
+    rlAssertNotGrep "Process [0-9][0-9]* \(will_segfault\) of user [0-9][0-9]* killed by SIGSEGV - dumping core" abrt_journal.log -E
+
+    # no crash is generated
+    rlAssert0 "Crash should not be generated" $(abrt-cli list 2> /dev/null | wc -l)
+}
+
+rlJournalStart
+    rlPhaseStartSetup
+        check_prior_crashes
+
+        TmpDir=$(mktemp -d)
+        pushd $TmpDir
+    rlPhaseEnd
+
+    rlPhaseStartTest "Ignoring will_segfault"
+        OLD_BLACKLIST=$(augtool print /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths | cut -d'=' -f2 | tr -d ' ')
+        rlLog "Storing CCpp.conf IgnoredPaths value '$OLD_BLACKLIST'"
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths foo,*will_segfault,foo2" 0 "Set IgnoredPaths"
+
+        test_not_create_dir
+
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths foo,/usr/*/will_segfault,foo2" 0 "Set IgnoredPaths"
+
+        test_not_create_dir
+
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths foo,/usr/bin/*,foo2" 0 "Set IgnoredPaths"
+
+        test_not_create_dir
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths foo,/usr/bin/will_*,foo2" 0 "Set IgnoredPaths"
+
+        test_not_create_dir
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths /usr/bin/will_segfault" 0 "Set IgnoredPaths"
+
+        test_not_create_dir
+
+        rlRun "augtool rm /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths" 0 "Restore IgnoredPaths option (removing)"
+        if [ ! -z $OLD_BLACKLIST ]; then
+            rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/IgnoredPaths $OLD_BLACKLIST" 0 "Restore BlackList option (setting old value)"
+        fi
+
+        # will_segfault works without ignoring
+        test_create_dir
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlBundleLogs abrt $(ls *.log)
+        popd # TmpDir
+        rm -rf $TmpDir
+    rlPhaseEnd
+    rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
ABRT will ignore crashes in executables whose absolute path matches one of
specified patterns.

Related to rhbz#1208713