### PR TITLE
testsuite: Minor fixes for skip-sosreport-dir test

### DIFF
--- a/tests/runtests/aux/test_order
+++ b/tests/runtests/aux/test_order
@@ -122,6 +122,8 @@ pstoreoops-harvest
 event-configuration
 report-cli-ask-functions
 
+skip-sosreport-dir
+
 # - random
 augeas
 

--- a/tests/runtests/skip-sosreport-dir/PURPOSE
+++ b/tests/runtests/skip-sosreport-dir/PURPOSE
@@ -1,0 +1,3 @@
+PURPOSE of skip-sosreport-dir
+Description: Test skipping of dumpdirs in which sosreport is being generated
+Author: Martin Kutlak <mkutlak@redhat.com>


### PR DESCRIPTION
I forgot to add the test to test-order in https://github.com/abrt/abrt/pull/1407.

The test also missed a PURPOSE description.