### PR TITLE
Abrt action save container data fix

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -796,11 +796,11 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_sbindir}/abrt-auto-reporting
 %{_libexecdir}/abrt-handle-event
 %{_libexecdir}/abrt-action-ureport
+%{_libexecdir}/abrt-action-save-container-data
 %{_bindir}/abrt-handle-upload
 %{_bindir}/abrt-action-notify
 %{_mandir}/man1/abrt-action-notify.1*
 %{_bindir}/abrt-action-save-package-data
-%{_bindir}/abrt-action-save-container-data
 %{_bindir}/abrt-watch-log
 %{_bindir}/abrt-action-analyze-python
 %{_bindir}/abrt-action-analyze-xorg

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -7,8 +7,7 @@ bin_SCRIPTS = \
     abrt-handle-upload
 
 bin_PROGRAMS = \
-    abrt-action-save-package-data \
-    abrt-action-save-container-data
+    abrt-action-save-package-data
 
 sbin_PROGRAMS = \
     abrtd \
@@ -16,7 +15,10 @@ sbin_PROGRAMS = \
     abrt-upload-watch \
     abrt-auto-reporting
 
-libexec_PROGRAMS = abrt-handle-event
+libexec_PROGRAMS = \
+    abrt-handle-event \
+    abrt-action-save-container-data
+
 
 # This is a daemon, building with full relro and PIE
 # for increased security.

--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -56,7 +56,7 @@ EVENT=post-create container_cmdline= remote!=1 component=
 
 # Store information about the container:
 EVENT=post-create container_cmdline!= remote!=1
-        abrt-action-save-container-data || :
+      /usr/libexec/abrt-action-save-container-data || :
 
 
 # Example: if you want all users (not just root) to be able to see some problems:


### PR DESCRIPTION
Changing  abrt-action-save-container-data location from bin to libexec.