### PR TITLE
testsuite: ccpp-plugin-debug: normalize ABRT_BINARY_COREDUMP

### DIFF
--- a/tests/runtests/ccpp-plugin-debug/runtest.sh
+++ b/tests/runtests/ccpp-plugin-debug/runtest.sh
@@ -73,7 +73,7 @@ rlJournalStart
         check_prior_crashes
         load_abrt_conf
 
-        ABRT_BINARY_COREDUMP=$ABRT_CONF_DUMP_LOCATION/$ABRT_BINARY_NAME"-coredump"
+        ABRT_BINARY_COREDUMP=$(echo $ABRT_CONF_DUMP_LOCATION/$ABRT_BINARY_NAME"-coredump" | sed 's/\/\//\//g')
 
         TmpDir=$(mktemp -d)
         cp $(which will_segfault) $TmpDir/$ABRT_BINARY_NAME


### PR DESCRIPTION
get rid of double slashes