### PR TITLE
spec: add rpm-build as BuildRequires

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -75,6 +75,7 @@ BuildRequires: %{dbus_devel}
 BuildRequires: gtk3-devel
 BuildRequires: glib2-devel >= 2.43
 BuildRequires: rpm-devel >= 4.6
+BuildRequires: rpm-build
 BuildRequires: desktop-file-utils
 BuildRequires: libnotify-devel
 #why? BuildRequires: file-devel


### PR DESCRIPTION
Without this patch 'make rpm' command fails with message
`rpmbuild: command not found`.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>