### PR TITLE
a-a-analyze-c: Fix segfault when saving function name

### DIFF
--- a/src/plugins/abrt-action-analyze-c.c
+++ b/src/plugins/abrt-action-analyze-c.c
@@ -259,6 +259,12 @@ int main(int argc, char **argv)
         sr_normalize_core_thread(thread);
 
         struct sr_core_frame *frame = thread->frames;
+        if (!frame)
+        {
+            log_info("Could not find any usable stack frame");
+            goto next;
+        }
+
         if (frame->function_name)
             dd_save_text(dd, FILENAME_CRASH_FUNCTION, frame->function_name);
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1708684

It seems impossible to infer the root cause of the crash from the provided coredump, so this is just a quick fix. This commit only adds a check that `frame` is not `NULL` before dereferencing it to prevent the segfault.

My hunch is that `sr_normalize_core_thread` might get rid of all the stack frames in some corner case. Though, after quickly going through the logic, I'm not sure how that would happen in real world.