### PR TITLE
Fix ShellCheck warnigs reported by Covscan

### DIFF
--- a/src/cli/abrt-console-notification.sh
+++ b/src/cli/abrt-console-notification.sh
@@ -26,11 +26,11 @@ if [ ! -f "$LPATHDIR" ]; then
     mkdir -p "$LPATHDIR" >"$ABRT_DEBUG_LOG" 2>&1 || return 0
 fi
 
-TMPPATH=`mktemp --tmpdir="$LPATHDIR" lastnotification.XXXXXXXX 2> "$ABRT_DEBUG_LOG"`
+TMPPATH=$(mktemp --tmpdir="$LPATHDIR" lastnotification.XXXXXXXX 2> "$ABRT_DEBUG_LOG")
 
 SINCE=0
 if [ -f "$SINCEFILE" ]; then
-    SINCE=`cat $SINCEFILE 2>"$ABRT_DEBUG_LOG"`
+    SINCE=$(cat "$SINCEFILE" 2>"$ABRT_DEBUG_LOG")
 fi
 
 # always update the lastnotification

--- a/src/cli/abrt-console-notification.sh
+++ b/src/cli/abrt-console-notification.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # If shell is not connect to a terminal, return immediately, because this script
 # should print out ABRT's status and it is senseless to continue without
 # terminal.

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -36,9 +36,7 @@ if $INSTALL_DI; then
         fi
     done
 
-    ${EXECUTABLE} ${EXTRA_ARGS} --size_mb=4096
-fi
-
-if [ $? = 0 ]; then
-    abrt-action-generate-backtrace && abrt-action-analyze-backtrace
+   if ${EXECUTABLE} "${EXTRA_ARGS}" --size_mb=4096; then
+       abrt-action-generate-backtrace && abrt-action-analyze-backtrace
+   fi
 fi

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -15,7 +15,7 @@ if $INSTALL_DI; then
     # debuginfo install fail even for root.
     # Therefore, if we are root, we don't use the wrapper.
     EXECUTABLE=@LIBEXEC_DIR@/abrt-action-install-debuginfo-to-abrt-cache
-    if [ x"`id -u`" = x"0" ]; then
+    if [ x"$(id -u)" = x"0" ]; then
         EXECUTABLE=abrt-action-install-debuginfo
     fi
 

--- a/src/plugins/abrt-action-analyze-ccpp-local.in
+++ b/src/plugins/abrt-action-analyze-ccpp-local.in
@@ -26,8 +26,9 @@ if $INSTALL_DI; then
     EXTRA_ARGS=
     for osrel in "${DUMP_DIR:-.}/os_info_in_rootdir" "${DUMP_DIR:-.}/os_info"
     do
-        if [ -e $osrel ]; then
-            . $osrel
+        if [ -e "$osrel" ]; then
+            # shellcheck source=/dev/null
+            . "$osrel"
             if [ -n "$VERSION_ID" ]; then
                 EXTRA_ARGS="--releasever=$VERSION_ID"
                 break

--- a/src/plugins/abrt-action-analyze-vulnerability.in
+++ b/src/plugins/abrt-action-analyze-vulnerability.in
@@ -2,8 +2,8 @@
 
 # Do we have the tools we need?
 # If no, exit silently.
-type @GDB@ >/dev/null 2>&1 || exit 0
-type eu-readelf >/dev/null 2>&1 || exit 0
+command -v @GDB@ >/dev/null 2>&1 || exit 0
+command -v eu-readelf >/dev/null 2>&1 || exit 0
 
 # Do we have coredump?
 test -r coredump || {


### PR DESCRIPTION
Fixes [ShellCheck](https://github.com/koalaman/shellcheck) warnings [SC2148](https://github.com/koalaman/shellcheck/wiki/SC2148), [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006), [SC1090](https://github.com/koalaman/shellcheck/wiki/SC1090), [SC2181](https://github.com/koalaman/shellcheck/wiki/SC2181), [SC2039](https://github.com/koalaman/shellcheck/wiki/SC2039).