### PR TITLE
python: create analyzer element in dumpdir

### DIFF
--- a/src/hooks/abrt_exception_handler.py.in
+++ b/src/hooks/abrt_exception_handler.py.in
@@ -63,6 +63,7 @@ def write_dump(tb_text, tb):
             s.connect(@VAR_RUN@ + "/abrt/abrt.socket")
             s.sendall("POST / HTTP/1.1\r\n\r\n")
             s.sendall("type=Python\0")
+            s.sendall("analyzer=abrt-python-handler\0")
             s.sendall("pid=%s\0" % os.getpid())
             s.sendall("executable=%s\0" % executable)
             # This handler puts a short(er) crash descr in 1st line of the backtrace.

--- a/src/hooks/abrt_exception_handler3.py.in
+++ b/src/hooks/abrt_exception_handler3.py.in
@@ -51,7 +51,7 @@ def send(data):
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.settimeout(5)
         s.connect(@VAR_RUN@ + "/abrt/abrt.socket")
-        pre = "POST / HTTP/1.1\r\n\r\ntype=Python3\0"
+        pre = "POST / HTTP/1.1\r\n\r\ntype=Python3\0analyzer=abrt-python3-handler\0"
         s.sendall(pre.encode())
         s.sendall(data.encode())
 


### PR DESCRIPTION
Stop creating of an analyzer element was introduced in commit
61b879a8efa04a41f5f75f7b0ef0fbe4707a42c0.
We still want to create the element for Python and Python3.

For Python problems the analyzer is abrt-python-handler and for Python3
problems the analyzer is abrt-python3-handler.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>