### PR TITLE
Import gobject from gi.repository if gi was already imported

### DIFF
--- a/src/python-problem/problem/watch.py
+++ b/src/python-problem/problem/watch.py
@@ -15,7 +15,7 @@ class ProblemWatcher(object):
 
     def __init__(self, auth):
         import dbus
-        import gobject
+        from gi.repository import GObject as gobject
         from dbus.mainloop.glib import DBusGMainLoop
 
         gobject.threads_init()


### PR DESCRIPTION
It isn't possible to 'import gobject' if gi/gi.repository was
imported before.

---
```AttributeError: When using gi.repository you must not import static modules like "gobject". Please change all occurrences of "import gobject" to "from gi.repository import GObject". See: https://bugzilla.gnome.org/show_bug.cgi?id=709183```

This is a problem when trying to use `ProblemWatcher` from applications using `gi.repository` (so for example all Gtk applications). 