### PR TITLE
spec: Build python*-abrt-addon packages as noarch

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -332,6 +332,7 @@ Search for a new updates in bodhi server.
 %if %{with python2}
 %package -n python2-abrt-addon
 Summary: %{name}'s addon for catching and analyzing Python exceptions
+BuildArch: noarch
 Requires: %{name} = %{version}-%{release}
 Requires: python2-systemd
 Requires: python2-abrt
@@ -357,6 +358,7 @@ programs in container.
 %if %{with python3}
 %package -n python3-abrt-addon
 Summary: %{name}'s addon for catching and analyzing Python 3 exceptions
+BuildArch: noarch
 Requires: %{name} = %{version}-%{release}
 Requires: python3-systemd
 Requires: python3-abrt


### PR DESCRIPTION
The packages do not include anything that needs to be compiled/build
hence should be noarch.

Related: bz#1508511

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>