### PR TITLE
spec: split out some abrt events

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -312,6 +312,25 @@ Requires: abrt-python3
 This package contains python 3 hook and python analyzer plugin for handling
 uncaught exception in python 3 programs.
 
+%package plugin-sosreport
+Summary: %{name}'s plugin for building automatic sosreports
+Group: System Environment/Libraries
+Requires: sosreport
+Requires: %{name} = %{version}-%{release}
+
+%description plugin-sosreport
+This package contains a configuration snippet to enable automatic generation
+of sosreports for abrt events.
+
+%package plugin-machine-id
+Summary: %{name}'s plugin to generate machine_id based off dmidecode
+Group: System Environment/Libraries
+Requires: %{name} = %{version}-%{release}
+
+%description plugin-machine-id
+This package contains a configuration snippet to enable automatic generation
+of machine_id for abrt events.
+
 %package tui
 Summary: %{name}'s command line interface
 Group: User Interface/Desktops
@@ -784,7 +803,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_sbindir}/abrt-auto-reporting
 %{_libexecdir}/abrt-handle-event
 %{_libexecdir}/abrt-action-ureport
-%{_libexecdir}/abrt-action-generate-machine-id
 %{_bindir}/abrt-handle-upload
 %{_bindir}/abrt-action-notify
 %{_mandir}/man1/abrt-action-notify.1.gz
@@ -1059,6 +1077,15 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_mandir}/man5/python3_event.conf.5.gz
 %{python3_sitearch}/abrt*
 %{python3_sitearch}/__pycache__/abrt*
+
+%files plugin-sosreport
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/libreport/events.d/sosreport_event.conf
+
+%files plugin-machine-id
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/libreport/events.d/machine-id_event.conf
+%{_libexecdir}/abrt-action-generate-machine-id
 
 %files cli
 %defattr(-,root,root,-)

--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -80,39 +80,6 @@ EVENT=post-create runlevel= remote!=1
 EVENT=post-create remote=1
         echo "Processing uploaded problem : $DUMP_DIR"
 
-# Example: if you want to save sosreport immediately at the moment of a crash:
-# (alternatively, you can add similar command to EVENT=analyze_foo's,
-# if you would rather perform this collection later):
-#EVENT=post-create remote!=1
-        nice sosreport --tmp-dir "$DUMP_DIR" --batch \
-                --only=anaconda --only=boot --only=devicemapper \
-                --only=filesys --only=hardware --only=kernel --only=libraries \
-                --only=memory --only=networking --only=nfsserver --only=pam \
-                --only=process --only=rpm -k rpm.rpmva=off --only=ssh \
-                --only=startup --only=yum --only=general --only=x11 \
-                --only=cups --only=logs --only=grub2 --only=cron --only=pci \
-                --only=auditd --only=selinux --only=lvm2 --only=sar \
-                --only=processor \
-                >sosreport.log 2>&1 \
-        && {
-                rm sosreport.log
-                rm sosreport*.md5
-                mv sosreport*.tar.bz2 sosreport.tar.bz2
-                mv sosreport*.tar.xz sosreport.tar.xz
-                exit 0
-        } 2>/dev/null
-        # Error in sosreport run. Let user see the problem.
-        echo "sosreport run failed with exit code $?, log follows:"
-        # sosreport prints many useless empty lines, nuke them:
-        # it looks awful in syslog otherwise.
-        cat sosreport.log | sed 's/  *$//' | grep -v '^$'
-        rm sosreport.log
-        exit 1
-
-# Example: if you want to include *machineid* in dump directories:
-#EVENT=post-create remote!=1
-    /usr/libexec/abrt-action-generate-machine-id -o $DUMP_DIR/machineid >>event_log 2>&1 || :
-
 # Example:
 # if you want to upload data immediately at the moment of a crash to
 # a remote directory:

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -94,6 +94,8 @@ dist_eventsconf_DATA = \
     python_event.conf \
     python3_event.conf \
     smart_event.conf \
+    sosreport_event.conf \
+    machine-id_event.conf \
     gconf_event.conf \
     vimrc_event.conf
 

--- a/src/plugins/machine-id_event.conf
+++ b/src/plugins/machine-id_event.conf
@@ -1,0 +1,3 @@
+#if you want to include *machineid* in dump directories:
+EVENT=post-create remote!=1
+    /usr/libexec/abrt-action-generate-machine-id -o $DUMP_DIR/machineid >>event_log 2>&1 || :

--- a/src/plugins/sosreport_event.conf
+++ b/src/plugins/sosreport_event.conf
@@ -1,0 +1,28 @@
+# Example: if you want to save sosreport immediately at the moment of a crash:
+# (alternatively, you can add similar command to EVENT=analyze_foo's,
+# if you would rather perform this collection later):
+EVENT=post-create remote!=1
+        nice sosreport --tmp-dir "$DUMP_DIR" --batch \
+                --only=anaconda --only=boot --only=devicemapper \
+                --only=filesys --only=hardware --only=kernel --only=libraries \
+                --only=memory --only=networking --only=nfsserver --only=pam \
+                --only=process --only=rpm -k rpm.rpmva=off --only=ssh \
+                --only=startup --only=yum --only=general --only=x11 \
+                --only=cups --only=logs --only=grub2 --only=cron --only=pci \
+                --only=auditd --only=selinux --only=lvm2 --only=sar \
+                --only=processor \
+                >sosreport.log 2>&1 \
+        && {
+                rm sosreport.log
+                rm sosreport*.md5
+                mv sosreport*.tar.bz2 sosreport.tar.bz2
+                mv sosreport*.tar.xz sosreport.tar.xz
+                exit 0
+        } 2>/dev/null
+        # Error in sosreport run. Let user see the problem.
+        echo "sosreport run failed with exit code $?, log follows:"
+        # sosreport prints many useless empty lines, nuke them:
+        # it looks awful in syslog otherwise.
+        cat sosreport.log | sed 's/  *$//' | grep -v '^$'
+        rm sosreport.log
+        exit 1


### PR DESCRIPTION
A fairly simple step one towards #1194 

It doesn't get all the examples separated out, but it is a start.