### PR TITLE
doc: remove obsolete doxygen tags

### DIFF
--- a/apidoc/Doxyfile.in
+++ b/apidoc/Doxyfile.in
@@ -173,8 +173,6 @@ MAN_LINKS              = NO
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
-XML_SCHEMA             =
-XML_DTD                =
 XML_PROGRAMLISTING     = YES
 #---------------------------------------------------------------------------
 # configuration options for the AutoGen Definitions output


### PR DESCRIPTION
Removes doxygen tags XML_SCHEMA and XML_DTD in apidoc, which became
obsolete and produces warnings while doxygen documentation generation.