### PR TITLE
Add a new element 'interpreter' for python problems 

### DIFF
--- a/src/plugins/python3_event.conf
+++ b/src/plugins/python3_event.conf
@@ -8,6 +8,10 @@ EVENT=post-create type=Python3 remote!=1
             exit 1
         fi
         abrt-action-analyze-python
+        # save Python3 package version
+        for line in $(rpm -qf $(which $(cut -d' ' -f1 < cmdline)) 2>/dev/null); do
+             echo -n $line > interpreter
+        done
 
 EVENT=report_Bugzilla type=Python3 component!=anaconda
         test -f component || abrt-action-save-package-data

--- a/src/plugins/python_event.conf
+++ b/src/plugins/python_event.conf
@@ -8,6 +8,10 @@ EVENT=post-create type=Python remote!=1
             exit 1
         fi
         abrt-action-analyze-python
+        # save Python2 package version
+        for line in $(rpm -qf $(which $(cut -d' ' -f1 < cmdline)) 2>/dev/null); do
+             echo -n $line > interpreter
+        done
 
 EVENT=report_Bugzilla type=Python component!=anaconda
         test -f component || abrt-action-save-package-data

--- a/tests/runtests/dumpdir_completedness/runtest.sh
+++ b/tests/runtests/dumpdir_completedness/runtest.sh
@@ -35,7 +35,7 @@ PACKAGE="abrt"
 DDFILES="abrt_version analyzer architecture cmdline component count cpuinfo executable hostname kernel last_occurrence os_release package pkg_arch pkg_epoch pkg_name pkg_release pkg_version pkg_vendor pkg_fingerprint reason time type uid username uuid os_info runlevel"
 
 CCPP_FILES="core_backtrace coredump dso_list environ limits maps open_fds pid pwd cgroup global_pid  proc_pid_status"
-PYTHON_FILES="backtrace"
+PYTHON_FILES="backtrace interpreter"
 
 rlJournalStart
     rlPhaseStartSetup


### PR DESCRIPTION
The element 'interpreter' contains rpm package
of an interpreter which ran a script which raised
an exception.

Fixes #1294
