### PR TITLE
Remove dependency on deprecated nss-pem

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -258,7 +258,7 @@ Summary: %{name}'s retrace client
 Requires: %{name} = %{version}-%{release}
 Requires: xz
 Requires: tar
-Requires: nss-pem
+Requires: p11-kit-trust
 
 %description retrace-client
 This package contains the client application for Retrace server

--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -1281,8 +1281,7 @@ int main(int argc, char **argv)
 
     /* Initialize NSS */
     SECMODModule *mod;
-    PK11GenericObject *cert;
-    nss_init(&mod, &cert);
+    nss_init(&mod);
 
     /* Run the desired operation. */
     int result = 0;
@@ -1334,7 +1333,7 @@ int main(int argc, char **argv)
         error_msg_and_die(_("Unknown operation: %s."), operation);
 
     /* Shutdown NSS. */
-    nss_close(mod, cert);
+    nss_close(mod);
 
     return result;
 }

--- a/src/plugins/https-utils.h
+++ b/src/plugins/https-utils.h
@@ -61,7 +61,7 @@ int http_get_response_code(const char *message);
 void http_print_headers(FILE *file, const char *message);
 char *tcp_read_response(PRFileDesc *tcp_sock);
 char *http_join_chunked(char *body, int bodylen);
-void nss_init(SECMODModule **mod, PK11GenericObject **cert);
-void nss_close(SECMODModule *mod, PK11GenericObject *cert);
+void nss_init(SECMODModule **mod);
+void nss_close(SECMODModule *mod);
 
 #endif


### PR DESCRIPTION
This commit removes dependency on nss-pem which is deprecated and
reimplements TLS client to use libnssckbi.so instead [1].

Resolves #1578427

[1] https://docs-old.fedoraproject.org/en-US/Fedora_Security_Team/1/html/Defensive_Coding/sect-Defensive_Coding-TLS-Client-NSS.html#ex-Defensive_Coding-TLS-NSS-Init

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>