### PR TITLE
testsuite: fix command typos

### DIFF
--- a/tests/runtests/abrt-action-find-bodhi-update/runtest.sh
+++ b/tests/runtests/abrt-action-find-bodhi-update/runtest.sh
@@ -119,7 +119,7 @@ rlJournalStart
         rlRun "abrt-action-find-bodhi-update -vvv -d $crash_PATH &> env_product.log" 0 "Product from env"
         rlAssertGrep "Using product foo" env_product.log
         rlRun "unset Bugzilla_Product"
-    lPhaseEnd
+    rlPhaseEnd
 
     rlPhaseStartCleanup
         rm -rf $crash_PATH

--- a/tests/runtests/ccpp-plugin-hook-ignoring/runtest.sh
+++ b/tests/runtests/ccpp-plugin-hook-ignoring/runtest.sh
@@ -225,7 +225,7 @@ rlJournalStart
 
         rlRun "userdel -f $TEST_USER"
         rlRun "userdel -f $TEST_USER2"
-        rlRUn "groupdel $TEST_GROUP"
+        rlRun "groupdel $TEST_GROUP"
     rlPhaseEnd
 
     rlPhaseStartTest "ignoring of abrt-hook-ccpp"

--- a/tests/runtests/compat-cores/runtest.sh
+++ b/tests/runtests/compat-cores/runtest.sh
@@ -184,7 +184,7 @@ rlJournalStart
         get_crash_path
 
         rlLog "core: `ls -l`"
-        rlAssertNotExist 'core.$killpid' 0 "Checking if core does not exist"
+        rlAssertNotExists 'core.$killpid' 0 "Checking if core does not exist"
         rlRun "journalctl SYSLOG_IDENTIFIER=abrt-hook-ccpp --since=\"$SINCE\" | grep \"Current suid_dumpable policy prevents from saving core dumps according to relative core_pattern\""
 
         rlRun "echo 0 > /proc/sys/fs/suid_dumpable" 0 "Set setuid no dump"

--- a/tests/runtests/reporter-mantisbt/runtest.sh
+++ b/tests/runtests/reporter-mantisbt/runtest.sh
@@ -561,7 +561,7 @@ rlJournalStart
         # not contain
         rlAssertNotGrep "<return SOAP-ENC:arrayType=\"ns1:IssueData\[0\]\" xsi:type=\"SOAP-ENC:Array\">" client_log 
         rlAssertNotGrep "Attaching better backtrace" client_log
-        rlAsserNottGrep "Found the same comment in the issue history, not adding a new one" client_log
+        rlAssertNotGrep "Found the same comment in the issue history, not adding a new one" client_log
         rlAssertNotGrep "<return xsi:type=\"xsd:integer\">4</return></ns1:mc_issue_attachment_addResponse>" client_log
         rlAssertNotGrep "<int>323795</int>" client_log #dummy
 
@@ -621,7 +621,7 @@ rlJournalStart
         rlAssertGrep "Status: new open http://localhost:12345/view.php?id=99" client_log
 
         # not contain
-        rlAsserNottGrep "Found the same comment in the issue history, not adding a new one" client_log
+        rlAssertNotGrep "Found the same comment in the issue history, not adding a new one" client_log
         rlAssertNotGrep "<int>323795</int>" client_log #dummy
 
         rm -f problem_dir/reported_to

--- a/tests/runtests/reporter-upload-ssh-keys/runtest.sh
+++ b/tests/runtests/reporter-upload-ssh-keys/runtest.sh
@@ -113,7 +113,7 @@ rlJournalStart
         LOG_FILE="ssh_commandline_only_private.log"
         rlRun "./expect reporter-upload -vvv -d problem_dir -u scp://root@localhost$TmpDir/target/upload.tar.gz -r pri-commandline >$LOG_FILE 2>&1"
 
-        rlAsserNottGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
+        rlAssertNotGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-commandline'" $LOG_FILE
         rlAssertNotGrep "curl: Using SSH public key file 'pub-commandline'" $LOG_FILE
         rlAssertGrep "curl: Using SSH private key file 'pri-commandline'" $LOG_FILE
@@ -121,7 +121,7 @@ rlJournalStart
         LOG_FILE="ssh_commandline_default.log"
         rlRun "./expect reporter-upload -vvv -d problem_dir -u scp://root@localhost$TmpDir/target/upload.tar.gz >$LOG_FILE 2>&1"
 
-        rlAsserNottGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
+        rlAssertNotGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
         rlAssertNotGrep "Using SSH private key 'pri-commandline'" $LOG_FILE
         rlAssertNotGrep "curl: Using SSH public key file 'pub-commandline'" $LOG_FILE
         rlAssertNotGrep "curl: Using SSH private key file 'pri-commandline'" $LOG_FILE

--- a/tests/runtests/rhts-test/runtest.sh
+++ b/tests/runtests/rhts-test/runtest.sh
@@ -399,8 +399,8 @@ rlJournalStart
         rlAssertGrep "post('http://127.0.0.1:12345/rs/telemetry/abrt/reports/attach/','{ \"bthash\": \"691cf824e3e07457156125636e86c50279e29496\", \"type\": \"RHCID\", \"data\": \"http:\\\/\\\/127.0.0.1:12345\\\/rs\\\/cases\\\/00809787\\\/attachments\\\/382c3498-0f19-3edc-aa56-580cf0bc7251\" }')" client_create6
         rlAssertGrep "curl sent header: 'POST /rs/telemetry/abrt/reports/attach/ HTTP/1" client_create6
 
-        rlAssertNOTGrep "Linking ABRT crash statistics record with contact email: 'abrt@email.com'" client_create6
-        rlAssertNOTGrep "post('http://127.0.0.1:12345/rs/telemetry/abrt/reports/attach/','{ \"bthash\": \"691cf824e3e07457156125636e86c50279e29496\", \"type\": \"email\", \"data\": \"abrt@email.com\" }')" client_create6
+        rlAssertNotGrep "Linking ABRT crash statistics record with contact email: 'abrt@email.com'" client_create6
+        rlAssertNotGrep "post('http://127.0.0.1:12345/rs/telemetry/abrt/reports/attach/','{ \"bthash\": \"691cf824e3e07457156125636e86c50279e29496\", \"type\": \"email\", \"data\": \"abrt@email.com\" }')" client_create6
 
         rlAssertGrep "(Attaching problem data to case)|(Adding comment to case) 'http://127.0.0.1:12345/rs/cases/00809787/attachments/382c3498-0f19-3edc-aa56-580cf0bc7251'" client_create6 -E
         rlAssertGrep "curl sent header: 'POST /rs/cases/[0-9]*/attachments/.*/comments HTTP/1" client_create6

--- a/tests/runtests/ureport-auth/runtest.sh
+++ b/tests/runtests/ureport-auth/runtest.sh
@@ -275,7 +275,7 @@ rlJournalStart
 
         rlAssertGrep "Failed to upload uReport to the server 'https://localhost:12345/faf'" rhsm_with_ca_broken.log
         rlAssertGrep "Error: curl_easy_perform: Problem with the SSL CA cert (path? access rights?)" rhsm_with_ca_broken.log
-        rlNotAssertGrep "This problem has already been reported." rhsm_with_ca_broken.log
+        rlAssertNotGrep "This problem has already been reported." rhsm_with_ca_broken.log
 
         # CA certificate does not exist
         rlLog "CA certificate does not exist"
@@ -289,7 +289,7 @@ rlJournalStart
 
         rlAssertGrep "curl_easy_perform: error_msg: curl_easy_perform: Peer certificate cannot be authenticated with given CA certificates" rhsm_with_ca_not_exist.log
         rlAssertGrep "Failed to upload uReport to the server 'https://localhost:12345/faf' with curl: Peer's Certificate issuer is not recognized." rhsm_with_ca_not_exist.log
-        rlNotAssertGrep "This problem has already been reported." rhsm_with_ca_not_exist.log
+        rlAssertNotGrep "This problem has already been reported." rhsm_with_ca_not_exist.log
 
         unset LIBREPORT_DEBUG_RHSMCON_PEM_DIR_PATH
         unset LIBREPORT_DEBUG_AUTHORITY_CERT_DIR_PATH


### PR DESCRIPTION
Hi,
I am currently playing around with my simple 'static analyser'-like tool that is specific for BeakerLib commands and tested it on your testsuite, so I fixed the obvious typos in command names.