### PR TITLE
testsuite: reporter-rhtsupport should attach whole dumpdir to a case

### DIFF
--- a/tests/runtests/rhts-test/pyserve
+++ b/tests/runtests/rhts-test/pyserve
@@ -5,6 +5,7 @@
 import os
 import sys
 import BaseHTTPServer
+import cgi
 
 class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_POST(self):
@@ -13,6 +14,20 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
 #        self.end_headers()
 
 #        print self.rfile.read(int(self.headers.getheader('content-length')))
+
+        if 'attachments' in self.path:
+            #content_length = int(self.headers['Content-Length'])
+            #file_content = self.rfile.read(content_length)
+            form = cgi.FieldStorage(
+                 fp=self.rfile,
+                 headers=self.headers,
+                 environ={"REQUEST_METHOD": "POST",
+                          "CONTENT_TYPE": self.headers['Content-Type']})
+
+            uploaded_file = form.getvalue("file")
+            if uploaded_file:
+                with open('data.tar.gz', "wb") as fh:
+                    fh.write(uploaded_file)
 
         response = self.dummy_response
         if not self.filelist:

--- a/tests/runtests/rhts-test/runtest.sh
+++ b/tests/runtests/rhts-test/runtest.sh
@@ -68,6 +68,21 @@ rlJournalStart
         rlAssertGrep "URL=http://127.0.0.1:12345/rs/cases/[0-9]*/attachments/.*" client_create
         rlAssertGrep "RHTSupport:.* URL=http://127.0.0.1:12345/rs/cases/[0-9]*/attachments/.*" problem_dir/reported_to
         rm -f problem_dir/reported_to
+
+        # pyserver stores received data as $RECEIVED_FILE
+        RECEIVED_FILE="data.tar.gz"
+        rlAssertExists $RECEIVED_FILE
+        rlRun "tar -zxvf $RECEIVED_FILE"
+
+        rlAssertExists "content.xml"
+        rlAssertExists "content"
+
+        # test wether the recieved data are the same as data in the problem dir
+        rlRun "diff -r problem_dir content &> dir_diff.log"
+        rlLog "diff dir content"
+        cat "dir_diff.log"
+
+        rm -rf content content.xml $RECEIVED_FILE
     rlPhaseEnd
 
     # testing -tCASE_NO


### PR DESCRIPTION
Related to rhbz#1261358

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>