### PR TITLE
plugins: Fix name of env variable for retrace server

### DIFF
--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -238,10 +238,56 @@ static int create_archive(bool unlink_temp)
     return tempfd;
 }
 
+G_GNUC_NULL_TERMINATED
+static SoupURI *build_uri_from_config(struct https_cfg *config,
+                                      const char       *segment,
+                                      ...)
+{
+    SoupURI *uri;
+    va_list args;
+    g_autofree const char *path = NULL;
+
+    g_return_val_if_fail(NULL != config, NULL);
+
+    uri = soup_uri_new_with_base(NULL, config->uri);
+    /* Really only for compatibility. */
+    if (NULL == soup_uri_get_scheme(uri))
+    {
+        g_autofree char *uri_string = NULL;
+
+        uri_string = g_strdup_printf("https://%s", config->uri);
+        uri = soup_uri_new(uri_string);
+    }
+
+    if (NULL == segment)
+    {
+        return uri;
+    }
+
+    path = soup_uri_get_path(uri);
+    path = g_build_path("/", path, segment, NULL);
+
+    va_start(args, segment);
+
+    for (segment = va_arg(args, const char *); NULL != segment; segment = va_arg(args, const char *))
+    {
+        g_autofree const char *tmp = NULL;
+
+        tmp = path;
+        path = g_build_path("/", path, segment, NULL);
+    }
+
+    va_end(args);
+
+    soup_uri_set_path(uri, path);
+
+    return uri;
+}
+
 struct retrace_settings *get_settings(SoupSession *session)
 {
     struct retrace_settings *settings;
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     guint response_code;
     g_autoptr(SoupBuffer) response = NULL;
@@ -250,8 +296,8 @@ struct retrace_settings *get_settings(SoupSession *session)
     const char *row;
 
     settings = xzalloc(sizeof(*settings));
-    uri = g_strdup_printf("%s/settings", cfg.uri);
-    message = soup_message_new("GET", uri);
+    uri = build_uri_from_config(&cfg, "settings", NULL);
+    message = soup_message_new_from_uri("GET", uri);
 
     soup_message_headers_append(message->request_headers, "Accept-Charset", lang.charset);
 
@@ -417,14 +463,14 @@ static int check_package(SoupSession   *session,
                          char         **msg)
 {
     g_autofree char *release_id = NULL;
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     guint response_code;
     g_autoptr(SoupBuffer) response = NULL;
 
     release_id = get_release_id(osinfo, arch);
-    uri = g_strdup_printf("%s/checkpackage", cfg.uri);
-    message = soup_message_new("GET", uri);
+    uri = build_uri_from_config(&cfg, "checkpackage", NULL);
+    message = soup_message_new_from_uri("GET", uri);
 
     soup_message_headers_append(message->request_headers, "X-Package-NVR", nvr);
     soup_message_headers_append(message->request_headers, "X-Package-Arch", arch);
@@ -714,7 +760,7 @@ static int create(SoupSession  *session,
         }
     }
 
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     g_autoptr(GMappedFile) file = NULL;
     char *contents;
@@ -724,8 +770,8 @@ static int create(SoupSession  *session,
     g_autoptr(SoupBuffer) response = NULL;
     const char *header_value;
 
-    uri = g_strdup_printf("%s/create", cfg.uri);
-    message = soup_message_new("POST", uri);
+    uri = build_uri_from_config(&cfg, "create", NULL);
+    message = soup_message_new_from_uri("POST", uri);
     file = g_mapped_file_new_from_fd(tempfd, FALSE, NULL);
     contents = g_mapped_file_get_contents(file);
     task_type_string = g_strdup_printf("%d", task_type);
@@ -840,14 +886,14 @@ static void status(SoupSession  *session,
                    char        **task_status,
                    char        **status_message)
 {
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     guint response_code;
     g_autoptr(SoupBuffer) response = NULL;
     const char *task_status_header;
 
-    uri = g_strdup_printf("%s/%s", cfg.uri, task_id);
-    message = soup_message_new("GET", uri);
+    uri = build_uri_from_config(&cfg, task_id, NULL);
+    message = soup_message_new_from_uri("GET", uri);
 
     soup_message_headers_append(message->request_headers, "X-Task-Password", task_password);
     soup_message_headers_append(message->request_headers, "Accept-Charset", lang.charset);
@@ -902,13 +948,13 @@ static void backtrace(SoupSession  *session,
                       const char   *task_password,
                       char        **backtrace)
 {
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     guint response_code;
     g_autoptr(SoupBuffer) response = NULL;
 
-    uri = g_strdup_printf("%s/%s/backtrace", cfg.uri, task_id);
-    message = soup_message_new("GET", uri);
+    uri = build_uri_from_config(&cfg, task_id, "backtrace", NULL);
+    message = soup_message_new_from_uri("GET", uri);
 
     soup_message_headers_append(message->request_headers, "X-Task-Password", task_password);
     soup_message_headers_append(message->request_headers, "Accept-Charset", lang.charset);
@@ -968,13 +1014,13 @@ static void exploitable(SoupSession  *session,
                         const char   *task_password,
                         char        **exploitable_text)
 {
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     guint response_code;
     g_autoptr(SoupBuffer) response = NULL;
 
-    uri = g_strdup_printf("%s/%s/exploitable", cfg.uri, task_id);
-    message = soup_message_new("GET", uri);
+    uri = build_uri_from_config(&cfg, task_id, "exploitable", NULL);
+    message = soup_message_new_from_uri("GET", uri);
 
     soup_message_headers_append(message->request_headers, "X-Task-Password", task_password);
     soup_message_headers_append(message->request_headers, "Accept-Charset", lang.charset);
@@ -1029,13 +1075,13 @@ static void run_log(SoupSession *session,
                     const char  *task_id,
                     const char  *task_password)
 {
-    g_autofree char *uri = NULL;
+    g_autoptr(SoupURI) uri = NULL;
     g_autoptr(SoupMessage) message = NULL;
     guint response_code;
     g_autoptr(SoupBuffer) response = NULL;
 
-    uri = g_strdup_printf("%s/%s/log", cfg.uri, task_id);
-    message = soup_message_new("GET", uri);
+    uri = build_uri_from_config(&cfg, task_id, "log", NULL);
+    message = soup_message_new_from_uri("GET", uri);
 
     soup_message_headers_append(message->request_headers, "X-Task-Password", task_password);
     soup_message_headers_append(message->request_headers, "Accept-Charset", lang.charset);

--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -557,6 +557,8 @@ static int create(SoupSession  *session,
 
     struct retrace_settings *settings = get_settings(session);
 
+    g_return_val_if_fail(NULL != settings, EXIT_FAILURE);
+
     if (settings->running_tasks >= settings->max_running_tasks)
     {
         alert(_("The server is fully occupied. Try again later."));

--- a/src/plugins/analyze_RetraceServer.xml.in
+++ b/src/plugins/analyze_RetraceServer.xml.in
@@ -14,7 +14,7 @@
 
         <option type="text" name="RETRACE_SERVER_URI">
            <_label>Retrace server URI</_label>
-           <default-value>retrace.fedoraproject.org</default-value>
+           <default-value>https://retrace.fedoraproject.org</default-value>
            <allow-empty>no</allow-empty>
            <_description>Address of the retrace server</_description>
        </option>

--- a/src/plugins/analyze_RetraceServer.xml.in
+++ b/src/plugins/analyze_RetraceServer.xml.in
@@ -12,8 +12,8 @@
     <options>
         <import-event-options event="report_Bugzilla"/>
 
-        <option type="text" name="RETRACE_SERVER_URL">
-           <_label>Retrace server URL</_label>
+        <option type="text" name="RETRACE_SERVER_URI">
+           <_label>Retrace server URI</_label>
            <default-value>retrace.fedoraproject.org</default-value>
            <allow-empty>no</allow-empty>
            <_description>Address of the retrace server</_description>

--- a/tests/runtests/abrt-cli-report-mantisbt/runtest.sh
+++ b/tests/runtests/abrt-cli-report-mantisbt/runtest.sh
@@ -70,7 +70,7 @@ EOF
 
     # retrace server
     cat > $retrace_conf << EOF
-RETRACE_SERVER_URL = 127.0.0.1
+RETRACE_SERVER_URI = 127.0.0.1
 RETRACE_SERVER_INSECURE = insecure
 EOF
 
@@ -138,7 +138,7 @@ function restore_configuration()
     rlRun "cp -v $retrace_event_conf'.backup' $retrace_event_conf" 0
     rlRun "rm -f $mantis_format_conf" 0
 
-    rlRun "unset RETRACE_SERVER_URL" 0
+    rlRun "unset RETRACE_SERVER_URI" 0
     rlRun "unset RETRACE_SERVER_PORT" 0
     rlRun "unset RETRACE_SERVER_INSECURE" 0
 }

--- a/tests/runtests/abrt-cli-report-mantisbt/runtest.sh
+++ b/tests/runtests/abrt-cli-report-mantisbt/runtest.sh
@@ -70,12 +70,11 @@ EOF
 
     # retrace server
     cat > $retrace_conf << EOF
-RETRACE_SERVER_URI = 127.0.0.1
+RETRACE_SERVER_URI = https://127.0.0.1:$retrace_server_port
 RETRACE_SERVER_INSECURE = insecure
 EOF
 
     rlAssert0 "set $retrace_conf" $?
-    rlRun "export RETRACE_SERVER_PORT=$retrace_server_port" 0 "exporting RETRACE_SERVER_PORT env"
 
     cat > $report_centos_conf << EOF
 Mantisbt_MantisbtURL = localhost:$mantisbt_port
@@ -139,7 +138,6 @@ function restore_configuration()
     rlRun "rm -f $mantis_format_conf" 0
 
     rlRun "unset RETRACE_SERVER_URI" 0
-    rlRun "unset RETRACE_SERVER_PORT" 0
     rlRun "unset RETRACE_SERVER_INSECURE" 0
 }
 


### PR DESCRIPTION
In f1d99e1d7593ab49147268b383cc82acbb0d94c1 the RETRACE_SERVER_URL was changed to RETRACE_SERVER_URI.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>