### PR TITLE
logging: rename omitted log() to log_warning()

### DIFF
--- a/src/daemon/abrt-handle-upload.in
+++ b/src/daemon/abrt-handle-upload.in
@@ -12,7 +12,7 @@ import shutil
 import datetime
 import grp
 
-from reportclient import set_verbosity, error_msg_and_die, error_msg, log
+from reportclient import set_verbosity, error_msg_and_die, error_msg, log_warning
 
 GETTEXT_PROGNAME = "abrt"
 import locale

--- a/src/plugins/abrt-action-find-bodhi-update
+++ b/src/plugins/abrt-action-find-bodhi-update
@@ -40,7 +40,7 @@ import sys
 from argparse import ArgumentParser
 from subprocess import Popen, PIPE
 
-from reportclient import (_, log, log1, set_verbosity, verbose, RETURN_OK,
+from reportclient import (_, log_warning, log1, set_verbosity, verbose, RETURN_OK,
                           RETURN_FAILURE, error_msg)
 import report
 

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -11,7 +11,7 @@ import errno
 import getopt
 import reportclient
 from subprocess import Popen, PIPE
-from reportclient import verbose, log, log1, log2, set_verbosity, error_msg_and_die, error_msg
+from reportclient import verbose, log_warning, log1, log2, set_verbosity, error_msg_and_die, error_msg
 import time
 from reportclient.debuginfo import DebugInfoDownload, filter_installed_debuginfos, build_ids_to_path, clean_up
 import problem

--- a/src/plugins/abrt-action-ureport
+++ b/src/plugins/abrt-action-ureport
@@ -11,7 +11,7 @@ import getopt
 import augeas
 
 from report import dd_opendir, DD_FAIL_QUIETLY_ENOENT, run_event_on_problem_dir
-from reportclient import set_verbosity, error_msg_and_die, error_msg, log1, log
+from reportclient import set_verbosity, error_msg_and_die, error_msg, log1, log_warning
 
 GETTEXT_PROGNAME = "abrt"
 import locale


### PR DESCRIPTION
Some of the log() functions were omitted in commit f33b8731efedd7382e4f11d83e618a06d92a23ab.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>