### PR TITLE
events: Comment examples consistently

### DIFF
--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -61,7 +61,7 @@ EVENT=post-create container_cmdline!= remote!=1
 
 # Example: if you want all users (not just root) to be able to see some problems:
 #EVENT=post-create
-        rm uid; chmod a+rX .
+#        rm uid; chmod a+rX .
 
 EVENT=post-create remote!=1
         # uid file is missing for problems visible to all users
@@ -107,7 +107,7 @@ EVENT=post-create remote=1
 #   below and change "EVENT=notify" to "EVENT=notify-dup".
 #
 #EVENT=notify
-        reporter-upload -u scp://user:password@server.name/var/spool/abrt-upload/ || :
+#        reporter-upload -u scp://user:password@server.name/var/spool/abrt-upload/ || :
 
 # Example:
 # if you want to upload data immediately at the moment of a crash to
@@ -126,7 +126,7 @@ EVENT=post-create remote=1
 #   below and change "EVENT=notify" to "EVENT=notify-dup".
 #
 #EVENT=notify
-        reporter-upload -u scp://user:password@server.name/tmp/crash.tar.gz || :
+#        reporter-upload -u scp://user:password@server.name/tmp/crash.tar.gz || :
 
 
 #open-gui event is used by abrt-gui's "Edit"->"Open problem data"

--- a/src/plugins/koops_event.conf
+++ b/src/plugins/koops_event.conf
@@ -24,11 +24,11 @@ EVENT=post-create type=Kerneloops remote!=1
 # oopses to be reported automatically and immediately without
 # user interaction, uncomment this line:
 #EVENT=post-create type=Kerneloops
-        reporter-kerneloops
+#        reporter-kerneloops
 
 # Report
 #EVENT=report_Kerneloops type=Kerneloops
-        reporter-kerneloops
+#        reporter-kerneloops
 
 EVENT=report_Bugzilla type=Kerneloops
         reporter-bugzilla -b \

--- a/src/plugins/vmcore_event.conf
+++ b/src/plugins/vmcore_event.conf
@@ -41,7 +41,7 @@ EVENT=analyze_VMcore type=vmcore
 # oopses to be reported automatically and immediately without
 # user interaction, uncomment this line:
 #EVENT=post-create type=vmcore
-        reporter-kerneloops
+#        reporter-kerneloops
 
 # report
 EVENT=report_Kerneloops type=vmcore


### PR DESCRIPTION
Even though libreport should parse the hanging lines as separate from
the preceding event, let's be on the safe side with these.