### PR TITLE
testsuite: mailx-reporting - hardcode locale and timezone

### DIFF
--- a/tests/runtests/mailx-reporting/runtest.sh
+++ b/tests/runtests/mailx-reporting/runtest.sh
@@ -44,6 +44,10 @@ rlJournalStart
         cp formatting_files/* $TmpDir
         rlRun "pushd $TmpDir"
 
+        rlFileBackup /etc/localtime
+        rlRun "ln -s /usr/share/zoneinfo/Europe/Prague /etc/localtime"
+        export LANG=C
+
         generate_crash
         get_crash_path
         wait_for_hooks
@@ -164,6 +168,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartCleanup
+        rlFileRestore
         rlBundleLogs abrt 'mail.out' $(ls *.log)
         rlRun "popd"
         rlRun "echo 'delete *' | mailx -u root" 0 "Delete mail"

--- a/tests/runtests/rhts-test/runtest.sh
+++ b/tests/runtests/rhts-test/runtest.sh
@@ -256,7 +256,7 @@ rlJournalStart
         rlAssertGrep "curl sent header: 'POST /rs/telemetry/abrt/reports/attach/ HTTP/1" client_create3
 
         rlAssertGrep "(Attaching problem data to case)|(Adding comment to case) 'http://127.0.0.1:12345/rs/cases/00809787/attachments/382c3498-0f19-3edc-aa56-580cf0bc7251'" client_create3 -E
-        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/comments HTTP/1" client_create3
+        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/*ments HTTP/1" client_create3
 
         rlRun "abrt-cli rm $crash_PATH" 0 "Remove crash dir"
         rlRun "rm -rf $ABRT_CONF_DUMP_LOCATION/last-ccpp"
@@ -304,7 +304,7 @@ rlJournalStart
         rlAssertGrep "post('http://127.0.0.1:12345/rs/telemetry/abrt/reports/attach/','{ \"bthash\": \"691cf824e3e07457156125636e86c50279e29496\", \"type\": \"email\", \"data\": \"abrt@email.com\" }')" client_create4
 
         rlAssertGrep "(Attaching problem data to case)|(Adding comment to case) 'http://127.0.0.1:12345/rs/cases/00809787/attachments/382c3498-0f19-3edc-aa56-580cf0bc7251'" client_create4 -E
-        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/comments HTTP/1" client_create4
+        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/*ments HTTP/1" client_create4
 
         rlRun "abrt-cli rm $crash_PATH" 0 "Remove crash dir"
         rlRun "rm -rf $ABRT_CONF_DUMP_LOCATION/last-ccpp"
@@ -353,7 +353,7 @@ rlJournalStart
         rlAssertGrep "post('http://127.0.0.1:12345/rs/telemetry/abrt/reports/attach/','{ \"bthash\": \"691cf824e3e07457156125636e86c50279e29496\", \"type\": \"email\", \"data\": \"abrt@email.com\" }')" client_create5
 
         rlAssertGrep "(Attaching problem data to case)|(Adding comment to case) 'http://127.0.0.1:12345/rs/cases/00809787/attachments/382c3498-0f19-3edc-aa56-580cf0bc7251'" client_create5 -E
-        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/comments HTTP/1" client_create5
+        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/*ments HTTP/1" client_create5
 
         rlRun "abrt-cli rm $crash_PATH" 0 "Remove crash dir"
         rlRun "rm -rf $ABRT_CONF_DUMP_LOCATION/last-ccpp"
@@ -403,7 +403,7 @@ rlJournalStart
         rlAssertNotGrep "post('http://127.0.0.1:12345/rs/telemetry/abrt/reports/attach/','{ \"bthash\": \"691cf824e3e07457156125636e86c50279e29496\", \"type\": \"email\", \"data\": \"abrt@email.com\" }')" client_create6
 
         rlAssertGrep "(Attaching problem data to case)|(Adding comment to case) 'http://127.0.0.1:12345/rs/cases/00809787/attachments/382c3498-0f19-3edc-aa56-580cf0bc7251'" client_create6 -E
-        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/comments HTTP/1" client_create6
+        rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/*ments HTTP/1" client_create6
 
         rlRun "abrt-cli rm $crash_PATH" 0 "Remove crash dir"
     rlPhaseEnd


### PR DESCRIPTION
The test is failing if there is different locale and timezone set than on the system where the templates were generated. Thus, I'm hardcoding it to use LANG=C and timezone Europe/Prague so the date / time is generated in the same format as expected.