### PR TITLE
Introduce unsafe reporting for not-reporable problems

### DIFF
--- a/doc/abrt-cli.txt
+++ b/doc/abrt-cli.txt
@@ -13,13 +13,13 @@ SYNOPSIS
 
 'abrt-cli' remove  [-v]  DIR...
 
-'abrt-cli' report  [-v]  [--delete]  DIR...
+'abrt-cli' report  [-v]  [--delete] [--unsafe] DIR...
 
 'abrt-cli' info    [-v]  [--detailed] [-s SIZE] DIR...
 
 'abrt-cli' status  [-vb] [--since NUM]
 
-'abrt-cli' process [-v]  [--since NUM] DIR...
+'abrt-cli' process [-v]  [--since NUM] [--unsafe] DIR...
 
 GLOBAL OPTIONS
 --------------
@@ -48,6 +48,9 @@ COMMAND OPTIONS
 
 --since NUM::
     Selects only problems detected after timestamp
+
+-u, --unsafe::
+   Ignore security checks to be able to report all problems
 
 --until NUM::
     Selects only the problems older than specified timestamp

--- a/src/cli/builtin-cmd.h
+++ b/src/cli/builtin-cmd.h
@@ -24,7 +24,13 @@ extern int cmd_list(int argc, const char **argv);
 extern int cmd_remove(int argc, const char **argv);
 extern int _cmd_remove(const char **dirs_strv);
 extern int cmd_report(int argc, const char **argv);
-extern int _cmd_report(const char **dirs_strv, int remove);
+enum {
+    /* Remove successfully reported */
+    CMD_REPORT_REMOVE = 1 << 0,
+    /* Ignore security checks - i.e not-repotable */
+    CMD_REPORT_UNSAFE = 1 << 1,
+};
+extern int _cmd_report(const char **dirs_strv, int flags);
 extern int cmd_info(int argc, const char **argv);
 extern int _cmd_info(problem_data_t *problem_data, int detailed, int text_size);
 extern int cmd_status(int argc, const char **argv);

--- a/src/cli/report.c
+++ b/src/cli/report.c
@@ -22,7 +22,7 @@
 #include "abrt-cli-core.h"
 #include "builtin-cmd.h"
 
-int _cmd_report(const char **dirs_strv, int remove)
+int _cmd_report(const char **dirs_strv, int flags)
 {
     int ret = 0;
     while (*dirs_strv)
@@ -39,10 +39,14 @@ int _cmd_report(const char **dirs_strv, int remove)
         const int not_reportable = test_exist_over_dbus(real_problem_id, FILENAME_NOT_REPORTABLE);
         if (not_reportable != 0)
         {
-            error_msg(_("Problem '%s' cannot be reported"), real_problem_id);
-            free(real_problem_id);
-            ++ret;
-            continue;
+            if (!(flags & CMD_REPORT_UNSAFE))
+            {
+                error_msg(_("Problem '%s' cannot be reported"), real_problem_id);
+                free(real_problem_id);
+                ++ret;
+                continue;
+            }
+            log_info(_("Problem '%s' is labeled as 'not-reportable'?"), real_problem_id);
         }
 
         const int res = chown_dir_over_dbus(real_problem_id);
@@ -58,7 +62,7 @@ int _cmd_report(const char **dirs_strv, int remove)
                                            | LIBREPORT_RUN_CLI);
 
         /* the problem was successfully reported and option is -d */
-        if(remove && (status == 0 || status == EXIT_STOP_EVENT_RUN))
+        if((flags & CMD_REPORT_REMOVE) && (status == 0 || status == EXIT_STOP_EVENT_RUN))
         {
             log(_("Deleting '%s'"), real_problem_id);
             delete_dump_dir_possibly_using_abrtd(real_problem_id);
@@ -82,11 +86,14 @@ int cmd_report(int argc, const char **argv)
     enum {
         OPT_v = 1 << 0,
         OPT_d = 1 << 1,
+        OPT_u = 1 << 2,
     };
 
     struct options program_options[] = {
         OPT__VERBOSE(&g_verbose),
         OPT_BOOL('d', "delete", NULL, _("Remove PROBLEM_DIR after reporting")),
+        OPT_BOOL('u', "unsafe", NULL, _("Ignore security checks to be able to "
+                                        "report all problems")),
         OPT_END()
     };
 
@@ -101,5 +108,11 @@ int cmd_report(int argc, const char **argv)
     load_abrt_conf();
     free_abrt_conf_data();
 
-    return _cmd_report(argv, opts & OPT_d);
+    int report_flags = 0;
+    if (opts & OPT_d)
+        report_flags |= CMD_REPORT_REMOVE;
+    if (opts & OPT_u)
+        report_flags |= CMD_REPORT_UNSAFE;
+
+    return _cmd_report(argv, report_flags);
 }

--- a/tests/runtests/cli-sanity/runtest.sh
+++ b/tests/runtests/cli-sanity/runtest.sh
@@ -123,6 +123,23 @@ rlJournalStart
         rlRun "rm -f $crash_PATH/not-reportable"
     rlPhaseEnd
 
+    rlPhaseStartTest "report not-reportable --unsafe parameter"
+        rlRun "touch $crash_PATH/not-reportable"
+
+        cp $crash_PATH/{type,analyzer} ./
+
+        echo "cli_sanity_test_not_reportable_unsafe" > $crash_PATH/type
+        echo "cli_sanity_test_not_reportable_unsafe" > $crash_PATH/analyzer
+
+        rlRun "abrt-cli report --unsafe $crash_PATH 2>&1 | tee abrt-cli-report-not-reportable-unsafe.log" 0
+        rlAssertNotGrep "Problem '$crash_PATH' cannot be reported" abrt-cli-report-not-reportable-unsafe.log
+        rlAssertGrep "Error: no processing is specified for event 'report-cli'" abrt-cli-report-not-reportable-unsafe.log
+
+        cp -f type analyzer $crash_PATH
+
+        rlRun "rm -f $crash_PATH/not-reportable"
+    rlPhaseEnd
+
     # This test used to select 1st analyzer (Local GNU Debugger)
     # and run it, then "edit" data with cat (this merely prints data to stdout)
     # and terminate. This was far from reliable (what if analyzer would change?).


### PR DESCRIPTION
Parameter unsafe ignores security checks and allows to report not reportable problems.

Related to #1351297
Related to #1166
