### PR TITLE
testsuite: test_order: Add abrt-auto-reporting-sanity-authenticated

### DIFF
--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -17,6 +17,7 @@ abrtd-concurrent-processing
 abrtd-infinite-event-loop
 symlinks-rhbz-895442
 abrt-auto-reporting-sanity
+abrt-auto-reporting-sanity-authenticated
 meaningful-logs
 abrt-crash-unpackaged
 


### PR DESCRIPTION
It was never added after the split.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>