### PR TITLE
spec: if using systemd, default to os-release ID for desktopvendor

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -23,13 +23,20 @@
 %define have_kexec_tools 1
 %endif
 
-%if 0%{?rhel} >= 6
-    %define desktopvendor redhat
-%else
-    %if 0%{?suse_version}
-        %define desktopvendor suse
+# rpmbuild --define 'desktopvendor mystring'
+%if "x%{desktopvendor}" == "x"
+    %if %{with systemd}
+        %define desktopvendor %(source /etc/os-release; echo ${ID})
     %else
-        %define desktopvendor fedora
+        %if 0%{?rhel} >= 6
+            %define desktopvendor redhat
+        %else
+            %if 0%{?suse_version}
+                %define desktopvendor suse
+            %else
+                %define desktopvendor fedora
+            %endif
+        %endif
     %endif
 %endif
 


### PR DESCRIPTION
If abrt is building with systemd support, the desktop vendor could be pulled out of /etc/os-release.

In theory this should eventually let the logic checking for suse/rhel/fedora fall away.

Down stream rebuilds (centos etc) should also benefit from this auto detect behavior.

https://www.freedesktop.org/software/systemd/man/os-release.html#ID=