### PR TITLE
RHEL6: ccpp: add AllowedUsers and AllowedGroups feature

### DIFF
--- a/src/hooks/CCpp.conf
+++ b/src/hooks/CCpp.conf
@@ -24,3 +24,10 @@ SaveBinaryImage = no
 # specified patterns.
 #
 #IgnoredPaths =
+
+# ABRT will process only crashes of either allowed users or users who are
+# members of allowed group. If no allowed users nor allowed group are specified
+# ABRT will process crashes of all users.
+#
+#AllowedUsers =
+#AllowedGroups =

--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -702,6 +702,44 @@ static bool is_path_ignored(const GList *list, const char *path)
     return false;
 }
 
+static bool is_user_allowed(uid_t uid, const GList *list)
+{
+    const GList *li;
+    for (li = list; li != NULL; li = g_list_next(li))
+    {
+        const char *username = (const char*)li->data;
+        struct passwd *pw = getpwnam(username);
+        if (pw == NULL)
+        {
+            VERB1 log("can't get uid of user '%s' (listed in 'AllowedUsers')", username);
+            continue;
+        }
+
+        if(pw->pw_uid == uid)
+            return true;
+    }
+    return false;
+}
+
+static bool is_user_in_allowed_group(uid_t uid, const GList *list)
+{
+    const GList *li;
+    for (li = list; li != NULL; li = g_list_next(li))
+    {
+        const char *groupname = (const char*)li->data;
+        struct group *gr = getgrnam(groupname);
+        if (gr == NULL)
+        {
+            VERB1 log("can't get gid of group '%s' (listed in 'AllowedGroups')", groupname);
+            continue;
+        }
+
+        if(uid_in_group(uid, gr->gr_gid))
+            return true;
+    }
+    return false;
+}
+
 /* Like other glibc functions this one also return 0 on logical true, positive
  * number on logical false and negative number on error. */
 static int process_is_syslog(pid_t pid)
@@ -848,6 +886,8 @@ int main(int argc, char** argv)
     bool setting_MakeCompatCore;
     bool setting_SaveBinaryImage;
     GList *setting_ignored_paths = NULL;
+    GList *setting_allowed_users = NULL;
+    GList *setting_allowed_groups = NULL;
     {
         map_string_t *settings = new_map_string();
         load_abrt_plugin_conf_file("CCpp.conf", settings);
@@ -862,6 +902,14 @@ int main(int argc, char** argv)
         value = get_map_string_item_or_NULL(settings, "IgnoredPaths");
         if (value)
             setting_ignored_paths = parse_list(value);
+
+        value = get_map_string_item_or_NULL(settings, "AllowedUsers");
+        if (value)
+            setting_allowed_users = parse_list(value);
+        value = get_map_string_item_or_NULL(settings, "AllowedGroups");
+        if (value)
+            setting_allowed_groups = parse_list(value);
+
         free_map_string(settings);
     }
 
@@ -975,6 +1023,25 @@ int main(int argc, char** argv)
         return 0;
     }
 
+     /* dumping core for user, if allowed */
+    if (setting_allowed_users || setting_allowed_groups)
+    {
+        if (setting_allowed_users && is_user_allowed(uid, setting_allowed_users))
+        {
+            VERB3 log("User %lu is listed in 'AllowedUsers'", (long unsigned)uid);
+        }
+        else if (setting_allowed_groups && is_user_in_allowed_group(uid, setting_allowed_groups))
+        {
+            VERB3 log("User %lu is member of group listed in 'AllowedGroups'", (long unsigned)uid);
+        }
+        else
+        {
+            error_msg_not_process_crash(pid_str, last_slash+1, (long unsigned)uid, signal_no,
+                signame, "ignoring (not allowed in 'AllowedUsers' nor 'AllowedGroups')");
+
+            xfunc_die();
+        }
+    }
 
     if (!daemon_is_ok())
     {

--- a/tests/runtests/ccpp-plugin-hook-ignoring/runtest.sh
+++ b/tests/runtests/ccpp-plugin-hook-ignoring/runtest.sh
@@ -33,32 +33,38 @@ PACKAGE="abrt"
 
 function test_create_dir {
 
-    user_ID=$(id -u)
+    REASON=${1:-"listed in 'IgnoredPaths'"}
+    shift
+    USER_PARAM=$1
+    user_UID=$(id -u $USER_PARAM)
+
     prepare
-    will_segfault &
-    PID=$!
+    PID=$(su -c "will_segfault &>/dev/null & echo \$!" $USER_PARAM)
     wait_for_hooks
     # get_crash_path checks if the crash was created
     get_crash_path
 
     tail -n 10 /var/log/messages >abrt_journal.log
 
-    rlAssertNotGrep "Process $PID \(will_segfault\) of user $user_UID killed by SIGSEGV - ignoring \(listed in 'IgnoredPaths'\)" abrt_journal.log -E
+    rlAssertNotGrep "Process $PID \(will_segfault\) of user $user_UID killed by SIGSEGV - ignoring \($REASON\)" abrt_journal.log -E
 
     rlRun "abrt-cli rm $crash_PATH" 0 "Removing problem dirs"
 }
 
 function test_not_create_dir {
 
-    user_UID=$(id -u)
+    REASON=${1:-"listed in 'IgnoredPaths'"}
+    shift
+    USER_PARAM=$1
+    user_UID=$(id -u $USER_PARAM)
+
     prepare
-    will_segfault &
-    PID=$!
+    PID=$(su -c "will_segfault &>/dev/null & echo \$!" $USER_PARAM)
     sleep 3
 
     tail -n 10 /var/log/messages >abrt_journal.log
 
-    rlAssertGrep "Process $PID \(will_segfault\) of user $user_UID killed by SIGSEGV - ignoring \(listed in 'IgnoredPaths'\)" abrt_journal.log -E
+    rlAssertGrep "Process $PID \(will_segfault\) of user $user_UID killed by SIGSEGV - ignoring \($REASON\)" abrt_journal.log -E
 
     # no crash is generated
     rlAssert0 "Crash should not be generated" $(abrt-cli list 2> /dev/null | wc -l)
@@ -110,6 +116,90 @@ rlJournalStart
 
         rlRun "mv -f ${CONF_PATH}.backup $CONF_PATH"
         rlRun "rm -f ${CONF_PATH}.without_ignore"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Ignoring due to either AllowedUsers or AllowedGroups"
+
+        # add user $TEST_USER and add the user to $TEST_GROUP
+        TEST_USER=abrt_user_allowed
+        TEST_USER2=abrt_user_allowed2
+        TEST_GROUP=abrt_group_allowed
+        CONF_FILE="/etc/abrt/plugins/CCpp.conf"
+        REASON_ALLOW="not allowed in 'AllowedUsers' nor 'AllowedGroups'"
+
+        rlRun "useradd -M $TEST_USER"
+        rlRun "useradd -M $TEST_USER2"
+        rlRun "groupadd -f $TEST_GROUP"
+        rlRun "usermod -aG $TEST_GROUP $TEST_USER"
+        rlLog "$(id $TEST_USER)"
+        rlLog "$(id $TEST_USER2)"
+
+        rlRun "cp -fv $CONF_FILE ${CONF_FILE}.backup"
+        rlRun "grep -v -e AllowedGroups -e AllowedUsers $CONF_FILE > ${CONF_FILE}.no_allowing"
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+
+        # will_segfault is processed, if no user allowing is defined
+        test_create_dir
+
+        rlLog "===================================================================="
+        # $TEST_USER is not allowed
+        rlRun "echo \"AllowedUsers = $TEST_USER2,root\" >> ${CONF_FILE}"
+
+        #                   $reason          $username
+        test_not_create_dir "$REASON_ALLOW"  $TEST_USER
+
+        rlLog "===================================================================="
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "echo \"AllowedGroups = $TEST_USER2\" >> ${CONF_FILE}"
+
+        #                   $reason          $username
+        test_not_create_dir "$REASON_ALLOW"  $TEST_USER
+
+        rlLog "===================================================================="
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "echo \"AllowedUsers = $TEST_USER2,root\" >> ${CONF_FILE}"
+        rlRun "echo \"AllowedGroups = $TEST_USER2,root\" >> ${CONF_FILE}"
+
+        #                    $reason          $username
+        test_not_create_dir  "$REASON_ALLOW"  $TEST_USER
+
+        rlLog "===================================================================="
+        # $TEST_USER is not allowed
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "echo \"AllowedUsers = $TEST_USER,$TEST_USER2\" >> ${CONF_FILE}"
+
+        #               $reason          $username
+        test_create_dir "$REASON_ALLOW"  $TEST_USER
+
+        rlLog "===================================================================="
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "echo \"AllowedGroups = $TEST_USER2,$TEST_USER\" >> ${CONF_FILE}"
+
+        #               $reason          $username
+        test_create_dir "$REASON_ALLOW"  $TEST_USER
+
+        rlLog "===================================================================="
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "echo \"AllowedGroups = $TEST_USER2,$TEST_GROUP\" >> ${CONF_FILE}"
+
+        #               $reason          $username
+        test_create_dir "$REASON_ALLOW"  $TEST_USER
+
+        rlLog "===================================================================="
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "echo \"AllowedUsers = $TEST_USER2,$TEST_USER\" >> ${CONF_FILE}"
+        rlRun "echo \"AllowedGroups = $TEST_USER2,$TEST_USER\" >> ${CONF_FILE}"
+
+        #               $reason          $username
+        test_create_dir "$REASON_ALLOW"  $TEST_USER
+
+        rlRun "cp -fv ${CONF_FILE}.no_allowing $CONF_FILE"
+        rlRun "rm -f  ${CONF_FILE}.no_allowing"
+        rlRun "rm -f  ${CONF_FILE}.backup"
+
+        rlRun "userdel -f $TEST_USER"
+        rlRun "userdel -f $TEST_USER2"
+        rlRUn "groupdel $TEST_GROUP"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
The feature allows dump core only for allowed users.
    
    The logic is the following:
     - if both options are not-defined or empty keep all core dumps
     - else if crashed UID is in the list of users keep the core dump
     - else if crashed UID belongs to a group in the list of groups keep the core dump
    
    Related to rhbz#1256705

Requires: https://github.com/abrt/libreport/pull/400