### PR TITLE
a-a-c-o-f-hw-error: do not crash on invalid unicode

### DIFF
--- a/src/plugins/abrt-action-check-oops-for-hw-error.in
+++ b/src/plugins/abrt-action-check-oops-for-hw-error.in
@@ -32,12 +32,19 @@ def tail_with_search(filename, string, maxlen):
         #print e
         return []
     l = []
-    for line in f:
-        if string in line:
-            l.append(line)
-            if len(l) > maxlen:
-                del l[0]
-    f.close()
+    try:
+        for line in f:
+            if string in line:
+                l.append(line)
+                if len(l) > maxlen:
+                    del l[0]
+    except ValueError as ex:
+        sys.stderr.write("Failed to read file '%s': %s\n"
+                         % (filename, str(ex)))
+        # ignore invalid input - return empty list on error
+        l = []
+    finally:
+        f.close()
     return l
 
 


### PR DESCRIPTION
Fixes Red Hat Bugzilla Bug 1287302

Signed-off-by: Jan Beran <jberan@redhat.com>