### PR TITLE
spec: turn on --enable-native-unwinder aarch64

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -644,7 +644,7 @@ CFLAGS="%{optflags} -Werror" %configure \
         --enable-suggest-autoreporting \
         --enable-authenticated-autoreporting \
 %endif
-%ifnarch arm armhfp armv7hl armv7l aarch64
+%ifnarch %{arm}
         --enable-native-unwinder \
 %endif
 %if %{?have_kexec_tools} == 0


### PR DESCRIPTION
Turning on native-unwinder for aarch64 according to #1260074

Related to #1260074

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>