### PR TITLE
a-a-install-debuginfo: correct handling of DebuginfoLocation

### DIFF
--- a/src/hooks/CCpp.conf
+++ b/src/hooks/CCpp.conf
@@ -34,7 +34,15 @@ SaveFullCore = yes
 # Used for debugging the hook
 #VerboseLog = 2
 
-# Specify where you want to store debuginfos (default: /var/cache/abrt-di)
+# Specify directories where ABRT should look for non-system debuginfos.
+#
+# Add a colon separated list of file system paths.
+#
+# Beware the first path in the list is used by ABRT to save downloaded
+# debuginfos, therefore the first path in the list must be _writable_, the
+# rest of the list can be read-only.
+#
+# (default: /var/cache/abrt-di)
 #
 #DebuginfoLocation = /var/cache/abrt-di
 

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -100,7 +100,9 @@ if __name__ == "__main__":
             "    -y          Noninteractive, assume 'Yes' to all questions\n"
             "    --ids       Default: build_ids\n"
             "    --tmpdir    Default: @LARGE_DATA_TMP_DIR@/abrt-tmp-debuginfo-RANDOM_SUFFIX\n"
-            "    --cache     Default: /var/cache/abrt-di\n"
+            "    --cache     Colon separated list of directories. The first one is used for\n"
+            "                saving installed debuginfos.\n"
+            "                Default: /var/cache/abrt-dir\n"
             "    --size_mb   Default: 4096\n"
             "    --pkgmgr   Default: PackageManager from CCpp.conf or 'dnf'\n"
             "    -e,--exact  Download only specified files\n"
@@ -155,7 +157,7 @@ if __name__ == "__main__":
         except OSError as ex:
             print(ex)
         else:
-            cachedirs = conf.get("DebuginfoLocation", None)
+            cachedirs = conf.get("DebuginfoLocation", None).split(":")
 
         if not cachedirs:
             cachedirs = ["/var/cache/abrt-di"]


### PR DESCRIPTION
Closes #1135
