### PR TITLE
Let containers know about their coredumps

### DIFF
--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -318,6 +318,16 @@ save_systemd_coredump_in_dump_directory(struct dump_dir *dd, struct crash_info *
     const char *data = NULL;
     size_t data_len = 0;
 
+    /* This journal field is not present most of the time, because it is
+     * created only for coredumps from processes running in a container.
+     *
+     * Printing out the log message would be confusing hence.
+     *
+     * If we find more similar fields, we should not add more if statements
+     * but encode this in the struct field_mapping.
+     *
+     * For now, it would be just vasting of memory and time.
+     */
     if (!abrt_journal_get_field(info->ci_journal, "COREDUMP_CONTAINER_CMDLINE", (const void **)&data, &data_len))
     {
         dd_save_binary(dd, FILENAME_CONTAINER_CMDLINE, data, data_len);


### PR DESCRIPTION
The commits of this pull request should allow image/container developers use the tool abrt-dump-journal-core to get information about crashes in their containers.

Actually, this pull request just adds the possibility to read core dump files from all systemd journals. It does that because when you run systemd in a container you have two journals:
- the host's journal
- the container's journal

Without this PR, the tool abrt-dump-journal-core reads only the latter one - the container's journal.

After merging this journal, you should be able to use the parametre "-a" to read also the host's journal where coredump files end up.

The next steps is to introduce another option to filter out all coredump files that are not from the container's hostname:
https://github.com/systemd/systemd/commit/f45b8015513d38ee5f7cc361db9c5b88c9aae704#diff-2a71e915f668d9cf67c1ebd2c2324d23