### PR TITLE
spec: Use macros where appropriate

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -494,8 +494,7 @@ to the shell
 %build
 autoconf
 
-%define var_base_dir spool
-%define default_dump_dir %{_localstatedir}/%{var_base_dir}/abrt
+%define default_dump_dir %{_localstatedir}/spool/abrt
 
 CFLAGS="%{optflags} -Werror" %configure \
 %if %{without python3}
@@ -521,14 +520,13 @@ CFLAGS="%{optflags} -Werror" %configure \
         --enable-dump-time-unwind \
         --disable-silent-rules
 
-make %{?_smp_mflags}
+%make_build
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT \
+%make_install \
 %if %{with python3}
              PYTHON=%{__python3} \
 %endif # with python3
-             mandir=%{_mandir} \
              dbusabrtdocdir=%{_defaultdocdir}/%{name}-dbus%{docdirversion}/html/
 
 %find_lang %{name}
@@ -538,21 +536,21 @@ make install DESTDIR=$RPM_BUILD_ROOT \
 # for those which needs to be byte-compiled with different
 # version (python2/python3).
 # rpm can do this work and use the appropriate python version.
-find $RPM_BUILD_ROOT -name "*.py[co]" -delete
+find %{buildroot} -name "*.py[co]" -delete
 
 # remove all .la and .a files
-find $RPM_BUILD_ROOT -name '*.la' -or -name '*.a' | xargs rm -f
-mkdir -p $RPM_BUILD_ROOT/var/cache/abrt-di
-mkdir -p $RPM_BUILD_ROOT/var/run/abrt
-mkdir -p $RPM_BUILD_ROOT%{default_dump_dir}
-mkdir -p $RPM_BUILD_ROOT/var/spool/abrt-upload
-mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/abrt
+find %{buildroot} -name '*.la' -or -name '*.a' | xargs rm -f
+mkdir -p %{buildroot}%{_localstatedir}/cache/abrt-di
+mkdir -p %{buildroot}%{_localstatedir}/lib/abrt
+mkdir -p %{buildroot}%{_localstatedir}/run/abrt
+mkdir -p %{buildroot}%{_localstatedir}/spool/abrt-upload
+mkdir -p %{buildroot}%{default_dump_dir}
 
 desktop-file-install \
-        --dir ${RPM_BUILD_ROOT}%{_datadir}/applications \
+        --dir %{buildroot}%{_datadir}/applications \
         src/applet/org.freedesktop.problems.applet.desktop
 
-ln -sf %{_datadir}/applications/org.freedesktop.problems.applet.desktop ${RPM_BUILD_ROOT}%{_sysconfdir}/xdg/autostart/
+ln -sf %{_datadir}/applications/org.freedesktop.problems.applet.desktop %{buildroot}%{_sysconfdir}/xdg/autostart/
 %if %{with python3}
 ln -sf %{_bindir}/abrt %{buildroot}%{_bindir}/abrt-cli
 ln -sf %{_mandir}/man1/abrt.1 %{buildroot}%{_mandir}/man1/abrt-cli.1
@@ -703,13 +701,13 @@ service abrtd condrestart >/dev/null 2>&1 || :
 %posttrans addon-ccpp
 # Migrate from abrt-ccpp.service to abrt-journal-core.service
 # 'systemctl preset abrt-ccpp.service abrt-journal-core.service'
-# is done only for installation by %systemd_post macro but not for package
+# is done only for installation by %%systemd_post macro but not for package
 # upgrade. Following lines affect changes in Fedora preset files in case of
 # package upgrade and also starts abrt-journal-core.service and stops
 # abrt-ccpp.service if abrt-ccpp.service is running.
 # All this has to be done only once because some users want to use
 # abrt-ccpp.service instead of the default abrt-journal-core.service.
-# Hence we introduced a %{_localstatedir}/lib/abrt/abrt-migrated file to
+# Hence we introduced a %%{_localstatedir}/lib/abrt/abrt-migrated file to
 # mark the migration was done.
 if test ! -f %{_localstatedir}/lib/abrt/abrt-migrated ; then
     systemctl --no-reload preset abrt-ccpp.service >/dev/null 2>&1 || : 


### PR DESCRIPTION
In the process, also fix rpmlint warnings and escape macros in comments.