### PR TITLE
dbus: entry: Don’t claim truncation when there was none

### DIFF
--- a/src/dbus/abrt_problems2_entry.c
+++ b/src/dbus/abrt_problems2_entry.c
@@ -796,7 +796,7 @@ int abrt_p2_entry_save_elements_in_dump_dir(struct dump_dir *dd,
                 continue;
             }
 
-            if (r >= max_size)
+            if (r < item_stat.st_size && r >= max_size)
             {
                 error_msg("File descriptor was truncated due to size limit");
 


### PR DESCRIPTION
When saving elements, if the file being copied exceeds size the limit,
the code will yell and bail. An issue with that is that the comparison
is not strict, which causes false positives when the actual file size is
equal to the limit.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>