### PR TITLE
RHEL7: augeas: augtool save oops.conf/DropNotReportableOopses

### DIFF
--- a/augeas/abrt.aug
+++ b/augeas/abrt.aug
@@ -4,8 +4,10 @@ module Abrt =
     let lns = Libreport.lns
 
     let filter = (incl "/etc/abrt/*" )
+               . (excl "/etc/abrt/plugins")
                . (incl "/etc/abrt/plugins/*")
                . (incl "/usr/share/abrt/conf.d/*")
+               . (excl "/usr/share/abrt/conf.d/plugins")
                . (incl "/usr/share/abrt/conf.d/plugins/*")
                . Util.stdexcl
 


### PR DESCRIPTION
Without this commit it was not possible to seve
/files/etc/abrt/plugins/oops.conf/DropNotReportableOopses.

Related to rhbz#1175679

- thanks to Dominic Cleal for the patch

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>