### PR TITLE
RHEL7: vmcore: catch IOErrors and OSErrors

### DIFF
--- a/src/hooks/abrt_harvest_vmcore.py.in
+++ b/src/hooks/abrt_harvest_vmcore.py.in
@@ -272,8 +272,16 @@ def harvest_vmcore():
             except OSError:
                 sys.stderr.write("Unable to delete '%s'. Ignoring\n" % f_full)
 
-        # Let abrtd know what type of problem it is:
-        create_abrtd_info(destdirnew)
+        try:
+            # Let abrtd know what type of problem it is:
+            create_abrtd_info(destdirnew)
+        except EnvironmentError as ex:
+            sys.stderr.write("Unable to create problem directory info: " + str(ex))
+            try:
+                shutil.rmtree(destdirnew)
+            except Exception as ex:
+                sys.stderr.write("Unable to remove incomplete problem directory: " + str(ex))
+            continue
 
         # chown -R 0:0
         change_owner_rec(destdirnew)


### PR DESCRIPTION
Perhaps some temporary data cleaner removed problem directory while the hook
was still using in.

Resolves: rhbz#1077241

Signed-off-by: Jakub Filak <jfilak@redhat.com>