### PR TITLE
logging: rename log() to log_warning()

### DIFF
--- a/src/applet/applet.c
+++ b/src/applet/applet.c
@@ -102,7 +102,7 @@ static void migrate_auto_reporting_to_gsettings(void)
     remove_map_string_item(settings, OPT_NAME);
     save_app_conf_file(APP_NAME, settings);
 
-    log("Successfully migrated "APP_NAME":"OPT_NAME" to "GS_SCHEMA_ID_PRIVACY":"GS_PRIVACY_OPT_AUTO_REPORTING);
+    log_warning("Successfully migrated "APP_NAME":"OPT_NAME" to "GS_SCHEMA_ID_PRIVACY":"GS_PRIVACY_OPT_AUTO_REPORTING);
 
 #undef OPT_NAME
 finito:

--- a/src/cli/process.c
+++ b/src/cli/process.c
@@ -67,7 +67,7 @@ static int process_one_crash(problem_data_t *problem_data, int report_flags)
 
         if(strcmp(action, "rm") == 0 || strcmp(action, "remove") == 0 )
         {
-            log(_("Deleting '%s'"), dir_name);
+            log_warning(_("Deleting '%s'"), dir_name);
             const char *dirs_strv[] = {dir_name, NULL};
             _cmd_remove(dirs_strv);
 
@@ -76,7 +76,7 @@ static int process_one_crash(problem_data_t *problem_data, int report_flags)
         else if (((report_flags & CMD_REPORT_UNSAFE) || not_reportable == NULL)
              && (strcmp(action, "e") == 0 || strcmp(action, "report") == 0))
         {
-            log(_("Reporting '%s'"), dir_name);
+            log_warning(_("Reporting '%s'"), dir_name);
             const char *dirs_strv[] = {dir_name, NULL};
             _cmd_report(dirs_strv, report_flags);
 

--- a/src/cli/report.c
+++ b/src/cli/report.c
@@ -45,7 +45,7 @@ int _cmd_report(const char **dirs_strv, int flags)
                 {
                     char *reason = load_text_over_dbus(real_problem_id, FILENAME_NOT_REPORTABLE);
                     if (reason != NULL)
-                        log("%s\n", reason);
+                        log_warning("%s\n", reason);
                     free(reason);
                 }
 
@@ -75,7 +75,7 @@ int _cmd_report(const char **dirs_strv, int flags)
         /* the problem was successfully reported and option is -d */
         if((flags & CMD_REPORT_REMOVE) && (status == 0 || status == EXIT_STOP_EVENT_RUN))
         {
-            log(_("Deleting '%s'"), real_problem_id);
+            log_warning(_("Deleting '%s'"), real_problem_id);
             delete_dump_dir_possibly_using_abrtd(real_problem_id);
         }
 

--- a/src/cli/rm.c
+++ b/src/cli/rm.c
@@ -45,7 +45,7 @@ static int remove_using_abrtd_or_fs(const char **dirs_strv)
         const char *rm_dir = *dirs_strv++;
         status = delete_dump_dir_possibly_using_abrtd(rm_dir);
         if (!status)
-            log("rm '%s'", rm_dir);
+            log_warning("rm '%s'", rm_dir);
         else
             errs++;
     }

--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -237,7 +237,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
         kernel = dd_load_text(dd, FILENAME_KERNEL);
         if (!kernel)
         {
-            log("File 'kernel' containing kernel version not "
+            log_warning("File 'kernel' containing kernel version not "
                 "found in current directory");
             goto ret;
         }
@@ -270,7 +270,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
      * the corresponding services. */
     if (!kernel_oops && is_path_blacklisted(executable))
     {
-        log("Blacklisted executable '%s'", executable);
+        log_warning("Blacklisted executable '%s'", executable);
         goto ret; /* return 1 (failure) */
     }
 
@@ -284,9 +284,9 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
             goto ret0; /* no error */
         }
         if (kernel_oops)
-            log("Can't find kernel package corresponding to '%s'", kernel);
+            log_warning("Can't find kernel package corresponding to '%s'", kernel);
         else
-            log("Executable '%s' doesn't belong to any package"
+            log_warning("Executable '%s' doesn't belong to any package"
                 " and ProcessUnpackaged is set to 'no'", executable);
         goto ret; /* return 1 (failure) */
     }
@@ -310,7 +310,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
         /* executable may have changed, check it again */
         if (is_path_blacklisted(executable))
         {
-            log("Blacklisted executable '%s'", executable);
+            log_warning("Blacklisted executable '%s'", executable);
             goto ret; /* return 1 (failure) */
         }
         if (!script_pkg)
@@ -320,7 +320,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
              */
             if (!settings_bProcessUnpackaged)
             {
-                log("Interpreter crashed, but no packaged script detected: '%s'", cmdline);
+                log_warning("Interpreter crashed, but no packaged script detected: '%s'", cmdline);
                 goto ret; /* return 1 (failure) */
             }
 
@@ -345,7 +345,7 @@ skip_interpreter:
      * the corresponding services. */
     if (!kernel_oops && g_list_find_custom(settings_setBlackListedPkgs, package_short_name, (GCompareFunc)g_strcmp0))
     {
-        log("Blacklisted package '%s'", package_short_name);
+        log_warning("Blacklisted package '%s'", package_short_name);
         goto ret; /* return 1 (failure) */
     }
 
@@ -353,7 +353,7 @@ skip_interpreter:
     if (!(fingerprint != NULL && rpm_fingerprint_is_imported(fingerprint))
          && settings_bOpenGPGCheck)
     {
-        log("Package '%s' isn't signed with proper key", package_short_name);
+        log_warning("Package '%s' isn't signed with proper key", package_short_name);
         goto ret; /* return 1 (failure) */
         /* We used to also check the integrity of the executable here:
          *  if (!CheckHash(package_short_name.c_str(), executable)) BOOM();

--- a/src/daemon/abrt-handle-event.c
+++ b/src/daemon/abrt-handle-event.c
@@ -330,7 +330,7 @@ static char *do_log(char *log_line, void *param)
      * Otherwise, errors on post-create result in
      * "Corrupted or bad dump DIR, deleting" without adequate explanation why.
      */
-    log("%s", log_line);
+    log_warning("%s", log_line);
     return log_line;
 }
 

--- a/src/daemon/abrt-handle-upload.in
+++ b/src/daemon/abrt-handle-upload.in
@@ -229,7 +229,7 @@ if __name__ == "__main__":
         if ex != 0:
             print_clean_and_die(_("Verification error on '{0}'").format(archive))
 
-        log(_("Unpacking '{0}'").format(archive))
+        log_warning(_("Unpacking '{0}'").format(archive))
         try:
             os.mkdir(tempdir)
         except OSError:

--- a/src/daemon/abrt-server.c
+++ b/src/daemon/abrt-server.c
@@ -387,7 +387,7 @@ static int run_post_create(const char *dirname, struct response *resp)
     bool child_is_post_create = 1; /* else it is a notify child */
 
  read_child_output:
-    //log("Reading from event fd %d", child_stdout_fd);
+    //log_warning("Reading from event fd %d", child_stdout_fd);
 
     /* Read streamed data and split lines */
     for (;;)
@@ -415,7 +415,7 @@ static int run_post_create(const char *dirname, struct response *resp)
                 dup_of_dir = xstrdup(msg + strlen("DUP_OF_DIR: "));
             }
             else
-                log("%s", msg);
+                log_warning("%s", msg);
 
             strbuf_clear(cmd_output);
             /* jump to next line */
@@ -444,14 +444,14 @@ static int run_post_create(const char *dirname, struct response *resp)
     {
         if (WIFSIGNALED(status))
         {
-            log("'post-create' on '%s' killed by signal %d",
+            log_warning("'post-create' on '%s' killed by signal %d",
                             dirname, WTERMSIG(status));
             goto delete_bad_dir;
         }
         /* else: it is WIFEXITED(status) */
         if (!dup_of_dir)
         {
-            log("'post-create' on '%s' exited with %d",
+            log_warning("'post-create' on '%s' exited with %d",
                             dirname, WEXITSTATUS(status));
             goto delete_bad_dir;
         }
@@ -504,7 +504,7 @@ static int run_post_create(const char *dirname, struct response *resp)
 
             if (!last_ocr)
             {   /* the new dump directory may lie in the dump location for some time */
-                log("Using current time for the last occurrence file which may be incorrect.");
+                log_warning("Using current time for the last occurrence file which may be incorrect.");
                 time_t t = time(NULL);
                 last_ocr = xasprintf("%lu", (long)t);
             }
@@ -537,7 +537,7 @@ static int run_post_create(const char *dirname, struct response *resp)
                 (dup_of_dir ? "notify-dup" : "notify"),
                 &fd
     );
-    //log("Started notify, fd %d -> %d", fd, child_stdout_fd);
+    //log_warning("Started notify, fd %d -> %d", fd, child_stdout_fd);
     xmove_fd(fd, child_stdout_fd);
     child_is_post_create = 0;
     if (dup_of_dir)

--- a/src/daemon/abrt-upload-watch.c
+++ b/src/daemon/abrt-upload-watch.c
@@ -103,7 +103,7 @@ run_abrt_handle_upload(struct process *proc, const char *name)
 static void
 handle_new_path(struct process *proc, char *name)
 {
-    log("Detected creation of file '%s' in upload directory '%s'", name, proc->upload_directory);
+    log_warning("Detected creation of file '%s' in upload directory '%s'", name, proc->upload_directory);
 
     if (proc->children < proc->max_children)
     {

--- a/src/daemon/abrtd.c
+++ b/src/daemon/abrtd.c
@@ -195,7 +195,7 @@ static void queue_post_craete_process(struct abrt_server_proc *proc)
             stop_abrt_server(removed_proc);
         }
 
-        log("Size of '%s' >= %u MB (MaxCrashReportsSize), deleting %s directory '%s'",
+        log_warning("Size of '%s' >= %u MB (MaxCrashReportsSize), deleting %s directory '%s'",
                 g_settings_dump_location, g_settings_nMaxCrashReportsSize,
                 kind, worst_dir);
 
@@ -283,7 +283,7 @@ static gboolean abrt_server_output_cb(GIOChannel *channel, GIOCondition conditio
             queue_post_craete_process(proc);
         }
         else
-            log("abrt-server(%d): not recognized message: '%s'", proc->pid, line);
+            log_warning("abrt-server(%d): not recognized message: '%s'", proc->pid, line);
 
         g_free(line);
     }
@@ -754,7 +754,7 @@ int main(int argc, char** argv)
 #endif
 
     unsetenv("ABRT_SYSLOG");
-    msg_prefix = g_progname; /* for log(), error_msg() and such */
+    msg_prefix = g_progname; /* for log_warning(), error_msg() and such */
 
     if (getuid() != 0)
         error_msg_and_die("Must be run as root");

--- a/src/dbus/abrt-configuration.c
+++ b/src/dbus/abrt-configuration.c
@@ -1015,7 +1015,7 @@ int main(int argc, char *argv[])
 
     export_abrt_envvars(0);
 
-    msg_prefix = "abrt-configuration"; /* for log(), error_msg() and such */
+    msg_prefix = "abrt-configuration"; /* for log_warning(), error_msg() and such */
 
     if (getuid() != 0)
         error_msg_and_die(_("This program must be run as root."));

--- a/src/dbus/abrt-dbus.c
+++ b/src/dbus/abrt-dbus.c
@@ -203,7 +203,7 @@ static struct dump_dir *open_dump_directory(GDBusMethodInvocation *invocation,
 {
     if (!allowed_problem_dir(problem_dir))
     {
-        log("UID=%d attempted to access not allowed problem directory '%s'",
+        log_warning("UID=%d attempted to access not allowed problem directory '%s'",
                 caller_uid, problem_dir);
         if (!(flags & OPEN_FAIL_NO_REPLY))
             return_InvalidProblemDir_error(invocation, problem_dir);
@@ -1035,7 +1035,7 @@ int main(int argc, char *argv[])
     if (!env_path || !env_path[0])
         putenv((char*)"PATH=/usr/sbin:/usr/bin:/sbin:/bin");
 
-    msg_prefix = "abrt-dbus"; /* for log(), error_msg() and such */
+    msg_prefix = "abrt-dbus"; /* for log_warning(), error_msg() and such */
 
     if (getuid() != 0)
         error_msg_and_die(_("This program must be run as root."));

--- a/src/dbus/abrt-polkit.c
+++ b/src/dbus/abrt-polkit.c
@@ -33,7 +33,7 @@
 #ifdef HAVE_POLKIT
 static gboolean do_cancel(GCancellable* cancellable)
 {
-    log("Timer has expired; cancelling authorization check\n");
+    log_warning("Timer has expired; cancelling authorization check\n");
     g_cancellable_cancel(cancellable);
     return FALSE;
 }

--- a/src/dbus/abrt_problems2.c
+++ b/src/dbus/abrt_problems2.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 
     export_abrt_envvars(0);
 
-    msg_prefix = "abrt-problems2"; /* for log(), error_msg() and such */
+    msg_prefix = "abrt-problems2"; /* for log_warning(), error_msg() and such */
 
     if (getuid() != 0)
         error_msg_and_die("This program must be run as root.");

--- a/src/dbus/abrt_problems2_service.c
+++ b/src/dbus/abrt_problems2_service.c
@@ -93,7 +93,7 @@ static void problems2_object_type_print_all_objects(struct problems2_object_type
     const char *p;
     AbrtP2Object *obj;
     while(g_hash_table_iter_next(&iter, (gpointer)&p, (gpointer)&obj))
-        log("%s: '%s' : %p", prefix, p, obj);
+        log_warning("%s: '%s' : %p", prefix, p, obj);
 }
 #endif
 

--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -197,16 +197,16 @@ static int open_user_core(uid_t uid, uid_t fsuid, gid_t fsgid, pid_t pid, char *
                 const char *val = "%";
                 if (specifier_num > 0) /* not %% */
                     val = percent_values[specifier_num - 1];
-                //log("c:'%c'", c);
-                //log("val:'%s'", val);
+                //log_warning("c:'%c'", c);
+                //log_warning("val:'%s'", val);
 
                 /* Replace %c at core_basename[idx] by its value */
                 idx--;
                 char *old = core_basename;
                 core_basename = xasprintf("%.*s%s%s", idx, core_basename, val, core_basename + idx + 2);
-                //log("pos:'%*s|'", idx, "");
-                //log("new:'%s'", core_basename);
-                //log("old:'%s'", old);
+                //log_warning("pos:'%*s|'", idx, "");
+                //log_warning("new:'%s'", core_basename);
+                //log_warning("old:'%s'", old);
                 free(old);
                 idx += strlen(val);
             }
@@ -785,18 +785,18 @@ create_core_backtrace(struct dump_dir *dd, uid_t uid, uid_t fsuid, gid_t gid,
     {
         if (WIFSIGNALED(status))
         {
-            log("Core backtrace generator signaled with %d", WTERMSIG(status));
+            log_warning("Core backtrace generator signaled with %d", WTERMSIG(status));
             goto core_backtrace_failed;
         }
         if (!WIFEXITED(status))
         {
-            log("Core backtrace generator did not properly exit");
+            log_warning("Core backtrace generator did not properly exit");
             goto core_backtrace_failed;
         }
         const int r = WEXITSTATUS(status);
         if (r != 0)
         {
-            log("Core backtrace generator exited with error %d", r);
+            log_warning("Core backtrace generator exited with error %d", r);
             goto core_backtrace_failed;
         }
 
@@ -1097,7 +1097,7 @@ int main(int argc, char** argv)
                 signame, "abrtd is not running");
 
         /* not an error, exit with exit code 0 */
-        log("If abrtd crashed, "
+        log_warning("If abrtd crashed, "
             "/proc/sys/kernel/core_pattern contains a stale value, "
             "consider resetting it to 'core'"
         );

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -75,7 +75,7 @@ void trim_problem_dirs(const char *dirname, double cap_size, const char *exclude
             free(worst_basename);
             break;
         }
-        log("%s is %.0f bytes (more than %.0fMiB), deleting '%s'",
+        log_warning("%s is %.0f bytes (more than %.0fMiB), deleting '%s'",
                 dirname, cur_size, cap_size / (1024*1024), worst_basename);
         char *d = concat_path_file(dirname, worst_basename);
         free(worst_basename);
@@ -256,7 +256,7 @@ char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char 
     dd_close(dd);
 
     /* Let user know what's going on */
-    log(_("Generating backtrace"));
+    log_warning(_("Generating backtrace"));
 
     unsigned i = 0;
     char *args[25];
@@ -367,11 +367,11 @@ char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char 
 
         bt_depth /= 2;
         if (bt)
-            log("Backtrace is too big (%u bytes), reducing depth to %u",
+            log_warning("Backtrace is too big (%u bytes), reducing depth to %u",
                         (unsigned)strlen(bt), bt_depth);
         else
             /* (NB: in fact, current impl. of exec_vp() never returns NULL) */
-            log("Failed to generate backtrace, reducing depth to %u",
+            log_warning("Failed to generate backtrace, reducing depth to %u",
                         bt_depth);
         free(bt);
 
@@ -443,7 +443,7 @@ int dump_suid_policy()
     FILE *f  = fopen(filename, "r");
     if (!f)
     {
-        log("Can't open %s", filename);
+        log_warning("Can't open %s", filename);
         return suid_dump_policy;
     }
 
@@ -452,7 +452,7 @@ int dump_suid_policy()
     if (c != EOF)
         suid_dump_policy = c - '0';
 
-    //log("suid dump policy is: %i", suid_dump_policy);
+    //log_warning("suid dump policy is: %i", suid_dump_policy);
     return suid_dump_policy;
 }
 

--- a/src/lib/ignored_problems.c
+++ b/src/lib/ignored_problems.c
@@ -176,7 +176,7 @@ void ignored_problems_add(ignored_problems_t *set, const char *problem_id)
          * already emitted good explanatory message. This message
          * explains what the previous failure causes.
          */
-        VERB1 log("Can't add problem '%s' to ignored problems:"
+        VERB1 log_warning("Can't add problem '%s' to ignored problems:"
                 " can't open the problem", problem_id);
         return;
     }
@@ -195,7 +195,7 @@ void ignored_problems_remove_row(ignored_problems_t *set, const char *problem_id
 {
     INITIALIZE_LIBABRT();
 
-    VERB1 log("Going to remove problem '%s' from ignored problems", problem_id);
+    VERB1 log_warning("Going to remove problem '%s' from ignored problems", problem_id);
 
     FILE *orig_fp;
     if (!ignored_problems_file_contains(set, problem_id, uuid, duphash, &orig_fp, "r"))

--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -71,7 +71,7 @@ static void record_oops(GList **oops_list, const struct abrt_koops_line_info* li
         free(version);
     }
 
-    VERB3 if (rv == 0) log("Dropped oops: too short");
+    VERB3 if (rv == 0) log_warning("Dropped oops: too short");
 }
 
 /* In some comparisons, we skip 1st letter, to avoid dealing with
@@ -567,9 +567,9 @@ int koops_hash_str_ext(char result[SHA1_RESULT_LEN*2 + 1], const char *oops_buf,
         hash_str = sr_thread_get_duphash(thread, frame_count, NULL,
                                          duphash_flags|SR_DUPHASH_NOHASH);
         if (hash_str)
-            log("Generating duphash: '%s'", hash_str);
+            log_warning("Generating duphash: '%s'", hash_str);
         else
-            log("Nothing useful for duphash");
+            log_warning("Nothing useful for duphash");
 
 
         free(hash_str);

--- a/src/lib/problem_api.c
+++ b/src/lib/problem_api.c
@@ -90,7 +90,7 @@ static int add_dirname_to_GList(struct dump_dir *dd, void *arg)
 {
     if (!dir_has_correct_permissions(dd->dd_dirname, DD_PERM_DAEMONS))
     {
-        log("Ignoring '%s': invalid owner, group or mode", dd->dd_dirname);
+        log_warning("Ignoring '%s': invalid owner, group or mode", dd->dd_dirname);
         /*Do not break*/
         return 0;
     }

--- a/src/plugins/abrt-action-analyze-backtrace.c
+++ b/src/plugins/abrt-action-analyze-backtrace.c
@@ -87,8 +87,8 @@ int main(int argc, char **argv)
          * instead of a backtrace.
          * and component only.  This is not supposed to happen often.
          */
-        log(_("Backtrace parsing failed for %s"), dump_dir_name);
-        log("%d:%d: %s", location.line, location.column, location.message);
+        log_warning(_("Backtrace parsing failed for %s"), dump_dir_name);
+        log_warning("%d:%d: %s", location.line, location.column, location.message);
         struct strbuf *emptybt = strbuf_new();
 
         char *executable = dd_load_text(dd, FILENAME_EXECUTABLE);
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
         {
             hash_str = sr_thread_get_duphash(crash_thread, 3, component,
                                              SR_DUPHASH_NOHASH);
-            log("Generating duphash: %s", hash_str);
+            log_warning("Generating duphash: %s", hash_str);
             free(hash_str);
         }
 
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
         free(hash_str);
     }
     else
-        log(_("Crash thread not found"));
+        log_warning(_("Crash thread not found"));
 
 
     /* Compute the backtrace rating. */

--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -17,16 +17,16 @@ _ = lambda x: gettext.gettext(x)
 
 verbose = 0
 
-def log(s):
+def log_warning(s):
     sys.stderr.write("%s\n" % s)
 
 def log1(message):
     if verbose > 0:
-        log(message)
+        log_warning(message)
 
 def log2(message):
     if verbose > 1:
-        log(message)
+        log_warning(message)
 
 def error_msg(s):
     sys.stderr.write("%s\n" % s)
@@ -69,7 +69,7 @@ def extract_info_from_core(coredump_name):
     #SEP = 3
     EXECUTABLE = 4
 
-    log(_("Analyzing coredump '%s'") % coredump_name)
+    log_warning(_("Analyzing coredump '%s'") % coredump_name)
     eu_unstrip_OUT = Popen(["eu-unstrip","--core=%s" % coredump_name, "-n"], stdout=PIPE, bufsize=-1, universal_newlines=True).communicate()[0]
     # parse eu_unstrip_OUT and return the list of build_ids
 
@@ -107,7 +107,7 @@ def extract_info_from_core(coredump_name):
             # "Please split kernel debuginfo packages so that VDSO debuginfos are separate" -
             # we might want to remove this special-casing later.
             if b_ids_line[BUILD_ID] == '-':
-                log(_("Missing build id: %s" % b_ids_line[EXECUTABLE]))
+                log_warning(_("Missing build id: %s" % b_ids_line[EXECUTABLE]))
             elif ((len(b_ids_line) == EXECUTABLE) or (b_ids_line[EXECUTABLE] not in ["linux-vdso.so.1", "linux-gate.so.1"])):
                 build_id = b_ids_line[BUILD_ID].split('@')[0]
                 build_ids.add(build_id)

--- a/src/plugins/abrt-action-analyze-oops.c
+++ b/src/plugins/abrt-action-analyze-oops.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
         if (!res || !drop_notreportable_oopses)
         {
             /* Let users know that they can configure ABRT to drop these oopses. */
-            log("Preserving oops '%s' because DropNotReportableOopses is 'no'", dump_dir_name);
+            log_warning("Preserving oops '%s' because DropNotReportableOopses is 'no'", dump_dir_name);
 
             dd_save_text(dd, FILENAME_NOT_REPORTABLE,
             _("The backtrace does not contain enough meaningful function frames "

--- a/src/plugins/abrt-action-find-bodhi-update
+++ b/src/plugins/abrt-action-find-bodhi-update
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         bug_id = proc.stdout.read().rstrip().decode("utf-8", "ignore")
 
     if bug_id:
-        log(_("Duplicate bugzilla bug '#{0}' was found").format(bug_id))
+        log_warning(_("Duplicate bugzilla bug '#{0}' was found").format(bug_id))
     else:
         log1(_("There is no bugzilla bug with 'abrt_hash:{0}'").format(duphash_content))
         sys.exit(RETURN_OK)

--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
     if (!backtrace)
     {
         backtrace = xstrdup("");
-        log("get_backtrace() returns NULL, broken core/gdb?");
+        log_warning("get_backtrace() returns NULL, broken core/gdb?");
     }
     free(debuginfo_dirs);
     free_abrt_conf_data();
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
     /* Don't be completely silent. gdb run takes a few seconds,
      * it is useful to let user know it (maybe) worked.
      */
-    log(_("Backtrace is generated and saved, %u bytes"), (int)strlen(backtrace));
+    log_warning(_("Backtrace is generated and saved, %u bytes"), (int)strlen(backtrace));
     free(backtrace);
 
     return 0;

--- a/src/plugins/abrt-action-generate-core-backtrace.c
+++ b/src/plugins/abrt-action-generate-core-backtrace.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     char *gdb_output = get_backtrace(dump_dir_name, exec_timeout_sec, NULL);
     if (!gdb_output)
     {
-        log(_("Error: GDB did not return any data"));
+        log_warning(_("Error: GDB did not return any data"));
         return 1;
     }
 
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 
     if (!success)
     {
-        log(_("Error: %s"), error_message);
+        log_warning(_("Error: %s"), error_message);
         free(error_message);
         return 1;
     }

--- a/src/plugins/abrt-action-list-dsos
+++ b/src/plugins/abrt-action-list-dsos
@@ -7,7 +7,7 @@ import os
 import getopt
 import rpm
 
-def log(s):
+def log_warning(s):
     sys.stderr.write("%s\n" % s)
 
 def error_msg(s):

--- a/src/plugins/abrt-action-trim-files.c
+++ b/src/plugins/abrt-action-trim-files.c
@@ -108,7 +108,7 @@ static double get_dir_size(const char *dirname,
                 GList *cur = preserve_files_list;
                 while (cur)
                 {
-                    //log("'%s' ? '%s'", fullname, *pp);
+                    //log_warning("'%s' ? '%s'", fullname, *pp);
                     if (strcmp(fullname, (char*)cur->data) == 0)
                         goto next;
                     cur = cur->next;

--- a/src/plugins/abrt-action-ureport
+++ b/src/plugins/abrt-action-ureport
@@ -144,7 +144,7 @@ if __name__ == "__main__":
         if reported_to and reported_to != "":
             bugs = get_bugzilla_reports(reported_to)
             if bugs:
-                log(_("A bug was already filed about this problem:"))
+                log_warning(_("A bug was already filed about this problem:"))
                 bugs = sorted(bugs)
                 for bug in bugs:
                     print(bug)
@@ -154,7 +154,7 @@ if __name__ == "__main__":
         else:
             log1("'%s/reported_to' doesn't exist", dirname)
 
-        log(_("uReport was already sent, not sending it again"))
+        log_warning(_("uReport was already sent, not sending it again"))
         sys.exit(0)
 
     if report_type == "CCpp" and not core_backtrace_exists:
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         watch = os.getenv("uReport_WatchReportedBugs") or ""
         if exitcode == 70 and watch.lower() in ["yes", "on", "1"]:
             if reported_to and reported_to != "" and get_bugzilla_reports(reported_to):
-                log(_("Adding you to CC List of the existing bugzilla bug"))
+                log_warning(_("Adding you to CC List of the existing bugzilla bug"))
                 run_event("watch_Bugzilla", dirname)
 
         email = os.getenv("uReport_ContactEmail")

--- a/src/plugins/abrt-dump-journal-xorg.c
+++ b/src/plugins/abrt-dump-journal-xorg.c
@@ -64,7 +64,7 @@ static GList *abrt_journal_extract_xorg_crashes(abrt_journal_t *journal)
     }
     while (abrt_journal_next(journal) > 0);
 
-    log("Found crashes: %d", g_list_length(crash_info_list));
+    log_warning("Found crashes: %d", g_list_length(crash_info_list));
 
     return crash_info_list;
 }

--- a/src/plugins/abrt-dump-oops.c
+++ b/src/plugins/abrt-dump-oops.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     unsigned errors = 0;
     if (opts & OPT_u)
     {
-        log("Updating problem directory");
+        log_warning("Updating problem directory");
         switch (g_list_length(oops_list))
         {
             case 0:

--- a/src/plugins/abrt-watch-log.c
+++ b/src/plugins/abrt-watch-log.c
@@ -29,16 +29,16 @@ static bool memstr(void *buf, unsigned size, const char *str)
     int len = strlen(str);
     while ((int)size >= len)
     {
-        //log("LOOKING FOR:'%s'", str);
+        //log_warning("LOOKING FOR:'%s'", str);
         char *first = memchr(buf, (unsigned char)str[0], size - len + 1);
         if (!first)
             break;
-        //log("FOUND:'%.66s'", first);
+        //log_warning("FOUND:'%.66s'", first);
         first++;
         if (len <= 1 || strncmp(first, str + 1, len - 1) == 0)
             return true;
         size -= (first - (char*)buf);
-        //log("SKIP TO:'%.66s' %d chars", first, (int)(first - (char*)buf));
+        //log_warning("SKIP TO:'%.66s' %d chars", first, (int)(first - (char*)buf));
         buf = first;
     }
     return false;
@@ -117,7 +117,7 @@ static void run_scanner_prog(int fd, struct stat *statbuf, GList *match_list, ch
      */
     if (lseek(fd, 0, SEEK_CUR) <= cur_pos)
     {
-        log("Warning, '%s' did not process its input", prog[0]);
+        log_warning("Warning, '%s' did not process its input", prog[0]);
         lseek(fd, statbuf->st_size, SEEK_SET);
     }
 }

--- a/src/plugins/bodhi.c
+++ b/src/plugins/bodhi.c
@@ -416,7 +416,7 @@ static GHashTable *bodhi_query_list(const char *query, const char *release)
     }
     free(bodhi_url_bugs);
 
-//    log("%s", post_state->body);
+//    log_warning("%s", post_state->body);
 
     json_object *json = json_tokener_parse(post_state->body);
     if (is_error(json))
@@ -569,13 +569,13 @@ int main(int argc, char **argv)
     if (query->buf[query->len - 1] == '&')
         query->buf[query->len - 1] = '\0';
 
-    log(_("Searching for updates"));
+    log_warning(_("Searching for updates"));
     GHashTable *update_hash_tbl = bodhi_query_list(query->buf, release);
     strbuf_free(query);
 
     if (!update_hash_tbl || !g_hash_table_size(update_hash_tbl))
     {
-        log(_("No updates for this package found"));
+        log_warning(_("No updates for this package found"));
         /*if (update_hash_tbl) g_hash_table_unref(update_hash_tbl);*/
         return 0;
     }
@@ -604,7 +604,7 @@ int main(int argc, char **argv)
     if (!q->len)
     {
         /*strbuf_free(q);*/
-        log(_("Local version of the package is newer than available updates"));
+        log_warning(_("Local version of the package is newer than available updates"));
         return 0;
     }
 

--- a/src/plugins/oops-utils.c
+++ b/src/plugins/oops-utils.c
@@ -29,7 +29,7 @@ int abrt_oops_process_list(GList *oops_list, const char *dump_location, const ch
     int oops_cnt = g_list_length(oops_list);
     if (oops_cnt != 0)
     {
-        log("Found oopses: %d", oops_cnt);
+        log_warning("Found oopses: %d", oops_cnt);
         if ((flags & ABRT_OOPS_PRINT_STDOUT))
         {
             int i = 0;
@@ -38,7 +38,7 @@ int abrt_oops_process_list(GList *oops_list, const char *dump_location, const ch
                 char *kernel_bt = (char*)g_list_nth_data(oops_list, i++);
                 char *tainted_short = kernel_tainted_short(kernel_bt);
                 if (tainted_short)
-                    log("Kernel is tainted '%s'", tainted_short);
+                    log_warning("Kernel is tainted '%s'", tainted_short);
 
                 free(tainted_short);
                 printf("\nVersion: %s", kernel_bt);
@@ -46,10 +46,10 @@ int abrt_oops_process_list(GList *oops_list, const char *dump_location, const ch
         }
         if (dump_location != NULL)
         {
-            log("Creating problem directories");
+            log_warning("Creating problem directories");
             errors = abrt_oops_create_dump_dirs(oops_list, dump_location, analyzer, flags);
             if (errors)
-                log("%d errors while dumping oopses", errors);
+                log_warning("%d errors while dumping oopses", errors);
             /*
              * This marker in syslog file prevents us from
              * re-parsing old oopses. The only problem is that we
@@ -75,7 +75,7 @@ int abrt_oops_process_list(GList *oops_list, const char *dump_location, const ch
         int n = unreported_cnt > 30 ? 30 : unreported_cnt;
         n = n * n;
         if (n > 9)
-            log(_("Sleeping for %d seconds"), n);
+            log_warning(_("Sleeping for %d seconds"), n);
         abrt_oops_signaled_sleep(n); /* max 15 mins */
     }
 

--- a/tests/koops-parser.at
+++ b/tests/koops-parser.at
@@ -23,9 +23,9 @@ int run_test(const struct test_struct *test)
 		version = NULL;
 	}
 	if (version)
-		log("version %s", version);
+		log_warning("version %s", version);
 	else
-		log("version was not found");
+		log_warning("version was not found");
 	free(version);
 	fclose(fp);
 	return version == NULL;
@@ -69,19 +69,19 @@ int run_test(const struct test_struct *test, int flags)
 	case TEST_NOT_TAINTED:
 		if (tnt)
 		{
-			log("%s '%s'", test->filename, tnt);
+			log_warning("%s '%s'", test->filename, tnt);
 			ret = 1;
 		}
 		break;
 	case TEST_TAINTED:
 		if (!tnt)
 		{
-			log("%s", test->filename);
+			log_warning("%s", test->filename);
 			ret = 1;
 		}
 		else if (strcmp(tnt, test->expected_results) != 0)
 		{
-			log("%s '%s'", test->filename, tnt);
+			log_warning("%s '%s'", test->filename, tnt);
 			ret = 1;
 		}
 	};
@@ -105,12 +105,12 @@ int main(void)
 		{ EXAMPLE_PFX"/koops-tainted-insane", "ABCDEFGHIJKLMNOPQRSTUVWXYZ" },
 	};
 
-	log("test not tainted");
+	log_warning("test not tainted");
 	int ret = 0;
 	for (int i = 0; i < ARRAY_SIZE(not_tainted); ++i)
 		ret |= run_test(&not_tainted[i], TEST_NOT_TAINTED);
 
-	log("test tainted");
+	log_warning("test tainted");
 	for (int i = 0; i < ARRAY_SIZE(tainted); ++i)
 		ret |= run_test(&tainted[i], TEST_TAINTED);
 
@@ -139,7 +139,7 @@ int run_test(const struct test_struct *test)
 	if (!strcmp(hash_oops1, hash_oops2))
 		return 0;
 
-	log("'%s' != '%s'", hash_oops1, hash_oops2);
+	log_warning("'%s' != '%s'", hash_oops1, hash_oops2);
 
 	return 1;
 }
@@ -194,7 +194,7 @@ int run_test(const struct test_struct *test)
 
 	int result = !(oops_list && !strcmp((char *)oops_list->data, oops_expected));
 	if (result)
-		log("Obtained:\n'%s'\nExpected:\n'%s'", (char *)oops_list->data, oops_expected);
+		log_warning("Obtained:\n'%s'\nExpected:\n'%s'", (char *)oops_list->data, oops_expected);
 
 	g_list_free_full(oops_list, free);
 	free(oops_expected_bck);

--- a/tests/runtests/upload-ftp/ftpserver.py
+++ b/tests/runtests/upload-ftp/ftpserver.py
@@ -456,7 +456,7 @@ class _FileReadWriteError(OSError):
 
 # --- loggers
 
-def log(msg):
+def log_warning(msg):
     """Log messages intended for the end user."""
     print msg
 
@@ -2554,9 +2554,9 @@ class FTPHandler(object, asynchat.async_chat):
 
     # --- logging wrappers
 
-    def log(self, msg):
+    def log_warning(self, msg):
         """Log a message, including additional identifying session data."""
-        log("[%s]@%s:%s %s" % (self.username, self.remote_ip,
+        log_warning("[%s]@%s:%s %s" % (self.username, self.remote_ip,
                                self.remote_port, msg))
 
     def logline(self, msg):
@@ -3744,7 +3744,7 @@ class FTPServer(object, asyncore.dispatcher):
             poll_fun = asyncore.poll
 
         if count is None:
-            log("Starting FTP server")
+            log_warning("Starting FTP server")
             try:
                 try:
                     while asyncore.socket_map or _scheduler._tasks:
@@ -3753,7 +3753,7 @@ class FTPServer(object, asyncore.dispatcher):
                 except (KeyboardInterrupt, SystemExit, asyncore.ExitNow):
                     pass
             finally:
-                log("Shutting down FTP server")
+                log_warning("Shutting down FTP server")
                 cls.close_all()
         else:
             while (asyncore.socket_map or _scheduler._tasks) and count > 0:
@@ -3786,7 +3786,7 @@ class FTPServer(object, asyncore.dispatcher):
             handler = self.handler(sock, self)
             if not handler.connected:
                 return
-            log("[]%s:%s Connected." % addr[:2])
+            log_warning("[]%s:%s Connected." % addr[:2])
             ip = addr[0]
             self.ip_map.append(ip)
 


### PR DESCRIPTION
Renaming log() logging function to log_warning() because
of conflict with log() function from math.h.

Related to #1481205

Requires https://github.com/abrt/libreport/pull/499