### PR TITLE
applet: Add systemd service unit

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -668,11 +668,8 @@ mkdir -p $RPM_BUILD_ROOT/var/%{var_base_dir}/abrt
 mkdir -p $RPM_BUILD_ROOT/var/spool/abrt-upload
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/abrt
 
-desktop-file-install \
-        --dir ${RPM_BUILD_ROOT}%{_datadir}/applications \
-        src/applet/org.freedesktop.problems.applet.desktop
-
-ln -sf %{_datadir}/applications/org.freedesktop.problems.applet.desktop ${RPM_BUILD_ROOT}%{_sysconfdir}/xdg/autostart/
+desktop-file-validate \
+        ${RPM_BUILD_ROOT}%{_datadir}/applications/org.freedesktop.problems.applet.desktop
 
 # After everything is installed, remove info dir
 rm -f %{buildroot}%{_infodir}/dir
@@ -780,6 +777,13 @@ chown -R abrt:abrt %{_localstatedir}/cache/abrt-di
 %post gui
 # update icon cache
 touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
+%systemd_user_post abrt-applet.service
+
+%preun gui
+%systemd_user_preun abrt-applet.service
+
+%postun gui
+%systemd_user_postun_with_restart abrt-applet.service
 
 %if %{with atomic}
 %post atomic
@@ -979,8 +983,8 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_bindir}/system-config-abrt
 #%%{_bindir}/test-report
 %{_datadir}/applications/org.freedesktop.problems.applet.desktop
-%config(noreplace) %{_sysconfdir}/xdg/autostart/org.freedesktop.problems.applet.desktop
 %{_datadir}/dbus-1/services/org.freedesktop.problems.applet.service
+%{_userunitdir}/abrt-applet.service
 %{_mandir}/man1/abrt-applet.1*
 %{_mandir}/man1/system-config-abrt.1*
 

--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,13 @@ AC_ARG_WITH([dbusinterfacedir],
         [], [with_dbusinterfacedir=${datadir}/dbus-1/interfaces])
 AC_SUBST([dbusinterfacedir], [$with_dbusinterfacedir])
 
+AC_ARG_WITH([systemduserunitdir],
+            [AS_HELP_STRING([--with-systemduserunitdir=DIR],
+                            [Directory for systemd user service unit files (default=PREFIX/lib/systemd/user)])],
+            [],
+            [with_systemduserunitdir='${prefix}/lib/systemd/user'])
+AC_SUBST([systemduserunitdir], [$with_systemduserunitdir])
+
 AC_ARG_WITH(largedatatmpdir,
             [AS_HELP_STRING([--with-largedatatmpdir=DIR],
                            [Directory where potentially large data are created (default: /var/tmp)])],
@@ -505,6 +512,7 @@ AC_CONFIG_FILES([
 	src/daemon/abrt-handle-upload
 	src/hooks/Makefile
 	src/applet/Makefile
+	src/applet/systemd/Makefile
 	src/cli/Makefile
 	src/cli-ng/Makefile
 	src/cli-ng/abrtcli/Makefile

--- a/src/applet/Makefile.am
+++ b/src/applet/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = systemd
+
 bin_PROGRAMS = abrt-applet
 #test-report
 
@@ -26,11 +28,6 @@ abrt_applet_LDADD =       \
 
 @INTLTOOL_DESKTOP_RULE@
 
-autostartdir = $(sysconfdir)/xdg/autostart
-autostart_in_files = org.freedesktop.problems.applet.desktop.in
-
-autostart_DATA = $(autostart_in_files:.desktop.in=.desktop)
-
 dbusservicedir = $(datadir)/dbus-1/services
 dbusservice_in_files = org.freedesktop.problems.applet.service.in
 
@@ -39,8 +36,11 @@ dbusservice_DATA = org.freedesktop.problems.applet.service
 org.freedesktop.problems.applet.service: org.freedesktop.problems.applet.service.in Makefile
 	$(AM_V_GEN) sed -e "s|\@bindir\@|$(bindir)|" $< > $@
 
-CLEANFILES = $(autostart_in_files:.desktop.in=.desktop)
+desktopdir = $(datadir)/applications
+desktop_in_files = org.freedesktop.problems.applet.desktop.in
+
+desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
 EXTRA_DIST =              \
-    $(autostart_in_files) \
-    $(dbusservice_in_files)
+    $(dbusservice_in_files) \
+    $(desktop_in_files)

--- a/src/applet/org.freedesktop.problems.applet.service.in
+++ b/src/applet/org.freedesktop.problems.applet.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.problems.applet
 Exec=@bindir@/abrt-applet --gapplication-service
+SystemdService=abrt-applet.service

--- a/src/applet/systemd/Makefile.am
+++ b/src/applet/systemd/Makefile.am
@@ -1,0 +1,7 @@
+systemduserunit_DATA = abrt-applet.service
+
+abrt-applet.service: abrt-applet.service.in
+	$(AM_V_GEN) sed -e "s|\@bindir\@|$(bindir)|" $< > $@
+
+EXTRA_DIST = \
+	abrt-applet.service.in

--- a/src/applet/systemd/abrt-applet.service.in
+++ b/src/applet/systemd/abrt-applet.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=ABRT Notification Daemon
+PartOf=graphical-session.target
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.problems.applet
+ExecStart=@bindir@/abrt-applet --gapplication-service
+Restart=on-failure
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Since using an autostart desktop file causes troubles on GNOME
(gnome-session chokes with D-Bus-activatable ones), having systemd
manage that instead probably makes more sense.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>