### PR TITLE
systemd-journal core dump file fixes

### DIFF
--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -254,8 +254,15 @@ save_systemd_coredump_in_dump_directory(struct dump_dir *dd, struct crash_info *
     }
 
     const size_t len = strlen(coredump_path);
-    if (   len >= 3
-        && coredump_path[len - 3] == '.' && coredump_path[len - 2] == 'x' && coredump_path[len - 1] == 'z')
+    if (   (len >= 3
+            && coredump_path[len - 3] == '.'
+            && coredump_path[len - 2] == 'x'
+            && coredump_path[len - 1] == 'z')
+        || (len >= 4
+            && coredump_path[len - 4] == '.'
+            && coredump_path[len - 3] == 'l'
+            && coredump_path[len - 2] == 'z'
+            && coredump_path[len - 1] == '4'))
     {
         if (dd_copy_file_unpack(dd, FILENAME_COREDUMP, coredump_path))
             return -1;


### PR DESCRIPTION
Without this pull request, abrt-action-dump-journal-core saves coredump files uncompressed, so the problem directories are unusable.