### PR TITLE
a-a-install-debuginfo: Exception may not have an argument errno

### DIFF
--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -236,12 +236,12 @@ if __name__ == "__main__":
             sys.exit(RETURN_FAILURE)
 
         # TODO: should we pass keep_rpms=keeprpms to DebugInfoDownload here??
-        downloader = download_class(cache=cachedirs[0], tmp=TMPDIR,
+        try:
+            downloader = download_class(cache=cachedirs[0], tmp=TMPDIR,
                                     noninteractive=noninteractive,
                                     repo_pattern=repo_pattern)
-        try:
             result = downloader.download(missing, download_exact_files=exact_fls)
-        except Exception as ex:
+        except OSError as ex:
             if ex.errno == errno.EPIPE:
                 clean_up(TMPDIR, silent=True)
                 exit(RETURN_FAILURE)


### PR DESCRIPTION
Also BrokenPipe error can appear even in download_class(), moving it to try
block.

Related to #1343826, #1343664

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>