### PR TITLE
abrt-dump-oops: return last oops instead of first

### DIFF
--- a/src/plugins/abrt-dump-oops.c
+++ b/src/plugins/abrt-dump-oops.c
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
                 }
             default:
                 {
-                    log_notice(_("More oopses found: process only the first one"));
+                    log_notice(_("More oopses found: process only the last one"));
                 }
                 /* falls trought */
             case 1:
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
                     struct dump_dir *dd = dd_opendir(problem_dir, /*open for writing*/0);
                     if (dd)
                     {
-                        abrt_oops_save_data_in_dump_dir(dd, (char *)oops_list->data, /*no proc modules*/NULL);
+                        abrt_oops_save_data_in_dump_dir(dd, (char *)g_list_last(oops_list)->data, /*no proc modules*/NULL);
                         dd_close(dd);
                     }
                 }


### PR DESCRIPTION
When picking an oops out of multiple occurrence picking the first one is
often wrong. Specifically for vmcore events the last oops is the most
interesting one so it makes the most sense to pick that one.

This choice may not always be correct but it seems like it will be
correct more often than when the first oops encountered is chosen.