### PR TITLE
dbus: Additional changes to allow optional polkit

### DIFF
--- a/src/applet/Makefile.am
+++ b/src/applet/Makefile.am
@@ -10,6 +10,7 @@ abrt_applet_CPPFLAGS = \
     -DLIBREPORT_PLUGINS_CONF_DIR=\"$(LIBREPORT_PLUGINS_CONF_DIR)\" \
     -DLOCALEDIR=\"$(localedir)\" \
     $(GTK_CFLAGS) \
+    $(GIO_UNIX_CFLAGS) \
     $(POLKIT_CFLAGS) \
     $(LIBREPORT_GTK_CFLAGS) \
     -D_GNU_SOURCE
@@ -21,6 +22,7 @@ abrt_applet_LDADD = \
     -lgthread-2.0 \
     $(LIBNOTIFY_LIBS) \
     $(GTK_LIBS) \
+    $(GIO_UNIX_LIBS) \
     $(POLKIT_LIBS)
 
 @INTLTOOL_DESKTOP_RULE@

--- a/src/applet/applet.c
+++ b/src/applet/applet.c
@@ -20,12 +20,19 @@
 # include <locale.h>
 #endif
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <gio/gdesktopappinfo.h>
 #define GDK_DISABLE_DEPRECATION_WARNINGS
 /* https://bugzilla.gnome.org/show_bug.cgi?id=734826 */
 #include <gtk/gtk.h>
 
+#ifdef HAVE_POLKIT
 #include <polkit/polkit.h>
+#endif
+
 #include <libnotify/notify.h>
 #include <glib.h>
 
@@ -453,6 +460,7 @@ static bool is_gnome_abrt_available(void)
 
 static bool is_user_admin(void)
 {
+#ifdef HAVE_POLKIT
     GError *error = NULL;
     bool ret = false;
     GPermission *perm = polkit_permission_new_sync ("org.freedesktop.problems.getall",
@@ -465,6 +473,9 @@ static bool is_user_admin(void)
     g_object_unref (perm);
 
     return ret;
+#else
+    return true;
+#endif
 }
 
 static gboolean

--- a/src/dbus/abrt_problems2_service.c
+++ b/src/dbus/abrt_problems2_service.c
@@ -16,7 +16,13 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifdef HAVE_POLKIT
 #include <polkit/polkit.h>
+#endif
 
 #include <glib-object.h>
 #include <gio/gio.h>
@@ -2355,6 +2361,7 @@ static int abrt_p2_service_private_init(AbrtP2ServicePrivate *pv,
         return 0;
     }
 
+#ifdef HAVE_POLKIT
     GError *local_error = NULL;
     g_polkit_authority = pv->p2srv_pk_authority = polkit_authority_get_sync(NULL,
                                                                             &local_error);
@@ -2368,6 +2375,7 @@ static int abrt_p2_service_private_init(AbrtP2ServicePrivate *pv,
 
     ++g_polkit_authority_refs;
     abrt_p2_session_class_set_polkit_authority(g_polkit_authority);
+#endif
     return 0;
 
 error_return:

--- a/src/dbus/abrt_problems2_session.c
+++ b/src/dbus/abrt_problems2_session.c
@@ -16,6 +16,10 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "abrt_problems2_session.h"
 
 #include "libabrt.h"
@@ -188,6 +192,7 @@ forgotten_state:
               new_state);
 }
 
+#ifdef HAVE_POLKIT
 static void check_authorization_callback(GObject *source,
             GAsyncResult *res,
             gpointer user_data)
@@ -235,9 +240,11 @@ static void check_authorization_callback(GObject *source,
     else
         log_debug("Operation finished after the session had been destroyed");
 }
+#endif
 
 static void authorization_request_initialize(AbrtP2Session *session, GVariant *parameters)
 {
+#ifdef HAVE_POLKIT
     struct check_auth_cb_params *auth_rq = xmalloc(sizeof(*auth_rq));
     auth_rq->session = session;
     auth_rq->cancellable = g_cancellable_new();
@@ -287,7 +294,9 @@ static void authorization_request_initialize(AbrtP2Session *session, GVariant *p
                                          auth_rq->cancellable,
                                          check_authorization_callback,
                                          auth_rq);
-
+#else
+    change_state(session, ABRT_P2_SESSION_STATE_AUTH);
+#endif
 }
 
 AbrtP2Session *abrt_p2_session_new(char *caller, uid_t uid)

--- a/src/dbus/abrt_problems2_session.h
+++ b/src/dbus/abrt_problems2_session.h
@@ -40,9 +40,22 @@
 #ifndef ABRT_PROBLEMS2_SESSION_H
 #define ABRT_PROBLEMS2_SESSION_H
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "abrt_problems2_task.h"
 
+#ifdef HAVE_POLKIT
 #include <polkit/polkit.h>
+#else
+struct _PolkitAuthority;
+typedef struct _PolkitAuthority PolkitAuthority;
+struct _PolkitDetails;
+typedef struct _PolkitDetails PolkitDetails;
+typedef struct _PolkitSubject PolkitSubject;
+#endif
+
 #include <glib-object.h>
 #include <gio/gio.h>
 #include <inttypes.h>


### PR DESCRIPTION
Dbus problem2 API changes must have been in flight when I made the first
patch to disable polkit. This fixes the polkit functions I missed.