### PR TITLE
Use correct paths for installed Python modules

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -935,14 +935,14 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_journalcatalogdir}/python3_abrt.catalog
 %config(noreplace) %{_sysconfdir}/libreport/plugins/catalog_python3_format.conf
 %{_mandir}/man5/python3_event.conf.5*
-%{python3_sitearch}/abrt3.pth
-%{python3_sitearch}/abrt_exception_handler3.py
-%{python3_sitearch}/__pycache__/abrt_exception_handler3.*
+%{python3_sitelib}/abrt3.pth
+%{python3_sitelib}/abrt_exception_handler3.py
+%{python3_sitelib}/__pycache__/abrt_exception_handler3.*
 
 %files -n python3-abrt-container-addon
-%{python3_sitearch}/abrt3_container.pth
-%{python3_sitearch}/abrt_exception_handler3_container.py
-%{python3_sitearch}/__pycache__/abrt_exception_handler3_container.*
+%{python3_sitelib}/abrt3_container.pth
+%{python3_sitelib}/abrt_exception_handler3_container.py
+%{python3_sitelib}/__pycache__/abrt_exception_handler3_container.*
 %endif # with python3
 
 %files plugin-sosreport
@@ -959,7 +959,7 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %config(noreplace) %{_sysconfdir}/bash_completion.d/abrt.bash_completion
 %{_bindir}/abrt
 %{_bindir}/abrt-cli
-%{python3_sitearch}/abrtcli/
+%{python3_sitelib}/abrtcli/
 %{_mandir}/man1/abrt.1*
 %{_mandir}/man1/abrt-cli.1*
 %endif # with python3

--- a/src/cli/abrtcli/Makefile.am
+++ b/src/cli/abrtcli/Makefile.am
@@ -9,7 +9,7 @@ PYFILES= \
 	utils.py
 
 abrtcli_PYTHON = $(PYFILES)
-abrtclidir = $(pyexecdir)/abrtcli
+abrtclidir = $(pythondir)/abrtcli
 
 config.py: config.py.in
 	sed -e s,\@LOCALE_DIR\@,$(localedir),g \

--- a/src/cli/abrtcli/cli/Makefile.am
+++ b/src/cli/abrtcli/cli/Makefile.am
@@ -10,4 +10,4 @@ abrtclicommands_PYTHON = \
 	retrace.py \
 	status.py
 
-abrtclicommandsdir = $(pyexecdir)/abrtcli/cli
+abrtclicommandsdir = $(pythondir)/abrtcli/cli

--- a/src/hooks/Makefile.am
+++ b/src/hooks/Makefile.am
@@ -35,7 +35,7 @@ EXTRA_DIST = \
 ALL_DEPENDENCES =
 
 if BUILD_PYTHON3
-py3hookdir = $(pyexecdir)
+py3hookdir = $(pythondir)
 dist_pluginsconf_DATA += python3.conf
 ALL_DEPENDENCES += abrt_exception_handler3.py
 


### PR DESCRIPTION
According to the [packaging guide](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_macros), we should be using `%{python3_sitelib}` to install Python modules rather than `%{python3_sitearch}` which is more suitable for compiled extensions. This also needs to be reflected in the automake scripts, where we need to replace `$(pyexecdir)` with `$(pythondir)`. (See [automake manual](https://www.gnu.org/software/automake/manual/html_node/Python.html).)

This is a follow-up to 20dcf7fb4.