### PR TITLE
spec: Require dbus-tools

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -462,6 +462,7 @@ hosts.
 Summary: ABRT DBus service
 Requires: %{name} = %{version}-%{release}
 Requires: abrt-libs = %{version}-%{release}
+Requires: dbus-tools
 
 %description dbus
 ABRT DBus service which provides org.freedesktop.problems API on dbus and


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1686864

`abrt-dbus` requires `dbus-send` in order to function properly.