### PR TITLE
abrtd.service: force abrt-dbus to load changes from conf

### DIFF
--- a/init-scripts/abrtd.service
+++ b/init-scripts/abrtd.service
@@ -8,6 +8,7 @@ After=livesys.service
 [Service]
 Type=dbus
 BusName=org.freedesktop.problems.daemon
+ExecStartPre=/usr/bin/bash -c "pkill abrt-dbus || :"
 ExecStart=/usr/sbin/abrtd -d -s
 
 [Install]


### PR DESCRIPTION
If abrt-dbus is running and some changes are done in abrt.conf the
changes are not read and used till abrt-dbus timeouts. Timeout is set
to 133 seconds in 'dbus/org.freedesktop.problems.service'.
    
Killing abrt-dbus before abrtd is started forces abrt-dbus to read all
new configurations.
