### PR TITLE
abrt-addon-python in containers

### DIFF
--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -652,6 +652,8 @@ int main(int argc, char** argv)
      */
     if (g_settings_debug_level >= 100)
         setrlimit(RLIMIT_CORE, &((struct rlimit){ RLIM_INFINITY, RLIM_INFINITY}));
+    if (g_settings_debug_level >= 200)
+        set_xfunc_diemode(DIEMODE_ABORT);
 
     /* ... and plugins/CCpp.conf */
     bool setting_MakeCompatCore;
@@ -851,7 +853,7 @@ int main(int argc, char** argv)
                                    signal_no, signame, "avoid recursion");
         }
 
-        xfunc_die();
+        exit(0);
     }
     /* Check /var/tmp/abrt/last-ccpp marker, do not dump repeated crashes
      * if they happen too often. Else, write new marker value.

--- a/src/hooks/abrt_exception_handler.py.in
+++ b/src/hooks/abrt_exception_handler.py.in
@@ -54,16 +54,6 @@ def write_dump(tb_text, tb):
         # (BTW, we *can't* assume the script is in current directory.)
         executable = sys.argv[0]
 
-    dso_list = None
-    # Trace back is None in case of SyntaxError exception.
-    if tb:
-        try:
-            import rpm
-            dso_list = get_dso_list(tb)
-        except ImportError as imperr:
-            syslog("RPM module not available, cannot query RPM db for package "\
-                   "names")
-
     # Open ABRT daemon's socket and write data to it
     try:
         import socket
@@ -80,9 +70,6 @@ def write_dump(tb_text, tb):
             # CCMainWindow.py:1:<module>:ZeroDivisionError: integer division or modulo by zero
             s.sendall("reason=%s\0" % tb_text.splitlines()[0])
             s.sendall("backtrace=%s\0" % tb_text)
-
-            if dso_list:
-                s.sendall("dso_list=%s\0" % "\n".join(dso_list))
 
             s.shutdown(socket.SHUT_WR)
 

--- a/src/hooks/abrt_exception_handler.py.in
+++ b/src/hooks/abrt_exception_handler.py.in
@@ -84,11 +84,6 @@ def write_dump(tb_text, tb):
             if dso_list:
                 s.sendall("dso_list=%s\0" % "\n".join(dso_list))
 
-            s.sendall("environ=")
-            for k,v in os.environ.iteritems():
-                s.sendall("%s=%s\n" % (k,v))
-            s.sendall("\0")
-
             s.shutdown(socket.SHUT_WR)
 
             # Read the response and log if there's anything wrong

--- a/src/hooks/abrt_exception_handler3.py.in
+++ b/src/hooks/abrt_exception_handler3.py.in
@@ -55,7 +55,6 @@ def send(data):
         s.sendall(pre.encode())
         s.sendall(data.encode())
 
-        s.sendall("\0".encode())
         s.shutdown(socket.SHUT_WR)
 
         while True:
@@ -88,10 +87,6 @@ def write_dump(tb_text, tb):
     data += "executable={0}\0".format(executable)
     data += "reason={0}\0".format(tb_text.splitlines()[0])
     data += "backtrace={0}\0".format(tb_text)
-
-    data += "environ="
-    for k, v in os.environ.items():
-        data += "{0}={1}\n".format(k, v)
 
     response = send(data)
     parts = response.split()


### PR DESCRIPTION
Requires: abrt/libreport#453

```
# docker pull fedora
# setenforce 0
# docker run -it -v /var/run/abrt:/var/run/abrt fedora /usr/bin/bash
# dnf install abrt-addon-python will-crash
# will_python_raise
# exit
# setenforce 1
# abrt-cli info -d [PROBLEM_ID]
reason:         will_python_raise:3:<module>:ZeroDivisionError: integer division or modulo by zero
...
container: docker
container_image: fedora
...
```
