### PR TITLE
Bodhi event

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -1094,6 +1094,8 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %defattr(-,root,root,-)
 %{_bindir}/abrt-bodhi
 %{_bindir}/abrt-action-find-bodhi-update
+%config(noreplace) %{_sysconfdir}/libreport/events.d/bodhi_event.conf
+%{_datadir}/libreport/events/analyze_BodhiUpdates.xml
 %{_mandir}/man1/abrt-bodhi.1.gz
 %{_mandir}/man1/abrt-action-find-bodhi-update.1.gz
 %endif

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -48,6 +48,7 @@ src/plugins/abrt-dump-journal-xorg.c
 src/plugins/abrt-dump-xorg.c
 src/plugins/abrt-journal.c
 src/plugins/abrt-retrace-client.c
+src/plugins/analyze_BodhiUpdates.xml.in
 src/plugins/analyze_LocalGDB.xml.in
 src/plugins/analyze_RetraceServer.xml.in
 src/plugins/collect_xsession_errors.xml.in

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -58,6 +58,11 @@ dist_events_DATA = \
     collect_vimrc_system.xml \
     post_report.xml
 
+if BUILD_BODHI
+dist_events_DATA += \
+    analyze_BodhiUpdates.xml
+endif
+
 @INTLTOOL_XML_RULE@
 
 libreportpluginconfdir = $(LIBREPORT_PLUGINS_CONF_DIR)
@@ -91,6 +96,10 @@ dist_eventsconf_DATA = \
     gconf_event.conf \
     vimrc_event.conf
 
+if BUILD_BODHI
+dist_eventsconf_DATA += \
+    bodhi_event.conf
+endif
 
 PYTHON_FILES = \
     abrt-action-install-debuginfo.in \
@@ -113,6 +122,7 @@ EXTRA_DIST = \
     collect_GConf.xml.in \
     collect_vimrc_user.xml.in \
     collect_vimrc_system.xml.in \
+    analyze_BodhiUpdates.xml.in \
     analyze_CCpp.xml.in \
     analyze_LocalGDB.xml.in \
     analyze_RetraceServer.xml.in \

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -1,20 +1,9 @@
 #!/bin/sh
 
 INSTALL_DI=true
-FIND_BODHI_UPDATE_ARGS=""
-# if bz is set to false it also disables bodhi, because it needs it's result
-WITH_BUGZILLA=true
 for opt in "$@"; do
     if [ x"$opt" = x"--without-di" ]; then
         INSTALL_DI=false
-    fi
-
-    if [ x"$opt" = x"--without-bz" ]; then
-        WITH_BUGZILLA=false
-    fi
-
-    if [ x"$opt" = x"--without-bodhi" ]; then
-        FIND_BODHI_UPDATE_ARGS="--without-bodhi"
     fi
 done
 
@@ -31,11 +20,5 @@ if $INSTALL_DI; then
 fi
 
 if [ $? = 0 ]; then
-    abrt-action-generate-backtrace &&
-    abrt-action-analyze-backtrace
-    if [ "$?" == "0" ]; then
-        if $WITH_BUGZILLA; then
-            abrt-action-find-bodhi-update $FIND_BODHI_UPDATE_ARGS
-        fi
-    fi
+    abrt-action-generate-backtrace && abrt-action-analyze-backtrace
 fi

--- a/src/plugins/analyze_BodhiUpdates.xml.in
+++ b/src/plugins/analyze_BodhiUpdates.xml.in
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<event>
+    <name>Bodhi Updates</name>
+    <_description>Search for updated packages that fixes the crash.</_description>
+    <_long-description>Looks for Bugzilla reports with the 'abrt_hash' value in Bugzilla Bug Whiteboar equal to 'UUID' of the crash. If such a bug found, search for Bodhi updates shipping fixes for the found Bugzilla bugs.</_long-description>
+
+    <requires-items>duphash,os_info</requires-items>
+    <gui-review-elements>no</gui-review-elements>
+    <sending-sensitive-data>no</sending-sensitive-data>
+
+    <options>
+        <import-event-options event="report_Bugzilla"/>
+    </options>
+</event>

--- a/src/plugins/bodhi_event.conf
+++ b/src/plugins/bodhi_event.conf
@@ -1,0 +1,2 @@
+EVENT=analyze_BodhiUpdates duphash!= os_info!=
+        abrt-action-find-bodhi-update

--- a/src/plugins/ccpp_retrace_event.conf
+++ b/src/plugins/ccpp_retrace_event.conf
@@ -1,4 +1,3 @@
 EVENT=analyze_RetraceServer type=CCpp
         abrt-retrace-client batch --dir "$DUMP_DIR" --status-delay 10 &&
-        abrt-action-analyze-backtrace &&
-        abrt-action-find-bodhi-update
+        abrt-action-analyze-backtrace


### PR DESCRIPTION
Analyzing of C/C++ problems should not always include finding Bodhi update - for example reporting a problem via Email does not require that. I know there were some attempts to sort out this issue in the history and I was refusing them but now I came up with an acceptable solution.

This PR introduces a new event call 'analyze_BodhiUpdates' and abrt/libreport#464 adds the event to Fedora workflows. This seems to me as the most natural approach. This approach will also enable searching for Bodhi updates for other problem types than just C/C++ problems.