### PR TITLE
testsuite: reporter-upload-ssh-keys: Don’t test curl output

### DIFF
--- a/tests/runtests/reporter-upload-ssh-keys/runtest.sh
+++ b/tests/runtests/reporter-upload-ssh-keys/runtest.sh
@@ -99,32 +99,24 @@ rlJournalStart
 
         rlAssertGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-commandline'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-commandline'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-commandline'" $LOG_FILE
 
         LOG_FILE="ssh_commandline_only_public.log"
         rlRun "./expect reporter-upload -vvv -d problem_dir -u scp://root@localhost$TmpDir/target/upload.tar.gz -b pub-commandline >$LOG_FILE 2>&1"
 
         rlAssertGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
         rlAssertNotGrep "Using SSH private key 'pri-commandline'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-commandline'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH private key file 'pri-commandline'" $LOG_FILE
 
         LOG_FILE="ssh_commandline_only_private.log"
         rlRun "./expect reporter-upload -vvv -d problem_dir -u scp://root@localhost$TmpDir/target/upload.tar.gz -r pri-commandline >$LOG_FILE 2>&1"
 
         rlAssertNotGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-commandline'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH public key file 'pub-commandline'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-commandline'" $LOG_FILE
 
         LOG_FILE="ssh_commandline_default.log"
         rlRun "./expect reporter-upload -vvv -d problem_dir -u scp://root@localhost$TmpDir/target/upload.tar.gz >$LOG_FILE 2>&1"
 
         rlAssertNotGrep "Using SSH public key 'pub-commandline'" $LOG_FILE
         rlAssertNotGrep "Using SSH private key 'pri-commandline'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH public key file 'pub-commandline'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH private key file 'pri-commandline'" $LOG_FILE
     rlPhaseEnd
 
     rlPhaseStartTest "set SSH keyfile conf file upload.conf"
@@ -142,8 +134,6 @@ EOF
 
         rlAssertGrep "Using SSH public key 'pub-conffile'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-conffile'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-conffile'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-conffile'" $LOG_FILE
 
 cat > $upload_conf <<EOF
 SSHPublicKey = pub-conffile
@@ -155,8 +145,6 @@ EOF
 
         rlAssertGrep "Using SSH public key 'pub-conffile'" $LOG_FILE
         rlAssertNotGrep "Using SSH private key 'pri-conffile'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-conffile'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH private key file 'pri-conffile'" $LOG_FILE
 
 cat > $upload_conf <<EOF
 #SSHPublicKey = pub-conffile
@@ -168,8 +156,6 @@ EOF
 
         rlAssertNotGrep "Using SSH public key 'pub-conffile'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-conffile'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH public key file 'pub-conffile'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-conffile'" $LOG_FILE
 
         rlFileRestore
     rlPhaseEnd
@@ -191,8 +177,6 @@ EOF
 
         rlAssertGrep "Using SSH public key 'pub-env-conf'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-env-conf'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-env-conf'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-env-conf'" $LOG_FILE
 
 cat > $event_upload_conf <<EOF
 Upload_URL = scp://root@localhost$TmpDir/target/upload.tar.gz
@@ -207,8 +191,6 @@ EOF
 
         rlAssertNotGrep "Using SSH public key 'pub-env-conf'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-env-conf'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH public key file 'pub-env-conf'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-env-conf'" $LOG_FILE
 
 cat > $event_upload_conf <<EOF
 Upload_URL = scp://root@localhost$TmpDir/target/upload.tar.gz
@@ -222,8 +204,6 @@ EOF
 
         rlAssertGrep "Using SSH public key 'pub-env-conf'" $LOG_FILE
         rlAssertNotGrep "Using SSH private key 'pri-env-conf'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-env-conf'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH private key file 'pri-env-conf'" $LOG_FILE
 
         rm -r $event_upload_conf
         rlFileRestore
@@ -251,8 +231,6 @@ EOF
 
         rlAssertGrep "Using SSH public key 'pub-env-xml'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-env-xml'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-env-xml'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-env-xml'" $LOG_FILE
 
         rlRun "cp -fv ${event_upload_xml}.backup $event_upload_xml"
 
@@ -263,8 +241,6 @@ EOF
 
         rlAssertGrep "Using SSH public key 'pub-env-xml'" $LOG_FILE
         rlAssertNotGrep "Using SSH private key 'pri-env-xml'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH public key file 'pub-env-xml'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH private key file 'pri-env-xml'" $LOG_FILE
 
         rlRun "cp -fv ${event_upload_xml}.backup $event_upload_xml"
 
@@ -275,8 +251,6 @@ EOF
 
         rlAssertNotGrep "Using SSH public key 'pub-env-xml'" $LOG_FILE
         rlAssertGrep "Using SSH private key 'pri-env-xml'" $LOG_FILE
-        rlAssertNotGrep "curl: Using SSH public key file 'pub-env-xml'" $LOG_FILE
-        rlAssertGrep "curl: Using SSH private key file 'pri-env-xml'" $LOG_FILE
 
         rlRun "mv -fv ${event_upload_xml}.backup $event_upload_xml"
         rm -r $event_upload_conf


### PR DESCRIPTION
With the advent of the libssh backend in curl, some of the expected
output might not be there. There is no way to check if the specified key
file is being used just by reading the output.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>