### PR TITLE
cli-ng: fix abrt list --fmt parameter

### DIFF
--- a/src/cli-ng/abrtcli/cli.py
+++ b/src/cli-ng/abrtcli/cli.py
@@ -160,6 +160,8 @@ def list_problems(args):
 
     if not args.fmt:
         fmt = config.MEDIUM_FMT
+    else:
+        fmt = args.fmt
 
     if args.pretty != 'medium':
         fmt = getattr(config, '{}_FMT'.format(args.pretty.upper()))


### PR DESCRIPTION
Argument of parameter --fmt was not used even it is defined.

$ abrt list {what} raised exception UnboundLocalError.

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>