### PR TITLE
configure.ac: Add dependency on libcap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,7 @@ PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0])
 PKG_CHECK_MODULES([SATYR], [satyr])
 PKG_CHECK_MODULES([SYSTEMD], [libsystemd])
 PKG_CHECK_MODULES([GSETTINGS_DESKTOP_SCHEMAS], [gsettings-desktop-schemas >= 3.15.1])
+PKG_CHECK_MODULES([LIBCAP], [libcap])
 
 PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([dbusinterfacedir],


### PR DESCRIPTION
Since abrt-hook-ccpp requires libcap for sys/capabilities.h and the spec
file has a build-time dependency, one should be added to the autoconf
file as well.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>