### PR TITLE
testsuite: add a per test timeout for 15m

### DIFF
--- a/tests/runtests/aux/config.sh
+++ b/tests/runtests/aux/config.sh
@@ -48,6 +48,9 @@ export REINSTALL_BEFORE_EACH_TEST=0
 export RESTORE_CONFIGS_BEFORE_EACH_TEST=1
 export CLEAN_SPOOL_BEFORE_EACH_TEST=1
 export DUMP_PACKAGE_VERSIONS=1
+# Ensures that a test will not hang forever.
+# See man timeout for more details about the format.
+export TEST_TIMEOUT=15m
 
 # - misc
 export PACKAGES="abrt \

--- a/tests/runtests/aux/runner.sh
+++ b/tests/runtests/aux/runner.sh
@@ -83,7 +83,7 @@ if [ $1 ]; then
     echo ":: TEST START MARK ::"
     if [ -x /usr/bin/time ]; then
         tmpfile=$( mktemp )
-        /usr/bin/time -v -o $tmpfile ./$(basename $1)
+        /usr/bin/time -v -o $tmpfile /usr/bin/timeout $TEST_TIMEOUT ./$(basename $1)
         cat $tmpfile
         rm $tmpfile
     else


### PR DESCRIPTION
Regardless it is a bug in a test if the test hangs, we need to be able
to recover from this unpleasant state. One test must not destroy entire
suite.

I have chosen 15 minutes without any empirical measurements and I
believe that value is good for us.

Signed-off-by: Jakub Filak <jfilak@redhat.com>