### PR TITLE
Use GChecksum to compute checksums

### DIFF
--- a/src/plugins/abrt-action-analyze-backtrace.c
+++ b/src/plugins/abrt-action-analyze-backtrace.c
@@ -82,6 +82,8 @@ int main(int argc, char **argv)
     /* Store backtrace hash */
     if (!backtrace)
     {
+        g_autofree char *checksum = NULL;
+
         /*
          * The parser failed. Compute the duphash from the executable
          * instead of a backtrace.
@@ -98,10 +100,10 @@ int main(int argc, char **argv)
         strbuf_prepend_str(emptybt, component);
 
         log_debug("Generating duphash: %s", emptybt->buf);
-        char hash_str[SHA1_RESULT_LEN*2 + 1];
-        str_to_sha1str(hash_str, emptybt->buf);
 
-        dd_save_text(dd, FILENAME_DUPHASH, hash_str);
+        checksum = g_compute_checksum_for_string(G_CHECKSUM_SHA1, emptybt->buf, -1);
+
+        dd_save_text(dd, FILENAME_DUPHASH, checksum);
         /*
          * Other parts of ABRT assume that if no rating is available,
          * it is ok to allow reporting of the bug. To be sure no bad

--- a/src/plugins/abrt-action-analyze-c.c
+++ b/src/plugins/abrt-action-analyze-c.c
@@ -235,10 +235,11 @@ int main(int argc, char **argv)
 
     log_debug("String to hash: %s", string_to_hash);
 
-    char hash_str[SHA1_RESULT_LEN*2 + 1];
-    str_to_sha1str(hash_str, string_to_hash);
+    g_autofree char *checksum = NULL;
 
-    dd_save_text(dd, FILENAME_UUID, hash_str);
+    checksum = g_compute_checksum_for_string(G_CHECKSUM_SHA1, string_to_hash, -1);
+
+    dd_save_text(dd, FILENAME_UUID, checksum);
 
     /* Create crash_function element from core_backtrace */
     char *core_backtrace_json = dd_load_text_ext(dd, FILENAME_CORE_BACKTRACE,

--- a/src/plugins/abrt-action-analyze-python.c
+++ b/src/plugins/abrt-action-analyze-python.c
@@ -26,6 +26,8 @@
 
 int main(int argc, char **argv)
 {
+    g_autofree char *checksum = NULL;
+
     /* I18n */
     setlocale(LC_ALL, "");
 #if ENABLE_NLS
@@ -91,13 +93,12 @@ int main(int argc, char **argv)
 
     char *bt_end = strchrnul(bt, '\n');
     *bt_end = '\0';
-    char hash_str[SHA1_RESULT_LEN*2 + 1];
-    str_to_sha1str(hash_str, bt);
+    checksum = g_compute_checksum_for_string(G_CHECKSUM_SHA1, bt, -1);
 
     free(bt);
 
-    dd_save_text(dd, FILENAME_UUID, hash_str);
-    dd_save_text(dd, FILENAME_DUPHASH, hash_str);
+    dd_save_text(dd, FILENAME_UUID, checksum);
+    dd_save_text(dd, FILENAME_DUPHASH, checksum);
     dd_close(dd);
 
     return 0;


### PR DESCRIPTION
d605ffeaa6ae411ef396160ffd67b7a6fd27c6ba in libreport removed some
convenience API for hashing data, so let’s just go with what GLib has in
store.