### PR TITLE
Python 3.6 invalid escape sequence deprecation fix

### DIFF
--- a/src/plugins/abrt-action-check-oops-for-alt-component.in
+++ b/src/plugins/abrt-action-check-oops-for-alt-component.in
@@ -14,7 +14,7 @@ _ = gettext.gettext
 tags = [
 "WARNING:",
 "[ER]IP[^:]",
-" \[<[a-f0-9]{8,16}>\]"
+" \\[<[a-f0-9]{8,16}>\\]"
 ]
 
 checks = [


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior