### PR TITLE
plugins: a-a-g-machine-id use dmidecode command

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -92,7 +92,9 @@ Requires: python3-%{name} = %{version}-%{release}
 Requires(pre): %{shadow_utils}
 Requires: python3-augeas
 Requires: python3-dbus
-Requires: python3-dmidecode
+%ifarch aarch64 i686 x86_64
+Requires: dmidecode
+%endif
 Requires: libreport-plugin-ureport
 %if 0%{?rhel}
 Requires: libreport-plugin-rhtsupport

--- a/src/plugins/abrt-action-generate-machine-id
+++ b/src/plugins/abrt-action-generate-machine-id
@@ -20,8 +20,10 @@
 """This module provides algorithms for generating Machine IDs.
 """
 
+import os
 import sys
 from argparse import ArgumentParser
+from subprocess import check_output
 import logging
 
 import hashlib
@@ -35,38 +37,26 @@ def generate_machine_id_dmidecode():
 
     """
 
-    try:
-        import dmidecode
-    except ImportError as ex:
-        raise RuntimeError("Could not import dmidecode module: {0}"
-                .format(str(ex)))
+    if not os.path.isfile("/usr/sbin/dmidecode"):
+        raise RuntimeError("Could not find dmidecode. It might not be available for this " \
+                           "architecture.")
 
-    dmixml = dmidecode.dmidecodeXML()
-    # Fetch all DMI data into a libxml2.xmlDoc object
-    dmixml.SetResultType(dmidecode.DMIXML_DOC)
-    xmldoc = dmixml.QuerySection('all')
-
-    # Do some XPath queries on the XML document
-    dmixp = xmldoc.xpathNewContext()
-
-    # What to look for - XPath expressions
-    keys = ['/dmidecode/SystemInfo/Manufacturer',
-            '/dmidecode/SystemInfo/ProductName',
-            '/dmidecode/SystemInfo/SerialNumber',
-            '/dmidecode/SystemInfo/SystemUUID']
+    # What to look for
+    keys = ['system-manufacturer',
+            'system-product-name',
+            'system-serial-number',
+            'system-uuid']
 
     # Create a sha256 of ^ for machine_id
     machine_id = hashlib.sha256()
 
-    # Run xpath expressions
+    # Run dmidecode command
     for k in keys:
-        data = dmixp.xpathEval(k)
-        for d in data:
-            # Update the hash as we find the fields we are looking for
-            machine_id.update(d.get_content().encode())
+        data = check_output(["dmidecode", "-s", k]).strip()
 
-    del dmixp
-    del xmldoc
+        # Update the hash as we find the fields we are looking for
+        machine_id.update(data)
+
     # Create sha256 digest
     return machine_id.hexdigest()
 


### PR DESCRIPTION
python-dmidecode is broken on aarch64 [1] and the issue won't be fixed.
Recommendation is to use regular dmidecode command instead.

The dmidecode is only available on aarch64, x86_64, i686 because
other archs (ppc, s390) do not have DMI table to decode.

Related to BZ#1569076

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1509938