### PR TITLE
retrace-client: Require nss-pem

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -216,6 +216,7 @@ Summary: %{name}'s retrace client
 Requires: %{name} = %{version}-%{release}
 Requires: xz
 Requires: tar
+Requires: nss-pem
 
 %description retrace-client
 This package contains the client application for Retrace server


### PR DESCRIPTION
nss from version 3.35.0-3 does not require nss-pem.
Without nss-pem retrace-client was not able to initialise security
module.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>