### PR TITLE
spec: Add explicit package-version requirement for abrt-libs

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -182,6 +182,7 @@ Development libraries and headers for %{name}.
 
 %package gui-libs
 Summary: Libraries for %{name}-gui
+Requires: %{name}-libs = %{version}-%{release}
 
 %description gui-libs
 Libraries for %{name}-gui.
@@ -510,6 +511,7 @@ environment.
 %package atomic
 Summary: Package to make easy default installation on Atomic hosts.
 Requires: %{name}-addon-coredump-helper = %{version}-%{release}
+Requires: %{name}-libs = %{version}-%{release}
 Conflicts: %{name}-addon-ccpp
 
 %description atomic


### PR DESCRIPTION
Subpackage abrt-gui-libs, abrt-atomic consumes library libabrt.so.0()(64bit)
from subpackage abrt-libs but does not have explicit package version requirement.

Please add Requires: abrt-libs = %{version}-%{release} to abrt-gui-libs, abrt-atomic
in the specfile to avoid the need to test interoperability between the various combinations
of old and new subpackages.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>