### PR TITLE
a-a-s-c-data: correct detection of container type

### DIFF
--- a/src/daemon/abrt-action-save-container-data.c
+++ b/src/daemon/abrt-action-save-container-data.c
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
     if (container_cmdline == NULL)
         error_msg_and_die("The crash didn't occur in container");
 
-    if (strstr(container_cmdline, "/docker ") != 0)
+    if (strstr(container_cmdline, "/docker ") != 0 || prefixcmp(container_cmdline, "/usr/libexec/docker") == 0)
         dump_docker_info(dd, root_dir);
     else if (strstr(container_cmdline, "/lxc-") != 0)
         dump_lxc_info(dd, container_cmdline);

--- a/src/daemon/abrt-action-save-container-data.c
+++ b/src/daemon/abrt-action-save-container-data.c
@@ -278,9 +278,9 @@ int main(int argc, char **argv)
     if (container_cmdline == NULL)
         error_msg_and_die("The crash didn't occur in container");
 
-    if (strstr("/docker ", container_cmdline) == 0)
+    if (strstr(container_cmdline, "/docker ") != 0)
         dump_docker_info(dd, root_dir);
-    else if (strstr("/lxc-", container_cmdline) == 0)
+    else if (strstr(container_cmdline, "/lxc-") != 0)
         dump_lxc_info(dd, container_cmdline);
     else
         error_msg_and_die("Unsupported container technology");

--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -56,7 +56,7 @@ EVENT=post-create container_cmdline= remote!=1 component=
 
 # Store information about the container:
 EVENT=post-create container_cmdline!= remote!=1
-        abrt-action-save-container-data
+        abrt-action-save-container-data || :
 
 
 # Example: if you want all users (not just root) to be able to see some problems:


### PR DESCRIPTION
strstr() returns 0 (NULL) if the needle is not found in the haystack.

Signed-off-by: Jakub Filak <jfilak@redhat.com>