### PR TITLE
koops_event: add check to not send MCEs as uReports

### DIFF
--- a/src/plugins/abrt-action-check-oops-for-hw-error.in
+++ b/src/plugins/abrt-action-check-oops-for-hw-error.in
@@ -108,6 +108,9 @@ if __name__ == "__main__":
         with open_or_die("kernel", "w") as krnlfile:
             krnlfile.write(kernel)
 
+    with open_or_die("mce", "w") as f:
+        f.write("fatal" if vmcore_mce else "non-fatal")
+
     # vmcore MCEs already have good backtrace element, nothing more to do
     if vmcore_mce:
         sys.exit(0)

--- a/src/plugins/koops_event.conf
+++ b/src/plugins/koops_event.conf
@@ -36,14 +36,18 @@ EVENT=report_Bugzilla type=Kerneloops
 
 # Send micro report
 EVENT=report_uReport type=Kerneloops
-        /usr/libexec/abrt-action-ureport
+        if [ ! -e mce ]; then
+            /usr/libexec/abrt-action-ureport
+        else
+            echo "Not reportable, problem has hardware character (MCE)"
+        fi
 
 # Update ABRT database after successful report to bugzilla
 EVENT=post_report type=Kerneloops
         reporter-ureport -A -B
 
 # Automatic/simple GUI-based kernel oopses reporting will do this:
-EVENT=report-gui type=Kerneloops
+EVENT=report-gui type=Kerneloops mce!=non-fatal
         report-gtk -- "$DUMP_DIR"
 
 EVENT=report-cli type=Kerneloops


### PR DESCRIPTION
Resolves abrt/abrt#1033

I think the best place to check for attempt to send MCE ureport is in
src/plugins/koops_event.conf -> EVENT=report_uReport
it would be possible in abrt-action-ureport too, but abrt-action-ureport is used by other scripts as
(ccpp_event.conf, python3_event.conf, ...) and those have nothing to do with MCEs
