### PR TITLE
RHEL7: don't expect kernel's version '2.6.*' or '3.*.*' 

### DIFF
--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -534,7 +534,10 @@ char *koops_extract_version(const char *linepointer)
      || strstr(linepointer, "REGS")
      || strstr(linepointer, "EFLAGS")
     ) {
-        const char *regexp = "([0-9]+\\.[0-9]+\\.[0-9]+-[^ \\)]+)[ \\)]";
+        /* "(4.7.0-2.x86_64.fc25) #"    */
+        /* " 4.7.0-2.x86_64.fc25 #"     */
+        /* " 2.6.3.4.5-2.x86_64.fc22 #" */
+        const char *regexp = "([ \\(]|kernel-)([0-9]+\\.[0-9]+\\.[0-9]+(\\.[^.-]+)*-[^ \\)]+)\\)? #";
         regex_t re;
         int r = regcomp(&re, regexp, REG_EXTENDED);
         if (r != 0)
@@ -545,8 +548,8 @@ char *koops_extract_version(const char *linepointer)
             return NULL;
         }
 
-        regmatch_t matchptr[2];
-        r = regexec(&re, linepointer, 2, matchptr, 0);
+        regmatch_t matchptr[3];
+        r = regexec(&re, linepointer, sizeof(matchptr)/sizeof(matchptr[0]), matchptr, 0);
         if (r != 0)
         {
             if (r != REG_NOMATCH)
@@ -565,7 +568,11 @@ char *koops_extract_version(const char *linepointer)
             return NULL;
         }
 
-        char *ret = xstrndup(linepointer + matchptr[1].rm_so, matchptr[1].rm_eo - matchptr[1].rm_so);
+        /* 0: entire string */
+        /* 1: version prefix */
+        /* 2: version string */
+        const regmatch_t *const ver = matchptr + 2;
+        char *ret = xstrndup(linepointer + ver->rm_so, ver->rm_eo - ver->rm_so);
 
         regfree(&re);
         return ret;


### PR DESCRIPTION
Related to #1378469