### PR TITLE
cli,dbus: Allow polkit to be optional at build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,8 +189,6 @@ PKG_CHECK_MODULES([LIBNOTIFY], [libnotify >= 0.7.0])
 PKG_CHECK_MODULES([NSS], [nss])
 PKG_CHECK_MODULES([LIBREPORT], [libreport])
 PKG_CHECK_MODULES([LIBREPORT_GTK], [libreport-gtk])
-PKG_CHECK_MODULES([POLKIT], [polkit-gobject-1])
-PKG_CHECK_MODULES([POLKIT_AGENT], [polkit-agent-1])
 PKG_CHECK_MODULES([GIO], [gio-2.0])
 PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0])
 PKG_CHECK_MODULES([SATYR], [satyr])
@@ -431,6 +429,17 @@ ABRT_PARSE_WITH([rpm]))
 [then]
     PKG_CHECK_MODULES([RPM], [rpm])
     AC_DEFINE(HAVE_LIBRPM, [], [Have rpm support.])
+[fi]
+
+AC_ARG_WITH(polkit,
+AS_HELP_STRING([--with-polkit],[build polkit support (default is YES)]),
+ABRT_PARSE_WITH([polkit]))
+
+[if test -z "$NO_POLKIT"]
+[then]
+    PKG_CHECK_MODULES([POLKIT], [polkit-gobject-1])
+    PKG_CHECK_MODULES([POLKIT_AGENT], [polkit-agent-1])
+    AC_DEFINE(HAVE_POLKIT, [], [Have polkit support.])
 [fi]
 
 # Initialize the test suite.

--- a/src/cli/abrt-cli-core.c
+++ b/src/cli/abrt-cli-core.c
@@ -23,13 +23,17 @@
 /* It is not possible to include polkitagent.h without the following define.
  * Check out the included header file.
  */
+#ifdef HAVE_POLKIT
 #define POLKIT_AGENT_I_KNOW_API_IS_SUBJECT_TO_CHANGE
 #include <polkitagent/polkitagent.h>
+#endif
 
 int g_cli_authenticate;
 
+#ifdef HAVE_POLKIT
 static PolkitAgentListener *s_local_polkit_agent = NULL;
 static gpointer s_local_agent_handle = NULL;
+#endif
 
 /* Vector of problems: */
 /* problem_data_vector[i] = { "name" = { "content", CD_FLAG_foo_bits } } */
@@ -126,6 +130,7 @@ char *hash2dirname_if_necessary(const char *input)
 
 void initialize_polkit_agent(void)
 {
+#ifdef HAVE_POLKIT
     GError *error = NULL;
     PolkitSubject *subject = polkit_unix_process_new_for_owner(
                                 getpid(),
@@ -148,13 +153,18 @@ void initialize_polkit_agent(void)
     }
 
     g_object_unref(subject);
+#else
+    log_info("Polkit support is currently disabled");
+#endif
 }
 
 void uninitialize_polkit_agent(void)
 {
+#ifdef HAVE_POLKIT
     if (s_local_agent_handle != NULL)
         polkit_agent_listener_unregister(s_local_agent_handle);
 
     if (s_local_polkit_agent != NULL)
         g_object_unref(s_local_polkit_agent);
+#endif
 }


### PR DESCRIPTION
This might blow your mind, but my use case for ABRT is on an embedded platform. You might have figured out by now from my pattern of pull requests that I want to be able to remove as many optional features as possible.