### PR TITLE
kernel: modify suspicious string "invalid opcode:"

### DIFF
--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -139,7 +139,7 @@ static const char *const s_koops_suspicious_strings[] = {
     "coprocessor segment overrun:",
     "invalid TSS:",
     "segment not present:",
-    "invalid opcode:",
+    "invalid opcode",
     "alignment check:",
     "stack segment:",
     "fpu exception:",

--- a/tests/examples/oops6.right
+++ b/tests/examples/oops6.right
@@ -1,41 +1,35 @@
 abrt-dump-oops: Found oopses: 1
 
-Version: 3.5.3-1.fc17.x86_64
-general protection fault: 0000 [#1] SMP 
-CPU 1 
-Modules linked in: vfat fat usb_storage fuse ebtable_nat ebtables ipt_MASQUERADE iptable_nat nf_nat xt_CHECKSUM iptable_mangle bridge stp llc rfcomm be2iscsi iscsi_boot_sysfs bnep bnx2i cnic uio cxgb4i cxgb4 cxgb3i cxgb3 mdio ip6t_REJECT nf_conntrack_ipv6 nf_defrag_ipv6 ip6table_filter ip6_tables libcxgbi ib_iser rdma_cm tpm_bios nf_conntrack_ipv4 nf_defrag_ipv4 xt_state nf_conntrack ib_addr iw_cm ib_cm ib_sa ib_mad ib_core iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nls_utf8 hfsplus snd_hda_codec_hdmi btusb bluetooth snd_hda_codec_cirrus b43 snd_hda_intel coretemp mac80211 snd_hda_codec cfg80211 rfkill ssb microcode snd_hwdep snd_pcm snd_page_alloc snd_timer snd lpc_ich mfd_core tg3 mei applesmc bcma input_polldev shpchp i2c_i801 soundcore apple_gmux apple_bl vhost_net tun macvtap macvlan kvm_intel nfsd kvm nfs_acl auth_rpcgss uinput lockd sunrpc crc32c_intel ghash_clmulni_intel firewire_ohci firewire_core crc_itu_t sdhci_pci sdhci mmc_core i915 video i2c
-_algo_bit drm_kms_helper drm i2c_core [last unloaded: scsi_wait_scan]
-Pid: 1659, comm: rpm Not tainted 3.5.3-1.fc17.x86_64 #1 Apple Inc. Macmini5,1/Mac-8ED6AF5B48C039E1
-RIP: 0010:[<ffffffff812db222>]  [<ffffffff812db222>] memcpy+0x12/0x110
-RSP: 0018:ffff880041c5dc30  EFLAGS: 00010202
-RAX: ffff880041c5dcc4 RBX: 0000000000000004 RCX: 0000000000000004
-RDX: 0000000000000004 RSI: 0005080000000800 RDI: ffff880041c5dcc4
-RBP: ffff880041c5dc98 R08: 0000000000000000 R09: ffff880076677e50
-R10: ffff880005dbc780 R11: 0000000000000069 R12: ffff880041c5dcc4
-R13: ffff880000000000 R14: 0000160000000000 R15: 0000000000000004
-FS:  00007fa354dc7800(0000) GS:ffff880100240000(0000) knlGS:0000000000000000
-CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
-CR2: 00007f838e0bd430 CR3: 000000003c8c3000 CR4: 00000000000407e0
-DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
-DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000400
-Process rpm (pid: 1659, threadinfo ffff880041c5c000, task ffff8800039a4530)
-Stack:
- ffffffffa053f719 ffff880041c5dc98 ffffffff00000800 ffff880000000004
- ffff880076677e50 ffff880041c5dcc8 00000069a0542980 ff7bffef00000000
- 0000000000000001 ffff880041c5dd10 0000000000000003 0000000000000003
+Version: 4.8.15-300.fc25.x86_64
+traps: chrome[2979] trap invalid opcode ip:55911b28dba3 sp:7ffea558a3e0 error:0
+ in chrome[55911728a000+6a0b000]
+chrome: page allocation failure: order:5, mode:0x24040c0(GFP_KERNEL|__GFP_COMP)
+CPU: 0 PID: 2979 Comm: chrome Not tainted 4.8.15-300.fc25.x86_64 #1
+Hardware name: Gigabyte Technology Co., Ltd. Z87M-D3H/Z87M-D3H, BIOS F11 08/12/2014
+ ffffa9660e293738 ffffffff833f3ddd ffffffff83c507c8 0000000000000001
+ ffffa9660e2937c0 ffffffff831cc45a 024040c090d21e80 ffffffff83c507c8
+ ffffa9660e293760 ffffa96600000010 ffffa9660e2937d0 ffffa9660e293780
 Call Trace:
- [<ffffffffa053f719>] ? hfsplus_bnode_read+0x89/0x100 [hfsplus]
- [<ffffffffa0541e9e>] hfsplus_brec_find+0x7e/0x150 [hfsplus]
- [<ffffffffa053d7ea>] hfsplus_delete_cat+0x7a/0x290 [hfsplus]
- [<ffffffffa053e93b>] hfsplus_unlink+0x8b/0x1f0 [hfsplus]
- [<ffffffff8127621c>] ? security_inode_permission+0x1c/0x30
- [<ffffffff8119384e>] vfs_unlink+0x9e/0x110
- [<ffffffff81196de3>] do_unlinkat+0x183/0x1c0
- [<ffffffff810d358c>] ? __audit_syscall_entry+0xcc/0x300
- [<ffffffff810d3bac>] ? __audit_syscall_exit+0x3ec/0x450
- [<ffffffff811a416e>] ? mnt_want_write+0x3e/0x60
- [<ffffffff81197b86>] sys_unlink+0x16/0x20
- [<ffffffff81614ae9>] system_call_fastpath+0x16/0x1b
-Code: 4e 48 83 c4 08 5b 5d c3 90 e8 eb fb ff ff eb e6 90 90 90 90 90 90 90 90 90 48 89 f8 48 89 d1 48 c1 e9 03 83 e2 07 f3 48 a5 89 d1 <f3> a4 c3 20 4c 8b 06 4c 8b 4e 08 4c 8b 56 10 4c 8b 5e 18 48 8d 
-RIP  [<ffffffff812db222>] memcpy+0x12/0x110
- RSP <ffff880041c5dc30>
+ [<ffffffff833f3ddd>] dump_stack+0x63/0x86
+ [<ffffffff831cc45a>] warn_alloc+0x13a/0x170
+ [<ffffffff831cc176>] ? __alloc_pages_direct_compact+0x46/0xf0
+ [<ffffffff831cc752>] __alloc_pages_slowpath+0x252/0xb40
+ [<ffffffff831cd331>] __alloc_pages_nodemask+0x2f1/0x340
+ [<ffffffff83222ff5>] alloc_pages_current+0x95/0x140
+ [<ffffffff831ee158>] kmalloc_order+0x18/0x40
+ [<ffffffff831ee1a4>] kmalloc_order_trace+0x24/0xa0
+ [<ffffffff8323072d>] __kmalloc+0x1cd/0x1f0
+ [<ffffffff832bac67>] ? elf_core_dump+0xb67/0x1590
+ [<ffffffff832bad1d>] elf_core_dump+0xc1d/0x1590
+ [<ffffffff8381a306>] ? schedule_timeout+0x226/0x3f0
+ [<ffffffff832c0c8e>] do_coredump+0x55e/0xed0
+ [<ffffffff830cdd39>] ? try_to_wake_up+0x59/0x3d0
+ [<ffffffff830b235d>] get_signal+0x27d/0x630
+ [<ffffffff83026067>] do_signal+0x37/0x690
+ [<ffffffff830b0f89>] ? force_sig_info+0xc9/0xe0
+ [<ffffffff83026cf9>] ? do_trap+0x69/0x140
+ [<ffffffff83027119>] ? do_error_trap+0x89/0x110
+ [<ffffffff830b37a4>] ? restore_altstack+0x24/0x40
+ [<ffffffff83003286>] exit_to_usermode_loop+0x76/0xb0
+ [<ffffffff83003af0>] prepare_exit_to_usermode+0x40/0x50
+ [<ffffffff8381c5af>] retint_user+0x8/0x10

--- a/tests/examples/oops6.test
+++ b/tests/examples/oops6.test
@@ -1,40 +1,61 @@
-[1462424.527379] general protection fault: 0000 [#1] SMP 
-[1462424.527431] CPU 1 
-[1462424.527448] Modules linked in: vfat fat usb_storage fuse ebtable_nat ebtables ipt_MASQUERADE iptable_nat nf_nat xt_CHECKSUM iptable_mangle bridge stp llc rfcomm be2iscsi iscsi_boot_sysfs bnep bnx2i cnic uio cxgb4i cxgb4 cxgb3i cxgb3 mdio ip6t_REJECT nf_conntrack_ipv6 nf_defrag_ipv6 ip6table_filter ip6_tables libcxgbi ib_iser rdma_cm tpm_bios nf_conntrack_ipv4 nf_defrag_ipv4 xt_state nf_conntrack ib_addr iw_cm ib_cm ib_sa ib_mad ib_core iscsi_tcp libiscsi_tcp libiscsi scsi_transport_iscsi nls_utf8 hfsplus snd_hda_codec_hdmi btusb bluetooth snd_hda_codec_cirrus b43 snd_hda_intel coretemp mac80211 snd_hda_codec cfg80211 rfkill ssb microcode snd_hwdep snd_pcm snd_page_alloc snd_timer snd lpc_ich mfd_core tg3 mei applesmc bcma input_polldev shpchp i2c_i801 soundcore apple_gmux apple_bl vhost_net tun macvtap macvlan kvm_intel nfsd kvm nfs_acl auth_rpcgss uinput lockd sunrpc crc32c_intel ghash_clmulni_intel firewire_ohci firewire_core crc_itu_t sdhci_pci sdhci mmc_core i915 video i2c
-_algo_bit drm_kms_helper drm i2c_core [last unloaded: scsi_wait_scan]
-[1462424.528377] 
-[1462424.528383] Pid: 1659, comm: rpm Not tainted 3.5.3-1.fc17.x86_64 #1 Apple Inc. Macmini5,1/Mac-8ED6AF5B48C039E1
-[1462424.528456] RIP: 0010:[<ffffffff812db222>]  [<ffffffff812db222>] memcpy+0x12/0x110
-[1462424.528515] RSP: 0018:ffff880041c5dc30  EFLAGS: 00010202
-[1462424.528552] RAX: ffff880041c5dcc4 RBX: 0000000000000004 RCX: 0000000000000004
-[1462424.528600] RDX: 0000000000000004 RSI: 0005080000000800 RDI: ffff880041c5dcc4
-[1462424.528647] RBP: ffff880041c5dc98 R08: 0000000000000000 R09: ffff880076677e50
-[1462424.528695] R10: ffff880005dbc780 R11: 0000000000000069 R12: ffff880041c5dcc4
-[1462424.528742] R13: ffff880000000000 R14: 0000160000000000 R15: 0000000000000004
-[1462424.528791] FS:  00007fa354dc7800(0000) GS:ffff880100240000(0000) knlGS:0000000000000000
-[1462424.528844] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
-[1462424.528883] CR2: 00007f838e0bd430 CR3: 000000003c8c3000 CR4: 00000000000407e0
-[1462424.528930] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
-[1462424.528978] DR3: 0000000000000000 DR6: 00000000ffff0ff0 DR7: 0000000000000400
-[1462424.529026] Process rpm (pid: 1659, threadinfo ffff880041c5c000, task ffff8800039a4530)
-[1462424.529077] Stack:
-[1462424.529094]  ffffffffa053f719 ffff880041c5dc98 ffffffff00000800 ffff880000000004
-[1462424.529154]  ffff880076677e50 ffff880041c5dcc8 00000069a0542980 ff7bffef00000000
-[1462424.529213]  0000000000000001 ffff880041c5dd10 0000000000000003 0000000000000003
-[1462424.529272] Call Trace:
-[1462424.529302]  [<ffffffffa053f719>] ? hfsplus_bnode_read+0x89/0x100 [hfsplus]
-[1462424.529355]  [<ffffffffa0541e9e>] hfsplus_brec_find+0x7e/0x150 [hfsplus]
-[1462424.529406]  [<ffffffffa053d7ea>] hfsplus_delete_cat+0x7a/0x290 [hfsplus]
-[1462424.529457]  [<ffffffffa053e93b>] hfsplus_unlink+0x8b/0x1f0 [hfsplus]
-[1462424.529505]  [<ffffffff8127621c>] ? security_inode_permission+0x1c/0x30
-[1462424.529554]  [<ffffffff8119384e>] vfs_unlink+0x9e/0x110
-[1462424.529593]  [<ffffffff81196de3>] do_unlinkat+0x183/0x1c0
-[1462424.529633]  [<ffffffff810d358c>] ? __audit_syscall_entry+0xcc/0x300
-[1462424.529677]  [<ffffffff810d3bac>] ? __audit_syscall_exit+0x3ec/0x450
-[1462424.532090]  [<ffffffff811a416e>] ? mnt_want_write+0x3e/0x60
-[1462424.534494]  [<ffffffff81197b86>] sys_unlink+0x16/0x20
-[1462424.536899]  [<ffffffff81614ae9>] system_call_fastpath+0x16/0x1b
-[1462424.539450] Code: 4e 48 83 c4 08 5b 5d c3 90 e8 eb fb ff ff eb e6 90 90 90 90 90 90 90 90 90 48 89 f8 48 89 d1 48 c1 e9 03 83 e2 07 f3 48 a5 89 d1 <f3> a4 c3 20 4c 8b 06 4c 8b 4e 08 4c 8b 56 10 4c 8b 5e 18 48 8d 
-[1462424.544800] RIP  [<ffffffff812db222>] memcpy+0x12/0x110
-[1462424.547415]  RSP <ffff880041c5dc30>
-[1462424.667311] ---[ end trace ca3a6cae6c998aca ]---
+traps: chrome[2979] trap invalid opcode ip:55911b28dba3 sp:7ffea558a3e0 error:0
+ in chrome[55911728a000+6a0b000]
+chrome: page allocation failure: order:5, mode:0x24040c0(GFP_KERNEL|__GFP_COMP)
+CPU: 0 PID: 2979 Comm: chrome Not tainted 4.9.3-200.fc25.x86_64 #1
+Hardware name: Gigabyte Technology Co., Ltd. Z87M-D3H/Z87M-D3H, BIOS F11 08/12/2014
+ ffffa9660e293738 ffffffff833f3ddd ffffffff83c507c8 0000000000000001
+ ffffa9660e2937c0 ffffffff831cc45a 024040c090d21e80 ffffffff83c507c8
+ ffffa9660e293760 ffffa96600000010 ffffa9660e2937d0 ffffa9660e293780
+Call Trace:
+ [<ffffffff833f3ddd>] dump_stack+0x63/0x86
+ [<ffffffff831cc45a>] warn_alloc+0x13a/0x170
+ [<ffffffff831cc176>] ? __alloc_pages_direct_compact+0x46/0xf0
+ [<ffffffff831cc752>] __alloc_pages_slowpath+0x252/0xb40
+ [<ffffffff831cd331>] __alloc_pages_nodemask+0x2f1/0x340
+ [<ffffffff83222ff5>] alloc_pages_current+0x95/0x140
+ [<ffffffff831ee158>] kmalloc_order+0x18/0x40
+ [<ffffffff831ee1a4>] kmalloc_order_trace+0x24/0xa0
+ [<ffffffff8323072d>] __kmalloc+0x1cd/0x1f0
+ [<ffffffff832bac67>] ? elf_core_dump+0xb67/0x1590
+ [<ffffffff832bad1d>] elf_core_dump+0xc1d/0x1590
+ [<ffffffff8381a306>] ? schedule_timeout+0x226/0x3f0
+ [<ffffffff832c0c8e>] do_coredump+0x55e/0xed0
+ [<ffffffff830cdd39>] ? try_to_wake_up+0x59/0x3d0
+ [<ffffffff830b235d>] get_signal+0x27d/0x630
+ [<ffffffff83026067>] do_signal+0x37/0x690
+ [<ffffffff830b0f89>] ? force_sig_info+0xc9/0xe0
+ [<ffffffff83026cf9>] ? do_trap+0x69/0x140
+ [<ffffffff83027119>] ? do_error_trap+0x89/0x110
+ [<ffffffff830b37a4>] ? restore_altstack+0x24/0x40
+ [<ffffffff83003286>] exit_to_usermode_loop+0x76/0xb0
+ [<ffffffff83003af0>] prepare_exit_to_usermode+0x40/0x50
+ [<ffffffff8381c5af>] retint_user+0x8/0x10
+Mem-Info:
+active_anon:7037325 inactive_anon:439700 isolated_anon:32
+ active_file:26879 inactive_file:18930 isolated_file:0
+ unevictable:662 dirty:843 writeback:156 unstable:0
+ slab_reclaimable:54077 slab_unreclaimable:57937
+ mapped:106009 shmem:99958 pagetables:130941 bounce:0
+ free:51693 free_pcp:57 free_cma:0
+Node 0 active_anon:28149300kB inactive_anon:1758800kB active_file:107516kB inactive_file:75720kB unevictable:2648kB isolated(anon):128kB isolated(file):0kB mapped:424036kB dirty:3372kB writeback:624kB shmem:0kB shmem_thp: 0kB shmem_pmdmapped: 0kB anon_thp: 399832kB writeback_tmp:0kB unstable:0kB pages_scanned:499 all_unreclaimable? no
+Node 0 DMA free:15200kB min:32kB low:44kB high:56kB active_anon:0kB inactive_anon:0kB active_file:0kB inactive_file:0kB unevictable:0kB writepending:0kB present:15988kB managed:15896kB mlocked:0kB slab_reclaimable:0kB slab_unreclaimable:696kB kernel_stack:0kB pagetables:0kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:0kB
+lowmem_reserve[]: 0 2415 31073 31073 31073
+Node 0 DMA32 free:120752kB min:5248kB low:7720kB high:10192kB active_anon:2209792kB inactive_anon:66432kB active_file:3372kB inactive_file:1580kB unevictable:0kB writepending:0kB present:2556492kB managed:2490500kB mlocked:0kB slab_reclaimable:7992kB slab_unreclaimable:6452kB kernel_stack:788kB pagetables:26292kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:0kB
+lowmem_reserve[]: 0 0 28657 28657 28657
+Node 0 Normal free:70820kB min:62296kB low:91640kB high:120984kB active_anon:25939300kB inactive_anon:1692436kB active_file:104140kB inactive_file:73848kB unevictable:2648kB writepending:3964kB present:29874176kB managed:29349888kB mlocked:2648kB slab_reclaimable:208316kB slab_unreclaimable:224600kB kernel_stack:50684kB pagetables:497472kB bounce:0kB free_pcp:256kB local_pcp:0kB free_cma:0kB
+lowmem_reserve[]: 0 0 0 0 0
+Node 0 DMA: 0*4kB 0*8kB 0*16kB 1*32kB (U) 1*64kB (U) 0*128kB 1*256kB (U) 1*512kB (U) 0*1024kB 1*2048kB (M) 3*4096kB (M) = 15200kB
+Node 0 DMA32: 918*4kB (UMEH) 1381*8kB (UMEH) 403*16kB (UMEH) 77*32kB (UMEH) 86*64kB (UMEH) 110*128kB (UMEH) 32*256kB (UME) 15*512kB (UME) 5*1024kB (UME) 2*2048kB (UM) 13*4096kB (M) = 121552kB
+Node 0 Normal: 15574*4kB (UMEH) 444*8kB (UMH) 195*16kB (H) 55*32kB (H) 10*64kB (H) 1*128kB (H) 0*256kB 0*512kB 0*1024kB 0*2048kB 0*4096kB = 71496kB
+Node 0 hugepages_total=0 hugepages_free=0 hugepages_surp=0 hugepages_size=1048576kB
+Node 0 hugepages_total=0 hugepages_free=0 hugepages_surp=0 hugepages_size=2048kB
+817618 total pagecache pages
+671719 pages in swap cache
+Swap cache stats: add 48474667, delete 47802948, find 21142431/37640654
+Free swap  = 31218700kB
+Total swap = 62494716kB
+8111664 pages RAM
+0 pages HighMem/MovableOnly
+147593 pages reserved
+0 pages cma reserved
+0 pages hwpoisoned

--- a/tests/runtests/journal-oops-processing/runtest.sh
+++ b/tests/runtests/journal-oops-processing/runtest.sh
@@ -154,6 +154,16 @@ rlJournalStart
             | grep -v "Version:" > \
             $TmpDir/oops5.right
 
+        sed "s/4.9.3-200.fc25.x86_64/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops6.test > \
+            $TmpDir/oops6.test
+
+        sed "s/4.8.15-300.fc25.x86_64/<KERNEL_VERSION>/" \
+            $EXAMPLES_PATH/oops6.right \
+            | grep -v "abrt-dump-oops:" \
+            | grep -v "Version:" > \
+            $TmpDir/oops6.right
+
         sed "s/3.10.0-33.el7.ppc64/<KERNEL_VERSION>/" \
             $EXAMPLES_PATH/oops8_ppc64.test > \
             $TmpDir/oops8_ppc64.test


### PR DESCRIPTION
"invalid opcode:" can be without colon.
    
systemd-journal output example:
    
    traps: chrome[2979] trap invalid opcode ip:55911b28dba3 sp:7ffea558a3e0
    error:0
     in chrome[55911728a000+6a0b000]
    
Related to #1413451
