### PR TITLE
cli-ng,hooks,python-problem: Allow python to be optional at build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,12 +56,6 @@ IT_PROG_INTLTOOL([0.35.0])
 
 dnl ****** END ****************************************
 
-AM_PATH_PYTHON
-if test -z "$PYTHON"; then
-    echo "*** Essential program python not found" 1>&2
-    exit 1
-fi
-
 AC_PATH_PROG([ASCIIDOC], [asciidoc], [no])
 [if test "$ASCIIDOC" = "no"]
 [then]
@@ -80,13 +74,50 @@ AC_PATH_PROG([XMLTO], [xmlto], [no])
     [exit 1]
 [fi]
 
-AC_PATH_PROG([PYTHON_CONFIG], [python-config], [no])
-[if test "$PYTHON_CONFIG" = "no"]
+AC_ARG_WITH(python2,
+AS_HELP_STRING([--with-python2],[build Python2 support (default is YES)]),
+ABRT_PARSE_WITH([python2]))
+
+[if test -z "$NO_PYTHON2"]
 [then]
-    [echo "The python-config program was not found in the search path. Please ensure"]
-    [echo "that it is installed and its directory is included in the search path."]
-    [echo "Then run configure again before attempting to build ABRT."]
-    [exit 1]
+    AM_CONDITIONAL(BUILD_PYTHON2, true)
+    AC_PATH_PROG([PYTHON], [python], [no])
+    [if test "$PYTHON" == "no"]
+    [then]
+        [echo "The python program was not found in the search path. Please ensure"]
+        [echo "that it is installed and its directory is included in the search path or"]
+        [echo "pass --without-python2 to ./configure."]
+        [echo "Then run configure again before attempting to build ABRT."]
+        [exit 1]
+    [fi]
+
+    AC_PATH_PROG([PYTHON_CONFIG], [python-config], [no])
+    [if test "$PYTHON_CONFIG" = "no"]
+    [then]
+        [echo "The python-config program was not found in the search path. Please ensure"]
+        [echo "that it is installed and its directory is included in the search path or"]
+        [echo "pass --without-python2 to ./configure."]
+        [echo "Then run configure again before attempting to build ABRT."]
+        [exit 1]
+    [fi]
+
+    PYTHON_CFLAGS=`python-config --cflags 2> /dev/null`
+    PYTHON_LIBS=`python-config --libs 2> /dev/null`
+
+    AC_SUBST([PYTHON2_PREFIX], ['${prefix}'])
+    AC_SUBST([PYTHON2_EXEC_PREFIX], ['${exec_prefix}'])
+
+    PYTHON2_DIR=`$PYTHON -c "import distutils.sysconfig; \
+        print(distutils.sysconfig.get_python_lib(0,0,prefix='$PYTHON2_PREFIX'))"`
+    PYTHON2_EXECDIR=`$PYTHON -c "import distutils.sysconfig; \
+        print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON2_EXEC_PREFIX'))"`
+
+    AC_SUBST(PYTHON_CFLAGS)
+    AC_SUBST(PYTHON_LIBS)
+    AC_SUBST(pythondir, $PYTHON2_DIR)
+    AC_SUBST(pyexecdir, $PYTHON2_EXECDIR)
+[else]
+    AM_CONDITIONAL(BUILD_PYTHON2, false)
 [fi]
 
 AC_ARG_WITH(python3,
@@ -174,12 +205,6 @@ ABRT_PARSE_WITH([pythontests]))
 [else]
     AM_CONDITIONAL(HAVE_PYTHON_NOSE, false)
 [fi]
-
-PYTHON_CFLAGS=`python-config --cflags 2> /dev/null`
-PYTHON_LIBS=`python-config --libs 2> /dev/null`
-
-AC_SUBST(PYTHON_CFLAGS)
-AC_SUBST(PYTHON_LIBS)
 
 PKG_CHECK_MODULES([GTK], [gtk+-3.0])
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.43])

--- a/src/cli-ng/abrtcli/Makefile.am
+++ b/src/cli-ng/abrtcli/Makefile.am
@@ -7,8 +7,10 @@ PYFILES= \
 	match.py \
 	utils.py
 
+if BUILD_PYTHON2
 abrtcli_PYTHON = $(PYFILES)
 abrtclidir = $(pyexecdir)/abrtcli
+endif
 
 config.py: config.py.in
 	sed -e s,\@LOCALE_DIR\@,$(localedir),g \

--- a/src/hooks/Makefile.am
+++ b/src/hooks/Makefile.am
@@ -1,7 +1,4 @@
 confdir = $(CONF_DIR)
-pyhookdir = $(pyexecdir)
-py3hookdir = $(py3execdir)
-
 pluginsconfdir = $(PLUGINS_CONF_DIR)
 
 dist_pluginsconf_DATA = \
@@ -68,18 +65,31 @@ abrt_merge_pstoreoops_LDADD = \
 
 DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@
 
+EXTRA_DIST = \
+    abrt-install-ccpp-hook.in \
+    abrt-harvest-pstoreoops.in
+
+if BUILD_PYTHON2
+pyhookdir = $(pyexecdir)
+
 pyhook_PYTHON = \
 	abrt_exception_handler.py \
 	abrt.pth
+
+EXTRA_DIST += \
+    abrt_exception_handler.py.in
+endif
+
+if BUILD_PYTHON3
+py3hookdir = $(py3execdir)
 
 py3hook_PYTHON = \
 	abrt_exception_handler3.py \
 	abrt3.pth
 
-EXTRA_DIST = abrt_exception_handler.py.in \
-	abrt_exception_handler3.py.in \
-	abrt-install-ccpp-hook.in \
-	abrt-harvest-pstoreoops.in
+EXTRA_DIST += \
+    abrt_exception_handler3.py.in
+endif
 
 if BUILD_ADDON_VMCORE
 sbin_SCRIPTS += \

--- a/src/python-problem/examples/Makefile.am
+++ b/src/python-problem/examples/Makefile.am
@@ -9,8 +9,10 @@ EXAMPLES = \
 	watch_example.py \
 	thread_watch_example.py
 
+if BUILD_PYTHON2
 example_PYTHON = $(EXAMPLES)
 exampledir = $(pythondir)/problem_examples
+endif
 
 if BUILD_PYTHON3
 example3_PYTHON = $(EXAMPLES)

--- a/src/python-problem/problem/Makefile.am
+++ b/src/python-problem/problem/Makefile.am
@@ -1,12 +1,5 @@
 PYFILES= __init__.py exception.py proxies.py tools.py watch.py config.py
 
-problem_PYTHON = $(PYFILES)
-
-problemdir = $(pyexecdir)/problem
-
-pyabrtdir = $(problemdir)
-pyabrt_LTLIBRARIES = _pyabrt.la
-
 PYEXTFILES = pyabrtmodule.c pyabrt.c common.h
 PYEXTCPPFLAGS = \
     -I$(srcdir)/../../include \
@@ -20,6 +13,13 @@ PYEXTLDFLAGS = \
      $(LIBREPORT_CFLAGS) \
     -Wl,-z,relro -Wl,-z,now
 
+if BUILD_PYTHON2
+problemdir = $(pyexecdir)/problem
+pyabrtdir = $(problemdir)
+
+problem_PYTHON = $(PYFILES)
+pyabrt_LTLIBRARIES = _pyabrt.la
+
 _pyabrt_la_SOURCES = $(PYEXTFILES)
 _pyabrt_la_CPPFLAGS = \
     $(PYEXTCPPFLAGS) \
@@ -30,13 +30,13 @@ _pyabrt_la_LDFLAGS = \
 _pyabrt_la_LIBADD = \
     ../../lib/libabrt.la
     $(PYTHON2_LIBS)
+endif
 
 if BUILD_PYTHON3
-problem3_PYTHON = $(PYFILES)
-
 problem3dir = $(py3execdir)/problem
-
 py3abrtdir = $(problem3dir)
+
+problem3_PYTHON = $(PYFILES)
 py3abrt_LTLIBRARIES = _py3abrt.la
 
 _py3abrt_la_SOURCES = $(PYEXTFILES)


### PR DESCRIPTION
This allows python2 and python3 to be independently used for builds that
only require using one or the other.