### PR TITLE
cli: do not ask for password if PrivateReports = no

### DIFF
--- a/src/cli/abrt-cli-core.c
+++ b/src/cli/abrt-cli-core.c
@@ -85,6 +85,11 @@ void restart_as_root_if_needed(unsigned cmd_argc, const char *cmd_argv[])
     if (g_settings_privatereports && getuid() == 0)
         return;
 
+    if (g_settings_privatereports == false){
+        log(_("PrivateReports is disabled. Run abrt-cli-root to see all problems detected by ABRT."));
+        return;
+    }
+
     log(_("PrivateReports is enabled. Only \"root\" can see the problems detected by ABRT."));
 
     if (!ask_yes_no(_("Do you wan to run abrt-cli-root?")))


### PR DESCRIPTION
abrt-cli list said "PrivateReports is enabled ..." and ask for root password
even if PrivateReports is disabled.

Related to #1318354

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>