### PR TITLE
Drop uses of bind_textdomain_codeset()

### DIFF
--- a/src/cli/abrtcli/l18n.py
+++ b/src/cli/abrtcli/l18n.py
@@ -28,7 +28,5 @@ def init():
     except IOError as ex:
         logging.debug("Unsupported locale '{0}': {1}".format(lcl, str(ex)))
 
-    gettext.bind_textdomain_codeset(progname,
-                                    locale.nl_langinfo(locale.CODESET))
     gettext.bindtextdomain(progname, localedir)
     gettext.textdomain(progname)

--- a/src/daemon/abrt-handle-upload.in
+++ b/src/daemon/abrt-handle-upload.in
@@ -26,11 +26,6 @@ def init_gettext():
     except locale.Error:
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME, locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -49,11 +49,6 @@ def init_gettext():
     except locale.Error:
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME, locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
     gettext.bindtextdomain(GETTEXT_PROGNAME, "@localedir@")
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-analyze-vmcore.in
+++ b/src/plugins/abrt-action-analyze-vmcore.in
@@ -22,11 +22,6 @@ def init_gettext():
     except locale.Error:
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME, locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-check-oops-for-alt-component.in
+++ b/src/plugins/abrt-action-check-oops-for-alt-component.in
@@ -61,13 +61,6 @@ if __name__ == "__main__":
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
 
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME,
-                                        locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
-
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-check-oops-for-hw-error.in
+++ b/src/plugins/abrt-action-check-oops-for-hw-error.in
@@ -81,13 +81,6 @@ if __name__ == "__main__":
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
 
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME,
-                                        locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
-
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -43,11 +43,6 @@ def init_gettext():
     except locale.Error:
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME, locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-perform-ccpp-analysis.in
+++ b/src/plugins/abrt-action-perform-ccpp-analysis.in
@@ -90,13 +90,6 @@ if __name__ == "__main__":
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
 
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME,
-                                        locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
-
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-action-ureport
+++ b/src/plugins/abrt-action-ureport
@@ -25,11 +25,6 @@ def init_gettext():
     except locale.Error:
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME, locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 

--- a/src/plugins/abrt-gdb-exploitable
+++ b/src/plugins/abrt-gdb-exploitable
@@ -22,11 +22,6 @@ def init_gettext():
     except locale.Error:
         os.environ['LC_ALL'] = 'C'
         locale.setlocale(locale.LC_ALL, "")
-    # Defeat "AttributeError: 'module' object has no attribute 'nl_langinfo'"
-    try:
-        gettext.bind_textdomain_codeset(GETTEXT_PROGNAME, locale.nl_langinfo(locale.CODESET))
-    except AttributeError:
-        pass
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 


### PR DESCRIPTION
6cac02cec6f457e4ab4edca8cebe2cda8dc4061d removed uses of l*gettext(),
which are the target of bind_textdomain_codeset(), thus making it no
longer needed.

Fixes https://github.com/abrt/abrt/issues/1411

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>