### PR TITLE
ccpp: add %h and %e parameter into abrt-hook-ccpp

### DIFF
--- a/src/hooks/abrt-hook-ccpp.c
+++ b/src/hooks/abrt-hook-ccpp.c
@@ -65,13 +65,13 @@ static struct dump_dir *dd;
  * %t - UNIX time of dump
  * %P - global pid
  * %I - crash thread tid
- * %e - executable filename (can contain white spaces)
+ * %h - hostname
+ * %e - executable filename (can contain white spaces, must be placed at the end)
  * %% - output one "%"
  */
 /* Hook must be installed with exactly the same sequence of %c specifiers.
- * Last one, %h, may be omitted (we can find it out).
  */
-static const char percent_specifiers[] = "%scpugtePi";
+static const char percent_specifiers[] = "%scpugtPIhe";
 static char *core_basename = (char*) "core";
 
 static DIR *open_cwd(pid_t pid)
@@ -146,7 +146,8 @@ static int setfscreatecon_raw(security_context_t context)
 }
 #endif
 
-static int open_user_core(uid_t uid, uid_t fsuid, gid_t fsgid, pid_t pid, char **percent_values)
+static int open_user_core(uid_t uid, uid_t fsuid, gid_t fsgid, pid_t pid,
+                          char **percent_values, const char *executable_filename)
 {
     proc_cwd = open_cwd(pid);
     if (proc_cwd == NULL)
@@ -196,7 +197,13 @@ static int open_user_core(uid_t uid, uid_t fsuid, gid_t fsgid, pid_t pid, char *
             {
                 const char *val = "%";
                 if (specifier_num > 0) /* not %% */
+                {
                     val = percent_values[specifier_num - 1];
+                    /* if %e (executable filename), use executable from
+                     * /proc/PID/exe symlink if exists */
+                    if (percent_specifiers[specifier_num] == 'e' && executable_filename)
+                        val = executable_filename;
+                }
                 //log_warning("c:'%c'", c);
                 //log_warning("val:'%s'", val);
 
@@ -917,9 +924,9 @@ int main(int argc, char** argv)
 
     if (argc < 8)
     {
-        /* percent specifier:         %s   %c              %p  %u  %g  %t   %P         %T        */
-        /* argv:                  [0] [1]  [2]             [3] [4] [5] [6]  [7]        [8]       */
-        error_msg_and_die("Usage: %s SIGNO CORE_SIZE_LIMIT PID UID GID TIME GLOBAL_PID GLOBAL_TID", argv[0]);
+        /* percent specifier:         %s   %c              %p  %u  %g  %t   %P         %I         %h       %e   */
+        /* argv:                  [0] [1]  [2]             [3] [4] [5] [6]  [7]        [8]        [9]      [10] */
+        error_msg_and_die("Usage: %s SIGNO CORE_SIZE_LIMIT PID UID GID TIME GLOBAL_PID GLOBAL_TID HOSTNAME BINARY_NAME", argv[0]);
     }
 
     /* Not needed on 2.6.30.
@@ -1016,13 +1023,21 @@ int main(int argc, char** argv)
 
     snprintf(path, sizeof(path), "%s/last-ccpp", g_settings_dump_location);
 
+    char *executable = get_executable_at(pid_proc_fd);
+    const char *last_slash = NULL;
+    if (executable)
+    {
+        last_slash = strrchr(executable, '/');
+        /* if the last_slash was found, skip it */
+        if (last_slash) ++last_slash;
+    }
+
     /* Open a fd to compat coredump, if requested and is possible */
     int user_core_fd = -1;
     if (setting_MakeCompatCore && ulimit_c != 0)
         /* note: checks "user_pwd == NULL" inside; updates core_basename */
-        user_core_fd = open_user_core(uid, fsuid, fsgid, pid, &argv[1]);
+        user_core_fd = open_user_core(uid, fsuid, fsgid, pid, &argv[1], (const char *)last_slash);
 
-    char *executable = get_executable_at(pid_proc_fd);
     if (executable == NULL)
     {
         /* readlink on /proc/$PID/exe failed, don't create abrt dump dir */
@@ -1031,9 +1046,6 @@ int main(int argc, char** argv)
         return create_user_core(user_core_fd, pid, ulimit_c);
     }
 
-    const char *last_slash = strrchr(executable, '/');
-    /* if the last_slash was found, skip it */
-    if (last_slash) ++last_slash;
 
     /* ignoring crashes */
     if (executable && is_path_ignored(setting_ignored_paths, executable))

--- a/src/hooks/abrt-install-ccpp-hook.in
+++ b/src/hooks/abrt-install-ccpp-hook.in
@@ -11,7 +11,7 @@ SAVED_PATTERN_DIR="@VAR_RUN@/abrt"
 SAVED_PATTERN_FILE="@VAR_RUN@/abrt/saved_core_pattern"
 HOOK_BIN="@libexecdir@/abrt-hook-ccpp"
 # Must match percent_specifiers[] order in abrt-hook-ccpp.c:
-PATTERN="|$HOOK_BIN %s %c %p %u %g %t %P %I"
+PATTERN="|$HOOK_BIN %s %c %p %u %g %t %P %I %h %e"
 
 # core_pipe_limit specifies how many dump_helpers can run at the same time
 # 0 - means unlimited, but it's not guaranteed that /proc/<pid> of crashing

--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -43,6 +43,7 @@ cli-authentication
 cli-process
 console-notifications
 check-hook-install
+ccpp-plugin-hook
 ccpp-plugin-hook-ignoring
 dumpoops
 dumpxorg

--- a/tests/runtests/ccpp-plugin-hook/PURPOSE
+++ b/tests/runtests/ccpp-plugin-hook/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of ccpp-plugin-hook
+Description: Testing functionality of abrt-hook-ccpp
+Author: Matej Habrnal <mhabrnal@redhat.com>

--- a/tests/runtests/ccpp-plugin-hook/runtest.sh
+++ b/tests/runtests/ccpp-plugin-hook/runtest.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of abrt-plugin-hook
+#   Description: Testing functionality of abrt-hook-ccpp
+#   Author: Matej Habrnal <mhabrnal@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2011 Red Hat, Inc. All rights reserved.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+. /usr/share/beakerlib/beakerlib.sh
+. ../aux/lib.sh
+
+TEST="ccpp-plugin-hook"
+PACKAGE="abrt"
+
+HOOK_PATH="/proc/sys/kernel/core_pattern"
+TESTED_PATTERN="core.%p.%u.%g.%s.%t.%h.%e"
+
+rlJournalStart
+    rlPhaseStartSetup
+        check_prior_crashes
+
+        rlRun "systemctl stop abrt-ccpp"
+
+        rlLog "Backup core_pattern hook"
+        HOOK_BCK=$( cat $HOOK_PATH )
+        rlLog "Hook bck: '$HOOK_BCK'"
+        rlLog "Tested hook: '$TESTED_PATTERN'"
+        rlRun "sysctl kernel.core_pattern=${TESTED_PATTERN}"
+        rlRun "systemctl start abrt-ccpp"
+
+        CCORE_BCK=$(augtool get /files/etc/abrt/plugins/CCpp.conf/MakeCompatCore | cut -d'=' -f2 | tr -d ' ')
+        rlLog "MakeCompatCore bck: '$HOOK_BCK'"
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/MakeCompatCore yes"
+
+        OGPGCH_BCK=$(augtool get /files/etc/abrt/plugins/abrt-action-save-package-data.conf/OpenGPGCheck | cut -d'=' -f2 | tr -d ' ')
+        rlLog "MakeCompatCore bck: '$OGPGCH_BCK'"
+        rlRun "augtool set /files/etc/abrt/plugins/abrt-action-save-package-data.conf/OpenGPGCheck no"
+
+        PUNPACKAGED_BCK=$(augtool get /files/etc/abrt/plugins/abrt-action-save-package-data.conf/ProcessUnpackaged | cut -d'=' -f2 | tr -d ' ')
+        rlLog "MakeCompatCore bck: '$PUNPACKAGED_BCK'"
+        rlRun "augtool set /files/etc/abrt/plugins/abrt-action-save-package-data.conf/ProcessUnpackaged yes"
+
+        ULIMIT_BCK=$(ulimit -c)
+        rlLog "ulimit -c bck: '$ULIMIT_BCK'"
+        rlRun "ulimit -c unlimited"
+
+        TmpDir=$(mktemp -d)
+        pushd $TmpDir
+
+        # create crashing binary which name contains space
+        rlRun "cp /usr/bin/will_segfault crash\ binary"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        prepare
+        ./crash\ binary
+        wait_for_hooks
+        get_crash_path
+
+        P_PID=$(cat $crash_PATH/pid | tr -d '\n') # core_pattern %p
+        P_UID=$(cat $crash_PATH/uid | tr -d '\n') # core_pattern %u
+        P_GID=$(id -g | tr -d '\n') # core_pattern %g
+        P_SIG=11 # generate_crash calls will_segfault; core_pattern %s
+        P_TIME=$(cat $crash_PATH/time | tr -d '\n') # core_pattern %t
+        P_HOST=$(cat $crash_PATH/hostname | tr -d '\n') # core_pattern %h
+        P_EXE=$(cat $crash_PATH/executable | tr -d '\n') # core_pattern %e
+
+        ls -al
+        # core file should exist
+        rlAssertExists "core.${P_PID}.${P_UID}.${P_GID}.${P_SIG}.${P_TIME}.${P_HOST}.${P_EXE##*/}"
+
+        rlRun "abrt-cli rm $crash_PATH"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        popd # TmpDir
+        rm -rf $TmpDir
+        rlRun "systemctl stop abrt-ccpp"
+        rlRun "echo '$HOOK_BCK' > $HOOK_PATH" 0 "Restore old hook"
+        rlRun "systemctl start abrt-ccpp"
+        rlRun "augtool set /files/etc/abrt/plugins/CCpp.conf/MakeCompatCore $CCORE_BCK" 0 "Restore old MakeCompatCor"
+        rlRun "augtool set /files/etc/abrt/plugins/abrt-action-save-package-data.conf/OpenGPGCheck $OGPGCH_BCK"
+        rlRun "augtool set /files/etc/abrt/plugins/abrt-action-save-package-data.conf/ProcessUnpackaged $PUNPACKAGED_BCK"
+        rlRun "ulimit -c $ULIMIT_BCK"
+    rlPhaseEnd
+    rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
    Without this commit core_pattern's parameters %h and %e was not
    translated at all.
    
    Due to 51531e9ea72af09571688a20f00e55cad5fe9c3a, %e has to be placed
    at the very end of the command in core_pattern.
    
    Example:
    If 'core_pattern = core.%h.%e.%p.%t' the result was
    core.%h.sleep.26284.1469805542 not core.myshostmane.sleep.26284.1469805542.
    
    Related to #1587891