### PR TITLE
 ccpp: add AllowedUsers and AllowedGroups feature

### DIFF
--- a/doc/abrt-CCpp.conf.txt
+++ b/doc/abrt-CCpp.conf.txt
@@ -45,6 +45,16 @@ IgnoredPaths = /path/to/ignore/*, */another/ignored/path* ...::
    ABRT will ignore crashes in executables whose absolute path matches one of
    specified patterns.
 
+AllowedUsers = root, ...::
+   ABRT will process only crashes of either allowed users 'AllowedUsers' or
+   users who are members of allowed group 'AllowedGroups'. If no allowed users
+   nor allowed group are specified ABRT will process crashes of all users.
+
+AllowedGroups = root, ...::
+   ABRT will process only crashes of either allowed users 'AllowedUsers' or
+   users who are members of allowed group 'AllowedGroups'. If no allowed users
+   nor allowed group are specified ABRT will process crashes of all users.
+
 VerboseLog = NUM::
    Used to make the hook more verbose
 

--- a/doc/abrt.conf.txt
+++ b/doc/abrt.conf.txt
@@ -36,7 +36,7 @@ DeleteUploaded = 'yes/no'::
    or not.
    The default value is 'no'.
 
-DebugLevel = '0-100':
+DebugLevel = '0-100'::
    Allows ABRT tools to detect problems in ABRT itself. By increasing the value
    you can force ABRT to detect, process and report problems in ABRT. You have
    to bare in mind that ABRT might fall into an infinite loop when handling

--- a/src/hooks/CCpp.conf
+++ b/src/hooks/CCpp.conf
@@ -54,3 +54,10 @@ SaveFullCore = yes
 # specified patterns.
 #
 #IgnoredPaths =
+
+# ABRT will process only crashes of either allowed users or users who are
+# members of allowed group. If no allowed users nor allowed group are specified
+# ABRT will process crashes of all users.
+#
+#AllowedUsers =
+#AllowedGroups =


### PR DESCRIPTION
The feature allows dump core only for allowed users.

The logic is the following:
 - if both options are not-defined or empty keep all core dumps
 - else if crashed UID is in the list of users keep the core dump
 - else if crashed UID belongs to a group in the list of groups keep the core dump

Related to rhbz#1256705

**Requires:** https://github.com/abrt/libreport/pull/398 