### PR TITLE
daemon: Allow rpm to be optional at build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,6 @@ PKG_CHECK_MODULES([GTK], [gtk+-3.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.43])
 PKG_CHECK_MODULES([DBUS], [dbus-1])
 PKG_CHECK_MODULES([LIBXML], [libxml-2.0])
-PKG_CHECK_MODULES([RPM], [rpm])
 PKG_CHECK_MODULES([LIBNOTIFY], [libnotify >= 0.7.0])
 PKG_CHECK_MODULES([NSS], [nss])
 PKG_CHECK_MODULES([LIBREPORT], [libreport])
@@ -423,6 +422,16 @@ ABRT_PARSE_WITH([selinux]))
     AM_CONDITIONAL(HAVE_SELINUX, true)
 [else]
     AM_CONDITIONAL(HAVE_SELINUX, false)
+[fi]
+
+AC_ARG_WITH(rpm,
+AS_HELP_STRING([--with-rpm],[build rpm support (default is YES)]),
+ABRT_PARSE_WITH([rpm]))
+
+[if test -z "$NO_RPM"]
+[then]
+    PKG_CHECK_MODULES([RPM], [rpm])
+    AC_DEFINE(HAVE_LIBRPM, [], [Have rpm support.])
 [fi]
 
 # Initialize the test suite.

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -95,6 +95,7 @@ abrt_action_save_package_data_CPPFLAGS = \
     -I$(srcdir)/../lib \
     -DCONF_DIR=\"$(CONF_DIR)\" \
     $(GLIB_CFLAGS) \
+    $(RPM_CFLAGS) \
     $(LIBREPORT_CFLAGS) \
     -D_GNU_SOURCE
 abrt_action_save_package_data_LDADD = \

--- a/src/daemon/rpm.h
+++ b/src/daemon/rpm.h
@@ -22,11 +22,6 @@
 #ifndef RPM_H_
 #define RPM_H_
 
-#include <rpm/rpmts.h>
-#include <rpm/rpmcli.h>
-#include <rpm/rpmdb.h>
-#include <rpm/rpmpgp.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This request is similar to the one I made for satyr, but this time the default should be yes.