### PR TITLE
gui-config: Remove deprecated GTK functions

### DIFF
--- a/src/configuration-gui/abrt-config-widget.c
+++ b/src/configuration-gui/abrt-config-widget.c
@@ -564,14 +564,8 @@ abrt_config_widget_init(AbrtConfigWidget *self)
     connect_switch_with_option(self, ABRT_OPT_SILENT_SHORTENED_REPORTING, "switch_silent_shortened_reporting");
     connect_switch_with_option(self, ABRT_OPT_NOTIFY_INCOMPLETE_PROBLEMS, "switch_notify_incomplete_problems");
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION == 1))
-    /* https://developer.gnome.org/gtk3/3.13/GtkWidget.html#gtk-widget-reparent */
-    /* gtk_widget_reparent has been deprecated since version 3.13.2 and should not be used in newly-written code. */
-    gtk_widget_reparent(WID("grid"), GTK_WIDGET(self));
-#else
     gtk_container_remove(GTK_CONTAINER(WID("window1")), WID("grid"));
     gtk_container_add(GTK_CONTAINER(self), WID("grid"));
-#endif
 
     /* Set the initial state of the properties */
     gtk_widget_show_all(GTK_WIDGET(self));

--- a/src/configuration-gui/system-config-abrt.c
+++ b/src/configuration-gui/system-config-abrt.c
@@ -53,24 +53,11 @@ GtkWidget *system_config_abrt_widget_new_with_close_button(system_config_abrt_wi
     gtk_widget_set_visible(GTK_WIDGET(config), TRUE);
     gtk_box_pack_start(box, GTK_WIDGET(config), /*expand*/TRUE, /*fill*/TRUE, /*padding*/0);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 13) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 13 && GTK_MICRO_VERSION == 1))
-    /* https://developer.gnome.org/gtk3/3.13/GtkAlignment.html#gtk-alignment-new */
-    /* GtkAlignment has been deprecated. Use GtkWidget alignment and margin properties */
-    gtk_box_pack_start(GTK_BOX(box),
-            gtk_alignment_new(/*xalign*/.5, /*yalign*/.5, /*xscale*/.5, /*yscale*/.5),
-            /*expand*/TRUE, /*fill*/TRUE, /*padding*/0);
-#endif
-
     GtkWidget *buttons = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, /*spacing*/0);
     gtk_box_pack_start(GTK_BOX(box), buttons, /*expand*/TRUE, /*fill*/FALSE, /*padding*/0);
 
-#if ((GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION < 11) || (GTK_MAJOR_VERSION == 3 && GTK_MINOR_VERSION == 11 && GTK_MICRO_VERSION < 2))
-    gtk_widget_set_margin_left(buttons, 10);
-    gtk_widget_set_margin_right(buttons, 10);
-#else
     gtk_widget_set_margin_start(buttons, 10);
     gtk_widget_set_margin_end(buttons, 10);
-#endif
     gtk_widget_set_margin_top(buttons, 10);
     gtk_widget_set_margin_bottom(buttons, 10);
 


### PR DESCRIPTION
They are not used anymore with the current GTK3 version 3.22.x.

resolves #1310

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>