### PR TITLE
koops: Improve not-reportable for oopses with taint flags

### DIFF
--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -748,9 +748,10 @@ static const char *const tnts_long[] = {
     /* B */ "System has hit bad_page.",
     /* C */ "Modules from drivers/staging are loaded.",
     /* D */ "Kernel has oopsed before",
-    /* E */ "Unsigned module has been loaded."
+    /* E */ "Unsigned module has been loaded.",
     /* F */ "Module has been forcibly loaded.",
-    /* G */ "Proprietary module has not been loaded.",
+            /* We don't want to be more descriptive about G flag */
+    /* G */ NULL, /* "Proprietary module has not been loaded." */
     /* H */ NULL,
     /* I */ "Working around severe firmware bug.",
     /* J */ NULL,
@@ -782,7 +783,7 @@ char *kernel_tainted_long(const char *tainted_short)
         {
             const char *const txt = tnts_long[tnt_index];
             if (txt)
-                strbuf_append_strf(tnt_long, "%s\n", txt);
+                strbuf_append_strf(tnt_long, "%c - %s\n", tainted_short[0], txt);
         }
 
         ++tainted_short;

--- a/src/plugins/oops-utils.c
+++ b/src/plugins/oops-utils.c
@@ -241,13 +241,12 @@ void abrt_oops_save_data_in_dump_dir(struct dump_dir *dd, char *oops, const char
 
             char *tnt_long = kernel_tainted_long(tainted_short);
             dd_save_text(dd, FILENAME_TAINTED_LONG, tnt_long);
-            free(tnt_long);
 
             struct strbuf *reason = strbuf_new();
             const char *fmt = _("A kernel problem occurred, but your kernel has been "
-                    "tainted (flags:%s). Kernel maintainers are unable to "
-                    "diagnose tainted reports.");
-            strbuf_append_strf(reason, fmt, tainted_short);
+                    "tainted (flags:%s). Explanation:\n%s"
+                    "Kernel maintainers are unable to diagnose tainted reports.");
+            strbuf_append_strf(reason, fmt, tainted_short, tnt_long);
 
             char *modlist = !proc_modules ? NULL : abrt_oops_list_of_tainted_modules(proc_modules);
             if (modlist)
@@ -259,6 +258,7 @@ void abrt_oops_save_data_in_dump_dir(struct dump_dir *dd, char *oops, const char
             dd_save_text(dd, FILENAME_NOT_REPORTABLE, reason->buf);
             strbuf_free(reason);
             free(tainted_short);
+            free(tnt_long);
         }
     }
 


### PR DESCRIPTION
Adds detailed info about taint flags to not-reportable. This
additional info contains description of every taint flag that appeared
in particular oops.
It is either good for user information and also solves the problem when users
opened bugs on abrt from misunderstanding tainted flags.

Related to rhbz#1452160

not-reportable now looks like this (3 lines added in this case):
A kernel problem occurred, but your kernel has been tainted (flags:GW).
Taint flags description:                                             << new
G - Proprietary module has not been loaded.          << new
W - Taint on warning.                                               << new
Kernel maintainers are unable to diagnose tainted reports. Tainted modules: vboxpci,vboxnetadp,vboxnetflt,vboxdrv.