### PR TITLE
testsuite: cli-process: Guard against multiple workflows

### DIFF
--- a/tests/runtests/cli-process/expect
+++ b/tests/runtests/cli-process/expect
@@ -1,10 +1,9 @@
 #!/usr/bin/expect -f
 
 set action [lindex $argv 0]
-set since [lindex $argv 1]
-set since_val [lindex $argv 2]
+set args [lrange $argv 1 end]
 
-spawn -noecho sh -c "abrt-cli p $since $since_val && sleep 0.5"
+spawn -noecho sh -c "abrt-cli $args && sleep 0.5"
 
 set timeout 10
 
@@ -20,6 +19,10 @@ while {1} {
         eof {break}
 
         timeout { itstime }
+
+        -re {([[:digit:]]+)(?= Report testing)} {
+            send "$expect_out(0,string)\n"
+        }
 
         "Actions: remove(rm), report(e), info(i), skip(s):" {
             send "$action\n"

--- a/tests/runtests/cli-process/runtest.sh
+++ b/tests/runtests/cli-process/runtest.sh
@@ -49,7 +49,7 @@ rlJournalStart
         wait_for_hooks
         get_crash_path
 
-        rlRun "./expect skip &> process.log" 0 "Running abrt-cli process via expect"
+        rlRun "./expect s process $crash_PATH &> process.log" 0 "Running abrt-cli process via expect"
 
         rlAssertGrep "reason:" process.log
         rlAssertGrep "time:" process.log
@@ -63,7 +63,7 @@ rlJournalStart
     rlPhaseStartTest "process action info"
 
         #abrt-cli info $crash_PATH
-        rlRun "./expect info &> process-info.log" 0 "Running abrt-cli info via expect"
+        rlRun "./expect i process $crash_PATH &> process-info.log" 0 "Running abrt-cli info via expect"
 
         rlAssertGrep "reason:" process-info.log
         rlAssertGrep "time:" process-info.log
@@ -84,7 +84,7 @@ rlJournalStart
         rlRun "echo not-reportable > $crash_PATH/not-reportable" 0 "Creating not-reportable file"
 
         #abrt-cli skip $crash_PATH
-        rlRun "./expect skip &> notrep.log" 0 "Running abrt-cli skip via expect"
+        rlRun "./expect s process $crash_PATH &> notrep.log" 0 "Running abrt-cli skip via expect"
 
         rlAssertGrep "reason:" notrep.log
         rlAssertGrep "time:" notrep.log
@@ -96,7 +96,7 @@ rlJournalStart
         rlRun "rm -f $crash_PATH/not-reportable" 0 "Removing not-reportable file"
 
         #abrt-cli skip $crash_PATH
-        rlRun "./expect skip &> notrep.log" 0 "Running abrt-cli skip via expect"
+        rlRun "./expect s process $crash_PATH &> notrep.log" 0 "Running abrt-cli skip via expect"
 
         rlAssertGrep "reason:" notrep.log
         rlAssertGrep "time:" notrep.log
@@ -159,8 +159,8 @@ EOF
 
         rlAssertExists "$event_conf_file"
 
-        rlRun "./expect report &> process_report.log" 0 "Running abrt-cli reporting via expect"
-        rlRun "abrt-cli e $crash_PATH &> report.log"
+        rlRun "./expect e process $crash_PATH &> process_report.log" 0 "Running abrt-cli reporting via expect"
+        rlRun "./expect - report $crash_PATH &> report.log" 0 "Running abrt-cli reporting via expect"
 
         rlAssertGrep "$(cat report.log)" process_report.log
 
@@ -222,8 +222,8 @@ EOF
 
         rlAssertExists "$event_conf_file"
 
-        rlRun "./expect report --unsafe &> process_report_unsafe.log" 0 "Running abrt-cli reporting via expect"
-        rlRun "abrt-cli e --unsafe $crash_PATH &> report_unsafe.log"
+        rlRun "./expect e process --unsafe $crash_PATH &> process_report_unsafe.log" 0 "Running abrt-cli reporting via expect"
+        rlRun "./expect - report --unsafe $crash_PATH &> report_unsafe.log" 0 "Running abrt-cli reporting via expect"
 
         rlAssertGrep "$(cat report_unsafe.log)" process_report_unsafe.log
 
@@ -238,7 +238,7 @@ EOF
         rlAssertExists "$crash_PATH"
 
         #abrt-cli remove
-        rlRun "./expect remove" 0 "Running abrt-cli remove via expect"
+        rlRun "./expect rm process $crash_PATH" 0 "Running abrt-cli remove via expect"
 
         rlAssertNotExists "$crash_PATH"
 
@@ -268,7 +268,7 @@ EOF
 
         rlLog "PATH2 = $crash2_PATH"
 
-        rlRun "./expect skip --since $second_crash_last_occurrence &> since.log" 0 "Running abrt-cli skip --since via expect"
+        rlRun "./expect s process --since $second_crash_last_occurrence &> since.log" 0 "Running abrt-cli skip --since via expect"
 
         rlAssertGrep "$crash2_PATH" since.log
         rlAssertNotGrep "$crash_PATH" since.log


### PR DESCRIPTION
RHEL builds include a uReport workflow, which gets picked up even with a
custom problem type and analyzer. This commit adds a regex to the expect
script that grabs the index of the test workflow and chooses it.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>