### PR TITLE
a-a-save-package-data: blacklist /usr/lib(64)/firefox/plugin-container

### DIFF
--- a/src/daemon/abrt-action-save-package-data.conf
+++ b/src/daemon/abrt-action-save-package-data.conf
@@ -15,7 +15,7 @@ ProcessUnpackaged = yes
 
 # Blacklisted executable paths (shell patterns)
 #
-BlackListedPaths = /usr/share/doc/*, */example*, /usr/bin/nspluginviewer
+BlackListedPaths = /usr/share/doc/*, */example*, /usr/bin/nspluginviewer, /usr/lib*/firefox/plugin-container
 
 # interpreters names
 Interpreters = python2, python2.7, python, python3, python3.3, python3.4, python3.5, perl, perl5.16.2


### PR DESCRIPTION
/usr/lib(64)/firefox/plugin-container is a sandbox/launcher for Firefox
plug-ins. When it crases Firefox loads it again so we don't want those crashes
reported.

Related to: rhbz#1308840

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>