### PR TITLE
testsuite: dbus-element-handling: Use external script

### DIFF
--- a/tests/runtests/dbus-elements-handling/runtest.sh
+++ b/tests/runtests/dbus-elements-handling/runtest.sh
@@ -133,29 +133,10 @@ function abrtElementsHandlingTest() {
 }
 
 function abrtMaxCrashReportsSizeTest() {
-    resp=`su $2 -c "python <<EOF
-import dbus
-import sys
-proxy=dbus.SystemBus().get_object('org.freedesktop.problems', '/org/freedesktop/problems')
-iface=dbus.Interface(proxy, 'org.freedesktop.problems')
-try:
-    iface.SetElement(\"$1\", \"onemibofx\", 1024*1024*\"x\")
-except dbus.exceptions.DBusException as e:
-    print \"%s: %s\" % (e.get_dbus_name(), e.get_dbus_message())
-EOF"`
+    rlRun "resp=\$(./set_element.py $1 onemibofx 1 1024)"
     rlAssertEquals "No free space detected" "_$resp" "_org.freedesktop.problems.Failure: No problem space left"
 
-    resp=`su $2 -c "python <<EOF
-import dbus
-import sys
-proxy=dbus.SystemBus().get_object('org.freedesktop.problems', '/org/freedesktop/problems')
-iface=dbus.Interface(proxy, 'org.freedesktop.problems')
-try:
-    iface.SetElement(\"$1\", \"onemibofx\", 512*1024*\"x\")
-    iface.SetElement(\"$1\", \"onemibofx\", 512*1024*\"x\")
-except dbus.exceptions.DBusException as e:
-    print \"%s: %s\" % (e.get_dbus_name(), e.get_dbus_message())
-EOF"`
+    rlRun "resp=\$(./set_element.py $1 onemibofx 2 512)"
     rlAssertEquals "Size limit correctly checks the size limit according to a new size of an element" "_$resp" "_"
 }
 

--- a/tests/runtests/dbus-elements-handling/set_element.py
+++ b/tests/runtests/dbus-elements-handling/set_element.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# argv[1] - problem directory
+# argv[2] - element name
+# argv[3] - loop counter
+# argv[4] - element size in kiB
+
+import dbus
+import sys
+
+bus = dbus.SystemBus()
+proxy = bus.get_object('org.freedesktop.problems', '/org/freedesktop/problems')
+iface = dbus.Interface(proxy, 'org.freedesktop.problems')
+
+try:
+    for i in range(int(sys.argv[3])):
+        iface.SetElement(sys.argv[1], sys.argv[2], int(sys.argv[4]) * 1024 * "x")
+except dbus.exceptions.DBusException as e:
+    print('{}: {}'.format(e.get_dbus_name(), e.get_dbus_message()))


### PR DESCRIPTION
Invoking `python` inline can result in the Python 2 interpreter being
run, which might be problematic if the project was configured with
--without-python2, as the F29 test runner in particular does not have
python2-dbus installed, which is required for this test.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>