### PR TITLE
abrt_event: Save cpuinfo in problem directories

### DIFF
--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -63,12 +63,20 @@ EVENT=post-create container_cmdline!= remote!=1
 #EVENT=post-create
         rm uid; chmod a+rX .
 
-
-# uid file is missing for problems visible to all users
-# (oops scanner is often set up to not create it).
-# Record username only if uid element is present:
 EVENT=post-create remote!=1
+        # uid file is missing for problems visible to all users
+        # (oops scanner is often set up to not create it).
+        # Record username only if uid element is present:
         if [ -f uid ]; then getent passwd "`cat uid`" | cut -d: -f1 >username; fi
+        # Save cpuinfo because crashes in some components are
+        # related to HW acceleration. The file must be captured for all crashes
+        # because of the library vs. executable problem.
+        if command -v lscpu >/dev/null 2>&1; then
+            # use lscpu if installed
+            lscpu > $DUMP_DIR/cpuinfo
+        else
+            cp /proc/cpuinfo $DUMP_DIR/cpuinfo
+        fi
 
 # Record runlevel (if not yet done) and don't return non-0 if it fails:
 EVENT=post-create runlevel= remote!=1

--- a/tests/runtests/dumpdir_completedness/runtest.sh
+++ b/tests/runtests/dumpdir_completedness/runtest.sh
@@ -32,7 +32,7 @@
 TEST="dumpdir_completedness"
 PACKAGE="abrt"
 
-DDFILES="abrt_version analyzer architecture cmdline component count executable hostname kernel last_occurrence os_release package pkg_arch pkg_epoch pkg_name pkg_release pkg_version pkg_vendor pkg_fingerprint reason time type uid username uuid os_info runlevel"
+DDFILES="abrt_version analyzer architecture cmdline component count cpuinfo executable hostname kernel last_occurrence os_release package pkg_arch pkg_epoch pkg_name pkg_release pkg_version pkg_vendor pkg_fingerprint reason time type uid username uuid os_info runlevel"
 
 CCPP_FILES="core_backtrace coredump dso_list environ limits maps open_fds var_log_messages pid pwd cgroup global_pid  proc_pid_status"
 PYTHON_FILES="backtrace"

--- a/tests/runtests/oops-processing/runtest.sh
+++ b/tests/runtests/oops-processing/runtest.sh
@@ -30,7 +30,7 @@
 
 TEST="oops_processing"
 PACKAGE="abrt"
-OOPS_REQUIRED_FILES="kernel uuid duphash
+OOPS_REQUIRED_FILES="kernel cpuinfo uuid duphash
 pkg_name pkg_arch pkg_epoch pkg_release pkg_version pkg_vendor pkg_fingerprint"
 EXAMPLES_PATH="../../examples"
 # abrt should store "xorg-x11-drv-ati" in component file in those test files


### PR DESCRIPTION
added under "remote!=1" condition, because we don't want to save cpuinfo for uploaded problems

tested for all kinds of problems, also gnome-abrt and abrt-cli list looks well, in output of "abrt-cli list --detailed" appears as:
... 
cpuinfo:        Text file, 4632 bytes
...