### PR TITLE
Update path to generated file in .gitignore after cli-ng move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,4 +196,4 @@ build/*
 *.trs
 .coverage
 toolswtf
-src/cli-ng/abrtcli/config.py
+src/cli/abrtcli/config.py


### PR DESCRIPTION
This file was moved in #1403 and it was forgotten to update the path here.