### PR TITLE
Do not use fedorahosted.org for tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,7 +78,7 @@ DIST=rawhide
 scratch-build: srpm
 	koji build --scratch $(DIST) `make srpm | grep Wrote | cut -d' ' -f2`
 
-UPLOAD_URL ?= fedorahosted.org:abrt
+UPLOAD_URL ?= localhost
 
 upload: dist
 	scp $(distdir).tar.gz $$(test -n "$$UPLOAD_LOGIN" && echo "$$UPLOAD_LOGIN@")$(UPLOAD_URL)
@@ -119,4 +119,3 @@ release:
 	git tag "$$NEW_VER"; \
 	echo -n "$$NEW_VER" > abrt-version
 	autoconf --force
-	$(MAKE) upload

--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -70,7 +70,7 @@ Version: @PACKAGE_VERSION@
 Release: 1%{?dist}
 License: GPLv2+
 URL: https://abrt.readthedocs.org/
-Source: https://fedorahosted.org/released/%{name}/%{name}-%{version}.tar.gz
+Source: https://github.com/abrt/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildRequires: %{dbus_devel}
 BuildRequires: gtk3-devel
 BuildRequires: glib2-devel >= 2.43


### PR DESCRIPTION
fedorahosted.org was retired on March 1st, 2017.
As we have all previous tarball created from github and all
version tags are in place I choose to use github as our new
tarball source.
