### PR TITLE
Use %s instead of %d.

### DIFF
--- a/po/tr.po
+++ b/po/tr.po
@@ -1475,7 +1475,7 @@ msgstr "Geri izleme işi başladı."
 #, c-format
 msgid "Task Id: %s\n"
 "Task Password: %s\n"
-msgstr "Görev Id: %d\n"
+msgstr "Görev Id: %s\n"
 "\n"
 "Görev Şifresi: %s\n"
 


### PR DESCRIPTION
mnowak> jfilak, then it fails with:
mnowak> rm -f tr.gmo && /usr/bin/msgfmt -c --statistics -o tr.gmo tr.po
mnowak> tr.po:14: warning: header field 'Project-Id-Version' still has the initial default value
mnowak> tr.po:1594: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
mnowak> 91 translated messages, 8 fuzzy translations, 346 untranslated messages.
mnowak> Makefile:200: recipe for target 'tr.gmo' failed
jfilak> mnowak: oops, I'll look into this tomorrow. I need to go now. Sorry.