### PR TITLE
a-d-journal-core: use pid of crashed process in dumpdir name

### DIFF
--- a/tests/runtests/abrt-dump-journal-core/runtest.sh
+++ b/tests/runtests/abrt-dump-journal-core/runtest.sh
@@ -57,6 +57,7 @@ rlJournalStart
 
         uid=$(cat ${crash_PATH}/uid)
         rlAssertEquals "uid file contains the same id as user who causes the crash" $uid 0
+        rlAssertEquals "pid in dumpdir name is the same as in pid element" ${crash_PATH##*-} "$(cat $crash_PATH/pid)"
 
         rlRun "abrt-cli remove $crash_PATH"
     rlPhaseEnd
@@ -78,6 +79,7 @@ rlJournalStart
 
         uid=$(cat ${crash_PATH}/uid)
         rlAssertEquals "uid file contains the same id as user who causes the crash" $uid $abrt_user_id
+        rlAssertEquals "pid in dumpdir name is the same as in pid element" ${crash_PATH##*-} "$(cat $crash_PATH/pid)"
 
         rlRun "userdel -r -f abrt_core_test"
         rlRun "abrt-cli remove $crash_PATH"


### PR DESCRIPTION
Without this commit pid of abrt-dump-journal-core is used in a name
of created problem directory instead of pid of crashed process.

Requires https://github.com/abrt/libreport/pull/495