### PR TITLE
Remove default configuration files

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -687,24 +687,14 @@ if [ -f /etc/abrt/plugins/CCpp.conf ]; then
     mv /etc/abrt/plugins/CCpp.conf /etc/abrt/plugins/CCpp.conf.rpmsave.atomic || exit 1;
 fi
 ln -sf /etc/abrt/plugins/CCpp_Atomic.conf /etc/abrt/plugins/CCpp.conf
-if [ -f /usr/share/abrt/conf.d/plugins/CCpp.conf ]; then
-    mv /usr/share/abrt/conf.d/plugins/CCpp.conf /usr/share/abrt/conf.d/plugins/CCpp.conf.rpmsave.atomic || exit 1;
-fi
-ln -sf /usr/share/abrt/conf.d/plugins/CCpp_Atomic.conf /usr/share/abrt/conf.d/plugins/CCpp.conf
 %systemd_post abrt-coredump-helper.service
 
 %preun atomic
 if [ -L /etc/abrt/plugins/CCpp.conf ]; then
     rm /etc/abrt/plugins/CCpp.conf
 fi
-if [ -L /usr/share/abrt/conf.d/plugins/CCpp.conf ]; then
-    rm /usr/share/abrt/conf.d/plugins/CCpp.conf
-fi
 if [ -f /etc/abrt/plugins/CCpp.conf.rpmsave.atomic ]; then
     mv /etc/abrt/plugins/CCpp.conf.rpmsave.atomic /etc/abrt/plugins/CCpp.conf || exit 1
-fi
-if [ -f  /usr/share/abrt/conf.d/plugins/CCpp.conf.rpmsave.atomic ]; then
-    mv /usr/share/abrt/conf.d/plugins/CCpp.conf.rpmsave.atomic /usr/share/abrt/conf.d/plugins/CCpp.conf || exit 1
 fi
 
 %postun atomic
@@ -806,12 +796,9 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_bindir}/abrt-action-analyze-xorg
 %config(noreplace) %{_sysconfdir}/dbus-1/system.d/org.freedesktop.problems.daemon.conf
 %config(noreplace) %{_sysconfdir}/%{name}/abrt-action-save-package-data.conf
-%{_datadir}/%{name}/conf.d/abrt-action-save-package-data.conf
 %config(noreplace) %{_sysconfdir}/%{name}/plugins/xorg.conf
-%{_datadir}/%{name}/conf.d/plugins/xorg.conf
 %{_mandir}/man5/abrt-xorg.conf.5*
 %config(noreplace) %{_sysconfdir}/%{name}/gpg_keys.conf
-%{_datadir}/%{name}/conf.d/gpg_keys.conf
 %{_mandir}/man5/gpg_keys.conf.5*
 %config(noreplace) %{_sysconfdir}/libreport/events.d/abrt_event.conf
 %{_mandir}/man5/abrt_event.conf.5*
@@ -838,13 +825,9 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %files libs
 %{_libdir}/libabrt.so.*
 %config(noreplace) %{_sysconfdir}/%{name}/abrt.conf
-%{_datadir}/%{name}/conf.d/abrt.conf
 %{_mandir}/man5/abrt.conf.5*
 %dir %{_sysconfdir}/%{name}
 %dir %{_sysconfdir}/%{name}/plugins
-%dir %{_datadir}/%{name}
-%dir %{_datadir}/%{name}/conf.d
-%dir %{_datadir}/%{name}/conf.d/plugins
 
 # filesystem package should own /usr/share/augeas/lenses directory
 %{_datadir}/augeas/lenses/abrt.aug
@@ -891,7 +874,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %files addon-ccpp
 %dir %attr(0775, abrt, abrt) %{_localstatedir}/cache/abrt-di
 %config(noreplace) %{_sysconfdir}/%{name}/plugins/CCpp.conf
-%{_datadir}/%{name}/conf.d/plugins/CCpp.conf
 %{_mandir}/man5/abrt-CCpp.conf.5*
 %{_libexecdir}/abrt-gdb-exploitable
 %{_journalcatalogdir}/abrt_ccpp.catalog
@@ -965,7 +947,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %config(noreplace) %{_sysconfdir}/libreport/plugins/catalog_koops_format.conf
 %{_mandir}/man5/koops_event.conf.5*
 %config(noreplace) %{_sysconfdir}/%{name}/plugins/oops.conf
-%{_datadir}/%{name}/conf.d/plugins/oops.conf
 %{_unitdir}/abrt-oops.service
 
 %dir %{_localstatedir}/lib/abrt
@@ -993,7 +974,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %config(noreplace) %{_sysconfdir}/libreport/events.d/vmcore_event.conf
 %{_mandir}/man5/vmcore_event.conf.5*
 %config(noreplace) %{_sysconfdir}/%{name}/plugins/vmcore.conf
-%{_datadir}/%{name}/conf.d/plugins/vmcore.conf
 %{_datadir}/libreport/events/analyze_VMcore.xml
 %{_unitdir}/abrt-vmcore.service
 %{_sbindir}/abrt-harvest-vmcore
@@ -1017,7 +997,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %if %{with python3}
 %files -n python3-abrt-addon
 %config(noreplace) %{_sysconfdir}/%{name}/plugins/python3.conf
-%{_datadir}/%{name}/conf.d/plugins/python3.conf
 %{_mandir}/man5/abrt-python3.conf.5*
 %config(noreplace) %{_sysconfdir}/libreport/events.d/python3_event.conf
 %{_journalcatalogdir}/abrt_python3.catalog
@@ -1060,7 +1039,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %files atomic
 %config(noreplace) %{_sysconfdir}/%{name}/plugins/CCpp_Atomic.conf
 %{_unitdir}/abrt-coredump-helper.service
-%{_datadir}/%{name}/conf.d/plugins/CCpp_Atomic.conf
 %config(noreplace) %{_sysconfdir}/%{name}/abrt-action-save-package-data.conf
 %{_bindir}/abrt-action-save-package-data
 %{_mandir}/man1/abrt-action-save-package-data.1*

--- a/augeas/abrt.aug
+++ b/augeas/abrt.aug
@@ -5,8 +5,6 @@ module Abrt =
 
     let filter = (incl "/etc/abrt/*.conf" )
                . (incl "/etc/abrt/plugins/*")
-               . (incl "/usr/share/abrt/conf.d/*")
-               . (incl "/usr/share/abrt/conf.d/plugins/*")
                . Util.stdexcl
 
    let xfm = transform lns filter

--- a/configure.ac
+++ b/configure.ac
@@ -192,11 +192,9 @@ AC_CHECK_HEADER([sys/inotify.h], [],
 AC_CHECK_HEADERS([locale.h])
 
 CONF_DIR='${sysconfdir}/${PACKAGE_NAME}'
-DEFAULT_CONF_DIR='${datadir}/${PACKAGE_NAME}/conf.d'
 VAR_RUN='${localstatedir}/run'
 VAR_STATE='${localstatedir}/lib/${PACKAGE_NAME}'
 PLUGINS_CONF_DIR='${sysconfdir}/${PACKAGE_NAME}/plugins'
-DEFAULT_PLUGINS_CONF_DIR='${datadir}/${PACKAGE_NAME}/conf.d/plugins'
 EVENTS_DIR='${datadir}/libreport/events'
 EVENTS_CONF_DIR='${sysconfdir}/libreport/events.d'
 JOURNAL_CATALOG_DIR='$(prefix)/lib/systemd/catalog'
@@ -336,11 +334,9 @@ AC_ARG_ENABLE([dump-time-unwind],
 [fi]
 
 AC_SUBST(CONF_DIR)
-AC_SUBST(DEFAULT_CONF_DIR)
 AC_SUBST(VAR_RUN)
 AC_SUBST(VAR_STATE)
 AC_SUBST(PLUGINS_CONF_DIR)
-AC_SUBST(DEFAULT_PLUGINS_CONF_DIR)
 AC_SUBST(EVENTS_CONF_DIR)
 AC_SUBST(JOURNAL_CATALOG_DIR)
 AC_SUBST(EVENTS_DIR)

--- a/doc/abrt-CCpp.conf.txt
+++ b/doc/abrt-CCpp.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 abrt-CCpp.conf - Configuration file for ABRT's core dump crash hook
 
+SYNOPSIS
+--------
+/etc/abrt/plugins/CCpp.conf
+
 DESCRIPTION
 -----------
 The configuration file consists of items in the format "Option = Value".
@@ -64,6 +68,10 @@ AllowedGroups = root, wheel, ...::
 
 VerboseLog = NUM::
    Used to make the hook more verbose
+
+FILES
+-----
+/etc/abrt/plugins/CCpp.conf
 
 SEE ALSO
 --------

--- a/doc/abrt-action-save-package-data.conf.txt
+++ b/doc/abrt-action-save-package-data.conf.txt
@@ -6,6 +6,10 @@ NAME
 abrt-action-save-package-data.conf - Configuration file for
 abrt-action-save-package-data
 
+SYNOPSIS
+--------
+/etc/abrt/abrt-action-save-package-data.conf
+
 DESCRIPTION
 -----------
 The 'abrt-action-save-package-data' tool queries RPM database and saves package
@@ -31,9 +35,13 @@ ProcessUnpackaged = 'yes' | 'no'::
    to an installed package.
    The default is 'no'.
 
+FILES
+-----
+/etc/abrt/abrt-action-save-package-data.conf
+
 SEE ALSO
 --------
-abrt.conf(5)
+abrt.conf(5), gpg_keys.conf(5)
 
 AUTHORS
 -------

--- a/doc/abrt-configuration.txt
+++ b/doc/abrt-configuration.txt
@@ -43,7 +43,6 @@ Example of the configuration XML file:
 ------------
 <node name="/com/redhat/problems/configuration/ccpp">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/plugins/CCpp.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/plugins/CCpp.conf" />
 
     <interface name="com.redhat.problems.configuration.ccpp">
         <property name="MakeCompatCore" type="b" access="readwrite"/>

--- a/doc/abrt-oops.conf.txt
+++ b/doc/abrt-oops.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 abrt-oops.conf - Configuration file for ABRT's Kernel Oops extractor
 
+SYNOPSIS
+--------
+/etc/abrt/plugins/oops.conf
+
 DESCRIPTION
 -----------
 The configuration file consists of items in the format "Option = Value".
@@ -17,6 +21,10 @@ DropNotReportableOopses = 'yes' / 'no'
 OnlyFatalMCE = 'yes' / 'no'
    If you want to see only fatal MCEs, set to "yes".
    Defaults is 'yes': detect only fatal ones.
+
+FILES
+-----
+/etc/abrt/plugins/oops.conf
 
 SEE ALSO
 --------

--- a/doc/abrt-python3.conf.txt
+++ b/doc/abrt-python3.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 abrt-python3.conf - Configuration file for ABRT's python 3 crash hook
 
+SYNOPSIS
+--------
+/etc/abrt/plugins/python3.conf
+
 DESCRIPTION
 -----------
 Currently, only one item exists:
@@ -14,6 +18,10 @@ RequireAbsolutePath = 'yes' / 'no' ...::
    and saved even in scripts which are run without full path
    in sys.argv[0].
    Default is 'yes': do not save them.
+
+FILES
+-----
+/etc/abrt/plugins/python3.conf
 
 SEE ALSO
 --------

--- a/doc/abrt-vmcore.conf.txt
+++ b/doc/abrt-vmcore.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 abrt-vmcore.conf - Configuration file for Configuration file for ABRT's VMCore addon
 
+SYNOPSIS
+--------
+/etc/abrt/plugins/vmcore.conf
+
 DESCRIPTION
 -----------
 The configuration file consists of items in the format "Option = Value".
@@ -14,6 +18,10 @@ CopyVMcore = 'yes' / 'no'::
    Set to 'no' if you want vmcore to be moved, not copied, from /var/crash
    to ABRT's main problem directory.
    Default is to copy vmcore.
+
+FILES
+-----
+/etc/abrt/plugins/vmcore.conf
 
 SEE ALSO
 --------

--- a/doc/abrt-xorg.conf.txt
+++ b/doc/abrt-xorg.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 abrt-xorg.conf - Configuration file for abrt-action-analyze-xorg
 
+SYNOPSIS
+--------
+/etc/abrt/plugins/xorg.conf
+
 DESCRIPTION
 -----------
 The 'abrt-action-analyze-xorg' tool processes Xorg crash problem data
@@ -17,6 +21,10 @@ BlacklistedXorgModules = 'moduleName', 'moduleName' ...::
    Xorg crash will be ignored if any of the listed Xorg modules were loaded
    at the time of the crash. Module names should be without "_drv.so" suffix:
    use 'buggymodule', not 'buggymodule_drv' or 'buggymodule_drv.so'.
+
+FILES
+-----
+/etc/abrt/plugins/xorg.conf
 
 SEE ALSO
 --------

--- a/doc/abrt.conf.txt
+++ b/doc/abrt.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 abrt.conf - Configuration file for abrt.
 
+SYNOPSIS
+--------
+/etc/abrt/abrt.conf
+
 DESCRIPTION
 -----------
 'abrt' is a daemon that watches for application crashes. When a crash occurs, it
@@ -66,6 +70,9 @@ ExploreChroots = 'true/false'::
      * save files like /etc/os-release from the process's root directory
    Default is false.
 
+FILES
+-----
+/etc/abrt/abrt.conf
 
 SEE ALSO
 --------

--- a/doc/abrtd.txt
+++ b/doc/abrtd.txt
@@ -51,10 +51,15 @@ application type (for example BugBuddy for GNOME applications), crashes of this
 type will be handled by that tool and not by 'abrtd'. If you want 'abrtd' to
 handle these crashes, turn off the higher-level crash-catching tool.
 
-AUTHORS
--------
-* ABRT team
+FILES
+-----
+/etc/abrt/abrt.conf::
+    Configuration file for the daemon.
 
 SEE ALSO
 --------
 abrt.conf(5)
+
+AUTHORS
+-------
+* ABRT team

--- a/doc/dbus-configuration/com.redhat.problems.configuration.abrt.xml.in
+++ b/doc/dbus-configuration/com.redhat.problems.configuration.abrt.xml.in
@@ -3,7 +3,6 @@
 
 <node name="/com/redhat/problems/configuration/abrt">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/abrt.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/abrt.conf" /> 
 
     <interface name="com.redhat.problems.configuration.abrt">
         <property name="WatchCrashdumpArchiveDir" type="s" access="readwrite">
@@ -22,32 +21,26 @@
 
         <property name="OpenGPGCheck" type="b" access="readwrite">
             <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/abrt-action-save-package-data.conf" />
-            <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/abrt-action-save-package-data.conf" /> 
         </property>
 
         <property name="BlackList" type="as" access="readwrite">
             <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/abrt-action-save-package-data.conf" />
-            <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/abrt-action-save-package-data.conf" /> 
         </property>
 
         <property name="BlackListPaths" type="as" access="readwrite">
             <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/abrt-action-save-package-data.conf" />
-            <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/abrt-action-save-package-data.conf" /> 
         </property>
 
         <property name="Interpreters" type="as" access="readwrite">
             <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/abrt-action-save-package-data.conf" />
-            <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/abrt-action-save-package-data.conf" /> 
         </property>
 
         <property name="ProcessUnpackaged" type="b" access="readwrite">
             <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/abrt-action-save-package-data.conf" />
-            <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/abrt-action-save-package-data.conf" /> 
         </property>
 
         <property name="GPGKeysDir" type="s" access="readwrite">
             <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/gpg_keys.conf" />
-            <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/gpg_keys.conf" /> 
         </property>
     </interface>
 </node>

--- a/doc/dbus-configuration/com.redhat.problems.configuration.ccpp.xml.in
+++ b/doc/dbus-configuration/com.redhat.problems.configuration.ccpp.xml.in
@@ -3,7 +3,6 @@
 
 <node name="/com/redhat/problems/configuration/ccpp">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/plugins/CCpp.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/plugins/CCpp.conf" />
 
     <interface name="com.redhat.problems.configuration.ccpp">
         <property name="MakeCompatCore" type="b" access="readwrite" />

--- a/doc/dbus-configuration/com.redhat.problems.configuration.oops.xml.in
+++ b/doc/dbus-configuration/com.redhat.problems.configuration.oops.xml.in
@@ -3,7 +3,6 @@
 
 <node name="/com/redhat/problems/configuration/oops">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/plugins/oops.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/plugins/oops.conf" />
 
     <interface name="com.redhat.problems.configuration.oops">
         <property name="OnlyFatalMCE" type="b" access="readwrite" />

--- a/doc/dbus-configuration/com.redhat.problems.configuration.python3.xml.in
+++ b/doc/dbus-configuration/com.redhat.problems.configuration.python3.xml.in
@@ -3,7 +3,6 @@
 
 <node name="/com/redhat/problems/configuration/python3">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/plugins/python3.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/plugins/python3.conf" />
 
     <interface name="com.redhat.problems.configuration.python3">
         <property name="RequireAbsolutePath" type="b" access="readwrite" />

--- a/doc/dbus-configuration/com.redhat.problems.configuration.vmcore.xml.in
+++ b/doc/dbus-configuration/com.redhat.problems.configuration.vmcore.xml.in
@@ -3,7 +3,6 @@
 
 <node name="/com/redhat/problems/configuration/vmcore">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/plugins/vmcore.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/plugins/vmcore.conf" />
 
     <interface name="com.redhat.problems.configuration.vmcore">
         <property name="CopyVMcore" type="b" access="readwrite" />

--- a/doc/dbus-configuration/com.redhat.problems.configuration.xorg.xml.in
+++ b/doc/dbus-configuration/com.redhat.problems.configuration.xorg.xml.in
@@ -3,7 +3,6 @@
 
 <node name="/com/redhat/problems/configuration/xorg">
     <annotation name="com.redhat.problems.ConfFile" value="/etc/abrt/plugins/xorg.conf" />
-    <annotation name="com.redhat.problems.DefaultConfFile" value="/usr/share/abrt/conf.d/plugins/xorg.conf" />
 
     <interface name="com.redhat.problems.configuration.xorg">
         <property name="BlacklistedXorgModules" type="as" access="readwrite" />

--- a/doc/gpg_keys.conf.txt
+++ b/doc/gpg_keys.conf.txt
@@ -5,6 +5,10 @@ NAME
 ----
 gpg_keys.conf - Configuration file for abrt-action-save-package-data.
 
+SYNOPSIS
+--------
+/etc/abrt/gpg_keys.conf
+
 DESCRIPTION
 -----------
 The configuration file consists of items in the format "Option = Value".
@@ -14,6 +18,10 @@ GPGKeysDir = 'directory'::
    The path of the directory which contains files with GPG keys of known
    RPM repositories. These keys are used to verify package signatures.
    Example: /etc/pki/rpm-gpg
+
+FILES
+--------
+/etc/abrt/gpg_keys.conf
 
 SEE ALSO
 --------

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -139,8 +139,6 @@ dist_daemonconf_DATA = \
     abrt.conf \
     abrt-action-save-package-data.conf \
     gpg_keys.conf
-defaultdaemonconfdir = $(DEFAULT_CONF_DIR)
-dist_defaultdaemonconf_DATA = $(dist_daemonconf_DATA)
 
 dbusabrtconfdir = ${sysconfdir}/dbus-1/system.d/
 dist_dbusabrtconf_DATA = org.freedesktop.problems.daemon.conf

--- a/src/daemon/abrt.conf
+++ b/src/daemon/abrt.conf
@@ -3,47 +3,58 @@
 # Note: you must ensure that whatever directory you specify here exists
 # and is writable for abrtd. abrtd will not create it automatically.
 #
+# Default: none
+#
 #WatchCrashdumpArchiveDir = /var/spool/abrt-upload
 
-# Max size for crash storage [MiB] or 0 for unlimited
+# Max size for crash storage [MiB] or 0 for unlimited.
+#
+# Default: 5000
 #
 MaxCrashReportsSize = 5000
 
 # Specify where you want to store coredumps and all files which are needed for
-# reporting. (default:/var/spool/abrt)
+# reporting.
 #
 # Changing dump location could cause problems with SELinux. See man abrt_selinux(8).
 #
+# Default: /var/spool/abrt
+#
 #DumpLocation = /var/spool/abrt
 
-# If you want to automatically clean the upload directory you have to tweak the
-# selinux policy:
+# Enables automatic cleaning of upload directory.
+#
+# If you decide to enable this, you have to tweak the SELinux policy:
 # # setsebool -P abrt_anon_write 1
+#
+# Default: no
 #
 DeleteUploaded = no
 
 # A name of event which is run automatically after problem's detection. The
-# event should perform some fast analysis and exit with 70 if the
-# problem is known.
+# event should perform some fast analysis and exit with 70 if the problem is
+# known.
 #
 # In order to run this event automatically after detection, the
 # AutoreportingEnabled option must be configured to 'yes'
 #
-# Default value: report_uReport
+# Default: report_uReport
 #
 AutoreportingEvent = report_uReport
 
 # Enables automatic running of the event configured in AutoreportingEvent option.
+#
+# Default: no
 #
 AutoreportingEnabled = no
 
 # Enables shortened GUI reporting where the reporting is interrupted after
 # AutoreportingEvent is done.
 #
-# Default value: Yes but only if application is running in GNOME desktop
-#                session; otherwise No.
+# Default: yes if application is running in a GNOME desktop session;
+#          no otherwise.
 #
-# ShortenedReporting = yes
+#ShortenedReporting = yes
 
 # Enables various features exploring process's root directories if they differ
 # from the default root directory. The following list includes examples of
@@ -56,15 +67,18 @@ AutoreportingEnabled = no
 #
 # Caution:
 #
-# THIS FEATURE MIGHT BE USED BY A LOCAL USER TO STEEL YOUR DATA BY ARRANGING A
-# SPECIAL ROOT DIRECTORY IN USER MOUNT NAMESAPCE
+# THIS FEATURE MIGHT BE USED BY A LOCAL USER TO STEAL YOUR DATA BY ARRANGING
+# A SPECIAL ROOT DIRECTORY IN USER MOUNT NAMESPACE
 #
-# ExploreChroots = false
+# Default: no
+#
+#ExploreChroots = no
 
-# Allows ABRT tools to detect problems in ABRT itself. By increasing the value
-# you can force ABRT to detect, process and report problems in ABRT. You have
-# to bare in mind that ABRT might fall into an infinite loop when handling
-# problems caused by itself.
-# The default is 0 (non debug mode).
+# Allows ABRT tools to detect problems in ABRT itself. By increasing the value,
+# you can force ABRT to detect, process and report problems in ABRT. You have to
+# bear in mind that ABRT might fall into an infinite loop when handling problems
+# caused by itself.
 #
-# DebugLevel = 0
+# Default: 0
+#
+#DebugLevel = 0

--- a/src/hooks/Makefile.am
+++ b/src/hooks/Makefile.am
@@ -9,9 +9,6 @@ if BUILD_ATOMIC
 dist_pluginsconf_DATA += CCpp_Atomic.conf
 endif
 
-defaultpluginsconfdir = $(DEFAULT_PLUGINS_CONF_DIR)
-dist_defaultpluginsconf_DATA = $(dist_pluginsconf_DATA)
-
 sbin_SCRIPTS = \
     abrt-install-ccpp-hook \
     abrt-harvest-pstoreoops

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -24,9 +24,7 @@ libabrt_la_CPPFLAGS = \
     -I$(srcdir)/../lib \
     -DVAR_RUN=\"$(VAR_RUN)\" \
     -DCONF_DIR=\"$(CONF_DIR)\" \
-    -DDEFAULT_CONF_DIR=\"$(DEFAULT_CONF_DIR)\" \
     -DPLUGINS_CONF_DIR=\"$(PLUGINS_CONF_DIR)\" \
-    -DDEFAULT_PLUGINS_CONF_DIR=\"$(DEFAULT_PLUGINS_CONF_DIR)\" \
     -DEVENTS_DIR=\"$(EVENTS_DIR)\" \
     -DDEFAULT_DUMP_LOCATION=\"$(DEFAULT_DUMP_LOCATION)\" \
     -DGDB=\"$(GDB)\" \

--- a/src/lib/abrt_conf.c
+++ b/src/lib/abrt_conf.c
@@ -189,14 +189,12 @@ int load_abrt_conf()
 
 static const char *const *get_conf_directories(void)
 {
-    static const char *base_directories[3];
+    static const char *base_directories[2];
 
-    const char *d = getenv("ABRT_DEFAULT_CONF_DIR");
-    const char *c = getenv("ABRT_CONF_DIR");
+    const char *d = getenv("ABRT_CONF_DIR");
 
-    base_directories[0] = d != NULL ? d : DEFAULT_CONF_DIR;
-    base_directories[1] = c != NULL ? d : CONF_DIR;
-    base_directories[2] = NULL;
+    base_directories[0] = d != NULL ? d : CONF_DIR;
+    base_directories[1] = NULL;
 
     return base_directories;
 }
@@ -209,7 +207,7 @@ int load_abrt_conf_file(const char *file, map_string_t *settings)
 
 int load_abrt_plugin_conf_file(const char *file, map_string_t *settings)
 {
-    static const char *const base_directories[] = { DEFAULT_PLUGINS_CONF_DIR, PLUGINS_CONF_DIR, NULL };
+    static const char *const base_directories[] = { PLUGINS_CONF_DIR, NULL };
 
     return load_conf_file_from_dirs(file, base_directories, settings, /*skip key w/o values:*/ false);
 }

--- a/src/lib/abrt_conf.c
+++ b/src/lib/abrt_conf.c
@@ -21,7 +21,7 @@
 #define ABRT_CONF "abrt.conf"
 
 char *        g_settings_sWatchCrashdumpArchiveDir = NULL;
-unsigned int  g_settings_nMaxCrashReportsSize = 1000;
+unsigned int  g_settings_nMaxCrashReportsSize = 5000;
 char *        g_settings_dump_location = NULL;
 bool          g_settings_delete_uploaded = 0;
 bool          g_settings_autoreporting = 0;

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -196,8 +196,6 @@ endif
 confdir = $(PLUGINS_CONF_DIR)
 dist_conf_DATA = \
     xorg.conf
-defaultconfdir = $(DEFAULT_PLUGINS_CONF_DIR)
-dist_defaultconf_DATA = $(dist_conf_DATA)
 
 abrt_watch_log_SOURCES = \
     abrt-watch-log.c

--- a/tests/abrt_conf.at
+++ b/tests/abrt_conf.at
@@ -37,7 +37,6 @@ void test(struct result **res)
 
     close(conf_fd);
 
-    setenv("ABRT_DEFAULT_CONF_DIR", "/tmp", 1);
     setenv("ABRT_CONF_DIR", "/tmp", 1);
     setenv("ABRT_CONF_FILE_NAME", strrchr(conf_file, '/') + 1, 1);
 
@@ -59,7 +58,6 @@ void test(struct result **res)
 
     unsetenv("ABRT_CONF_FILE_NAME");
     unsetenv("ABRT_CONF_DIR");
-    unsetenv("ABRT_DEFAULT_CONF_DIR");
 
     for (struct result **iter = res; NULL != *iter; ++iter)
     {

--- a/tests/runtests/dbus-configuration/runtest.sh
+++ b/tests/runtests/dbus-configuration/runtest.sh
@@ -62,19 +62,12 @@ rlJournalStart
         INTERFACES_DIR=`pkg-config --variable=problemsconfigurationdir abrt`
         export INTERFACES_DIR
 
-        rlRun "DEFAULT_AUTO_REPORTING=\"$(augtool get /files/usr/share/abrt/conf.d/abrt.conf/AutoreportingEnabled | cut -d' ' -f3)\"" 0
         rlRun "ABRT_AUTO_REPORTING=\"$(augtool get /files/etc/abrt/abrt.conf/AutoreportingEnabled | cut -d' ' -f3)\"" 0
         rlRun "augtool set /files/etc/abrt/abrt.conf/AutoreportingEnabled $DEFAULT_AUTO_REPORTING" 0
 
-        if [ "xyes" == "x$DEFAULT_AUTO_REPORTING" ]; then
-            DEFAULT_AUTO_REPORTING="true"
-            SETTO_AUTO_REPORTING="False"
-            MODIFIED_AUTO_REPORTING="false"
-        else
-            DEFAULT_AUTO_REPORTING="false"
-            SETTO_AUTO_REPORTING="True"
-            MODIFIED_AUTO_REPORTING="true"
-        fi
+        DEFAULT_AUTO_REPORTING="false"
+        SETTO_AUTO_REPORTING="True"
+        MODIFIED_AUTO_REPORTING="true"
     rlPhaseEnd
 
     rlPhaseStartTest "Invalid XML interface file"
@@ -211,7 +204,6 @@ rlJournalStart
 
         echo "<node name='/com/redhat/problems/configuration/blah'>" \
              "<annotation name='com.redhat.problems.ConfFile' value='/tmp/abrt.conf'/>" \
-             "<annotation name='com.redhat.problems.DefaultConfFile' value='/usr/share/abrt/conf.d/abrt.conf'/>" \
              "<interface name='com.redhat.problems.configuration.blah'>" \
              "<property name='AutoreportingEnabled' type='b' access='readwrite'/>" \
              "</interface></node>" \
@@ -272,7 +264,6 @@ rlJournalStart
 
         echo "<node name='/com/redhat/problems/configuration/blah'>" \
              "<annotation name='com.redhat.problems.ConfFile' value='/tmp/abrt.conf'/>" \
-             "<annotation name='com.redhat.problems.DefaultConfFile' value='/usr/share/abrt/conf.d/abrt.conf'/>" \
              "<interface name='com.redhat.problems.configuration.blah'>" \
              "<property name='SuperSuccess' type='ab' access='readwrite'/>" \
              "</interface></node>" \


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1693287

All the config files were previously installed both to `/usr/share/abrt/conf.d` (defaults, loaded first), as well as `/etc/abrt` (system-wide overloads).

This PR removes the former directory and all its files and preserves the latter. Comments are also added to man pages to document where the files are located.