### PR TITLE
a-a-install-debuginfo: do not try to split None

### DIFF
--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -152,15 +152,14 @@ if __name__ == "__main__":
     set_verbosity(verbose)
 
     if not cachedirs:
+        cachedirs = ["/var/cache/abrt-di"]
         try:
             conf = problem.load_plugin_conf_file("CCpp.conf")
         except OSError as ex:
             print(ex)
         else:
-            cachedirs = conf.get("DebuginfoLocation", None).split(":")
+            cachedirs = conf.get("DebuginfoLocation", cachedirs[0]).split(":")
 
-        if not cachedirs:
-            cachedirs = ["/var/cache/abrt-di"]
     if not TMPDIR:
         # security people prefer temp subdirs in app's private dir, like /var/run/abrt
         # and we switched to /tmp but Fedora feature tmp-on-tmpfs appeared, hence we must


### PR DESCRIPTION
Bug introduced in commit bb653b71a9261c0b58a9256761bf034b24c2e1ad

Related #1135

Signed-off-by: Jakub Filak <jfilak@redhat.com>