### PR TITLE
RHEL7: daemon: send  base names from abrt-server to abrtd

### DIFF
--- a/src/daemon/abrt-server.c
+++ b/src/daemon/abrt-server.c
@@ -273,7 +273,7 @@ static int run_post_create(const char *dirname)
     log_debug("Creating glib main loop");
     struct waiting_context context = {0};
     context.main_loop = g_main_loop_new(NULL, FALSE);
-    context.dirname = dirname;
+    context.dirname = strrchr(dirname, '/') + 1;
 
     log_debug("Setting up a signal handler");
     /* Set up signal pipe */

--- a/src/daemon/abrtd.c
+++ b/src/daemon/abrtd.c
@@ -174,16 +174,15 @@ static void queue_post_craete_process(struct abrt_server_proc *proc)
            && worst_dir)
     {
         const char *kind = "old";
-        char *deleted = concat_path_file(g_settings_dump_location, worst_dir);
 
         GList *proc_of_deleted_item = NULL;
-        if (proc != NULL && strcmp(deleted, proc->dirname) == 0)
+        if (proc != NULL && strcmp(worst_dir, proc->dirname) == 0)
         {
             kind = "new";
             stop_abrt_server(proc);
             proc = NULL;
         }
-        else if ((proc_of_deleted_item = g_list_find_custom(s_dir_queue, deleted, (GCompareFunc)abrt_server_compare_dirname)))
+        else if ((proc_of_deleted_item = g_list_find_custom(s_dir_queue, worst_dir, (GCompareFunc)abrt_server_compare_dirname)))
         {
             kind = "unprocessed";
             struct abrt_server_proc *removed_proc = (struct abrt_server_proc *)proc_of_deleted_item->data;
@@ -195,6 +194,7 @@ static void queue_post_craete_process(struct abrt_server_proc *proc)
                 g_settings_dump_location, g_settings_nMaxCrashReportsSize,
                 kind, worst_dir);
 
+        char *deleted = concat_path_file(g_settings_dump_location, worst_dir);
         free(worst_dir);
         worst_dir = NULL;
 


### PR DESCRIPTION
The /creation_notification method accepts arbitrary file system path and
it might cause abrtd some troubles if the path is not in canonical form.

ABRT enforces the notified paths to be directories in /var/spool/abrt
but ignores number of slash occurrences as it is not security relevant.

Switching to base names will assure that the problems associated with file
system path forms will be gone and no new problems will be introduced.

The other option is to use realpath() but this function resolves
symbolic links and if /var/spool is a symbolic link, we will be in
trouble.

Related: rhbz#1132459

Signed-off-by: Jakub Filak <jfilak@redhat.com>