### PR TITLE
augeas: Adjust testsuite to changes in libreport

### DIFF
--- a/augeas/test_abrt.aug
+++ b/augeas/test_abrt.aug
@@ -52,44 +52,44 @@ AutoreportingEnabled = no
         { "#comment" = "in this directory (for example, uploaded via ftp, scp etc)." }
         { "#comment" = "Note: you must ensure that whatever directory you specify here exists" }
         { "#comment" = "and is writable for abrtd. abrtd will not create it automatically." }
-        { "#comment" = "" }
+        {}
         { "#comment" = "WatchCrashdumpArchiveDir = /var/spool/abrt-upload" }
         {}
         { "#comment" = "Max size for crash storage [MiB] or 0 for unlimited" }
-        { "#comment" = "" }
+        {}
         { "MaxCrashReportsSize" = "1000" }
         {}
         { "#comment" = "Specify where you want to store coredumps and all files which are needed for" }
         { "#comment" = "reporting. (default:/var/tmp/abrt)" }
-        { "#comment" = "" }
+        {}
         { "#comment" = "Changing dump location could cause problems with SELinux. See man abrt_selinux(8)." }
-        { "#comment" = "" }
+        {}
         { "#comment" = "DumpLocation = /var/tmp/abrt" }
         {}
         { "#comment" = "If you want to automatically clean the upload directory you have to tweak the" }
         { "#comment" = "selinux policy." }
-        { "#comment" = "" }
+        {}
         { "DeleteUploaded" = "no" }
         {}
         { "#comment" = "A name of event which is run automatically after problem's detection. The" }
         { "#comment" = "event should perform some fast analysis and exit with 70 if the" }
         { "#comment" = "problem is known." }
-        { "#comment" = "" }
+        {}
         { "#comment" = "In order to run this event automatically after detection, the" }
         { "#comment" = "AutoreportingEnabled option must be configured to 'yes'" }
-        { "#comment" = "" }
+        {}
         { "#comment" = "Default value: report_uReport" }
-        { "#comment" = "" }
+        {}
         { "AutoreportingEvent" = "report_uReport" }
         {}
         { "#comment" = "Enables automatic running of the event configured in AutoreportingEvent option." }
-        { "#comment" = "" }
+        {}
         { "AutoreportingEnabled" = "no" }
         {}
         { "#comment" = "Enables shortened GUI reporting where the reporting is interrupted after" }
         { "#comment" = "AutoreportingEvent is done." }
-        { "#comment" = "" }
+        {}
         { "#comment" = "Default value: Yes but only if application is running in GNOME desktop" }
         { "#comment" = "session; otherwise No." }
-        { "#comment" = "" }
+        {}
         { "#comment" = "ShortenedReporting = yes" }


### PR DESCRIPTION
This is a follow-up commit to the changes made in libreport:
https://github.com/abrt/libreport/pull/528/commits/5ad6d210c2fdbad88d56ae10c22a089824271392

Current lenses ignore empty comments (only '#' on the line) [1]

[1] http://augeas.net/docs/references/lenses/files/util-aug.html#Util.Comment

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>