### PR TITLE
abrt-hook-ccpp: Fix mismatching argument

### DIFF
--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -672,7 +672,7 @@ int main(int argc, char** argv)
         free_map_string(settings);
     }
 
-    if (argc == 2 && strcmp(argv[1], "--config-test"))
+    if (argc == 2 && !strcmp(argv[1], "--test-config"))
         return test_configuration(setting_SaveFullCore, setting_CreateCoreBacktrace);
 
     if (argc < 8)


### PR DESCRIPTION
The calling code in abrt-install-ccpp-hook was passing in --test-config.
This was only working due to the misuse of strcmp, so it was accepting
any string other than --config-test.