### PR TITLE
RHEL7: Fix memory leaks in abrt-dbus

### DIFF
--- a/src/dbus/abrt-polkit.c
+++ b/src/dbus/abrt-polkit.c
@@ -59,8 +59,11 @@ static PolkitResult do_check(PolkitSubject *subject, const char *action_id)
                 POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
                 cancellable,
                 &error);
+
+    g_object_unref(cancellable);
     g_object_unref(authority);
     g_source_remove(cancel_timeout);
+    g_object_unref(subject);
     if (error)
     {
         g_error_free(error);

--- a/src/lib/abrt_conf.c
+++ b/src/lib/abrt_conf.c
@@ -37,6 +37,9 @@ void free_abrt_conf_data()
 
     free(g_settings_dump_location);
     g_settings_dump_location = NULL;
+
+    free(g_settings_autoreporting_event);
+    g_settings_autoreporting_event = NULL;
 }
 
 static void ParseCommon(map_string_t *settings, const char *conf_filename)

--- a/src/lib/abrt_glib.c
+++ b/src/lib/abrt_glib.c
@@ -22,15 +22,14 @@
 GList *string_list_from_variant(GVariant *variant)
 {
     GList *list = NULL;
-    GVariantIter *iter;
+    GVariantIter iter;
+    g_variant_iter_init(&iter, variant);
     gchar *str;
-    g_variant_get(variant, "as", &iter);
-    while (g_variant_iter_loop(iter, "s", &str))
+    while (g_variant_iter_loop(&iter, "s", &str))
     {
         log_notice("adding: %s", str);
         list = g_list_prepend(list, xstrdup(str));
     }
-    g_variant_unref(variant);
 
     /* we were prepending items, so we should reverse the list to not confuse people
      * by returning items in reversed order than it's in the variant

--- a/src/lib/problem_api.c
+++ b/src/lib/problem_api.c
@@ -51,6 +51,7 @@ int for_each_problem_in_dir(const char *path,
         if (dir_fd < 0)
         {
             VERB2 perror_msg("can't open problem directory '%s'", full_name);
+            free(full_name);
             continue;
         }
 


### PR DESCRIPTION
Fix several repeated leaks that were causing abrt-dbus to waste system
memory.

I used this valgrind command:
    valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all \
             --track-origins=yes --suppressions=glib.supp \
             --log-file=/tmp/leaks-$(date +%s).txt abrt-dbus -vvv -t 10

With suppressions from libsecret and NetworkManager:
  * https://raw.githubusercontent.com/GNOME/libsecret/master/build/glib.supp
  * https://raw.githubusercontent.com/NetworkManager/NetworkManager/master/valgrind.suppressions

The suppressions were needed because Glib allocates a lot of static
stuff and does not free it at exit because it is useless.

Resolves: #1319704

Signed-off-by: Jakub Filak <jfilak@redhat.com>