### PR TITLE
ccpp: configure package repositories for correct OS

### DIFF
--- a/doc/abrt-action-install-debuginfo.txt
+++ b/doc/abrt-action-install-debuginfo.txt
@@ -38,6 +38,9 @@ OPTIONS
 -e,--exact::
    Download only specified files
 
+-R,--releasever::
+   Set specific version of Operating System
+
 AUTHORS
 -------
 * ABRT team

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -8,15 +8,34 @@ for opt in "$@"; do
 done
 
 if $INSTALL_DI; then
+    abrt-action-analyze-core --core=coredump -o build_ids || exit $?
+
     # On some systems debuginfo install needs root privileges.
     # Running a suided-to-abrt wrapper would make
     # debuginfo install fail even for root.
     # Therefore, if we are root, we don't use the wrapper.
+    EXECUTABLE=@LIBEXEC_DIR@/abrt-action-install-debuginfo-to-abrt-cache
     if [ x"`id -u`" = x"0" ]; then
-        abrt-action-analyze-core --core=coredump -o build_ids && abrt-action-install-debuginfo --size_mb=4096
-    else
-        abrt-action-analyze-core --core=coredump -o build_ids && @LIBEXEC_DIR@/abrt-action-install-debuginfo-to-abrt-cache --size_mb=4096
+        EXECUTABLE=abrt-action-install-debuginfo
     fi
+
+    # Get VERSION_ID from crash's /etc/os-release (stored as os_info in a dump
+    # directory).
+    # We need this value for package managers to configure the correct
+    # repositories (i.e. '$releasever' for DNF/Yum).
+    EXTRA_ARGS=
+    for osrel in "${DUMP_DIR:-.}/os_info_in_rootdir" "${DUMP_DIR:-.}/os_info"
+    do
+        if [ -e $osrel ]; then
+            . $osrel
+            if [ -n "$VERSION_ID" ]; then
+                EXTRA_ARGS="--releasever=$VERSION_ID"
+                break
+            fi
+        fi
+    done
+
+    ${EXECUTABLE} ${EXTRA_ARGS} --size_mb=4096
 fi
 
 if [ $? = 0 ]; then

--- a/src/plugins/abrt-action-install-debuginfo-to-abrt-cache.c
+++ b/src/plugins/abrt-action-install-debuginfo-to-abrt-cache.c
@@ -54,12 +54,14 @@ int main(int argc, char **argv)
         OPT_e = 1 << 3,
         OPT_r = 1 << 4,
         OPT_s = 1 << 5,
+        OPT_R = 1 << 6,
     };
 
     const char *build_ids = "build_ids";
     const char *exact = NULL;
     const char *repo = NULL;
     const char *size_mb = NULL;
+    const char *releasever = NULL;
 
     struct options program_options[] = {
         OPT__VERBOSE(&g_verbose),
@@ -68,6 +70,7 @@ int main(int argc, char **argv)
         OPT_STRING('e', "exact",     &exact, "EXACT",          _("Download only specified files")),
         OPT_STRING('r', "repo",       &repo, "REPO",           _("Pattern to use when searching for repos, default: *debug*")),
         OPT_STRING('s', "size_mb", &size_mb, "SIZE_MB",        _("Ignored option")),
+        OPT_STRING('R', "releasever", &releasever, "RELEASEVER", _("OS release version")),
         OPT_END()
     };
     const unsigned opts = parse_opts(argc, argv, program_options, program_usage_string);
@@ -114,8 +117,8 @@ int main(int argc, char **argv)
 
     log_info("Created working directory: %s", tmp_directory);
 
-    /* name, -v, --ids, -, -y, -e, EXACT, -r, REPO, -t, PATH, --, NULL */
-    const char *args[13];
+    /* name, -v, --ids, -, -y, -e, EXACT, -r, REPO, -t, PATH, --releaseve, VER, --, NULL */
+    const char *args[15];
     {
         const char *verbs[] = { "", "-v", "-vv", "-vvv" };
         unsigned i = 0;
@@ -135,6 +138,11 @@ int main(int argc, char **argv)
         {
             args[i++] = "--repo";
             args[i++] = repo;
+        }
+        if ((opts & OPT_R))
+        {
+            args[i++] = "--releasever";
+            args[i++] = releasever;
         }
         args[i++] = "--tmpdir";
         args[i++] = tmp_directory;

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -71,6 +71,7 @@ if __name__ == "__main__":
     missing = None
     repo_pattern = "*debug*"
     pkgmgr = None
+    releasever = None
 
     # localization
     init_gettext()
@@ -89,6 +90,7 @@ if __name__ == "__main__":
             "Usage: %s [-vy] [--ids=BUILD_IDS_FILE] [--pkgmgr=(yum|dnf)]\n"
             "       [--tmpdir=TMPDIR] [--cache=CACHEDIR[:DEBUGINFODIR1:DEBUGINFODIR2...]] [--size_mb=SIZE]\n"
             "       [-e, --exact=PATH[:PATH]...]\n"
+            "       [--releasever=RELEASEVER]\n"
             "\n"
             "Installs debuginfos for all build-ids listed in BUILD_IDS_FILE\n"
             "to CACHEDIR, using TMPDIR as temporary staging area.\n"
@@ -108,13 +110,15 @@ if __name__ == "__main__":
             "    -e,--exact  Download only specified files\n"
             "    --repo      Pattern to use when searching for repos.\n"
             "                Default: *debug*\n"
+            "    --releasever RELEASEVER\n"
+            "                Pass this OS version to package managers.\n"
             # --keeprpms is not documented yet because it's a NOP so far
     ) % PROGNAME
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "vyhe",
                 ["help", "ids=", "cache=", "size_mb=", "tmpdir=", "keeprpms",
-                 "exact=", "repo=", "pkgmgr="])
+                 "exact=", "repo=", "pkgmgr=", "releasever="])
     except getopt.GetoptError as err:
         print(err) # prints something like "option -a not recognized"
         exit(RETURN_FAILURE)
@@ -148,6 +152,8 @@ if __name__ == "__main__":
             repo_pattern = arg
         elif opt == "--pkgmgr":
             pkgmgr = arg
+        elif opt == "--releasever":
+            releasever = arg
 
     set_verbosity(verbose)
 
@@ -239,7 +245,8 @@ if __name__ == "__main__":
         try:
             downloader = download_class(cache=cachedirs[0], tmp=TMPDIR,
                                     noninteractive=noninteractive,
-                                    repo_pattern=repo_pattern)
+                                    repo_pattern=repo_pattern,
+                                    releasever=releasever)
             result = downloader.download(missing, download_exact_files=exact_fls)
         except OSError as ex:
             if ex.errno == errno.EPIPE:


### PR DESCRIPTION
If we run ABRT in a container or if we catch a crash in a chroot, we
need to look for debuginfo packages relevant to the source of the crash.
Hence we need to tell package managers which version of OS we are
interested in.

Signed-off-by: Jakub Filak <jfilak@redhat.com>