### PR TITLE
reorder function declaration

### DIFF
--- a/src/lib/notify_new_path.c
+++ b/src/lib/notify_new_path.c
@@ -18,12 +18,6 @@
 #include <sys/un.h>
 #include "libabrt.h"
 
-void notify_new_path(const char *path)
-{
-    /* Ignore results and don't wait for response -> NULL */
-    notify_new_path_with_response(path, NULL);
-}
-
 int notify_new_path_with_response(const char *path, char **message)
 {
     int retval;
@@ -105,4 +99,10 @@ int notify_new_path_with_response(const char *path, char **message)
 
     /* If code is greater than INT_MAX, -EBADMSG is returned. */
     return (int)code;
+}
+
+void notify_new_path(const char *path)
+{
+    /* Ignore results and don't wait for response -> NULL */
+    notify_new_path_with_response(path, NULL);
 }


### PR DESCRIPTION
addressing:
```
DEBUG: notify_new_path.c: In function 'abrt_notify_new_path':
DEBUG: notify_new_path.c:24:5: error: implicit declaration of function 'notify_new_path_with_response' [-Werror=implicit-function-declaration]
DEBUG:      notify_new_path_with_response(path, NULL);
DEBUG:      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```