### PR TITLE
cli-ng: Explicitly state python version in shebangs

### DIFF
--- a/src/cli-ng/abrt
+++ b/src/cli-ng/abrt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 import subprocess

--- a/src/cli-ng/tests/test_cli.py
+++ b/src/cli-ng/tests/test_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- encoding: utf-8 -*-
 import logging
 try:

--- a/src/cli-ng/tests/test_filtering.py
+++ b/src/cli-ng/tests/test_filtering.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- encoding: utf-8 -*-
 import logging
 try:

--- a/src/cli-ng/tests/test_match.py
+++ b/src/cli-ng/tests/test_match.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- encoding: utf-8 -*-
 import logging
 try:

--- a/src/cli-ng/tests/test_utils.py
+++ b/src/cli-ng/tests/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- encoding: utf-8 -*-
 import logging
 try:


### PR DESCRIPTION
Scripts should use /usr/bin/python[23] in shebangs.

See https://pagure.io/packaging-committee/issue/698
Also https://fedoraproject.org/wiki/Packaging:Python#Multiple_Python_Runtimes

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>