### PR TITLE
koops: Avoid explicit dependency on hash size

### DIFF
--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -138,9 +138,9 @@ char *kernel_tainted_short(const char *kernel_bt);
 #define kernel_tainted_long abrt_kernel_tainted_long
 char *kernel_tainted_long(const char *tainted_short);
 #define koops_hash_str_ext abrt_koops_hash_str_ext
-int koops_hash_str_ext(char hash_str[SHA1_RESULT_LEN*2 + 1], const char *oops_buf, int frame_count, int duphas_flags);
+char *koops_hash_str_ext(const char *oops_buf, int frame_count, int duphas_flags);
 #define koops_hash_str abrt_koops_hash_str
-int koops_hash_str(char hash_str[SHA1_RESULT_LEN*2 + 1], const char *oops_buf);
+char *koops_hash_str(const char *oops_buf);
 
 
 #define koops_line_skip_level abrt_koops_line_skip_level

--- a/src/plugins/abrt-action-analyze-oops.c
+++ b/src/plugins/abrt-action-analyze-oops.c
@@ -60,9 +60,8 @@ int main(int argc, char **argv)
     load_abrt_plugin_conf_file("oops.conf", settings);
 
     char *oops = dd_load_text(dd, FILENAME_BACKTRACE);
-    char hash_str[SHA1_RESULT_LEN*2 + 1];
-    int bad = koops_hash_str(hash_str, oops);
-    if (bad)
+    g_autofree char *hash_str = koops_hash_str(oops);
+    if (!hash_str)
     {
         error_msg("Can't find a meaningful backtrace for hashing in '%s'", dump_dir_name);
 
@@ -87,7 +86,7 @@ int main(int argc, char **argv)
             /* We need UUID file for the local duplicates look-up and DUPHASH */
             /* file is also useful because user can force ABRT to report */
             /* the oops into a bug tracking system (Bugzilla). */
-            bad = koops_hash_str_ext(hash_str, oops,
+            hash_str = koops_hash_str_ext(oops,
                     /* use no frame count limit */-1,
                     /* use every frame in stacktrace */0);
 
@@ -97,7 +96,7 @@ int main(int argc, char **argv)
 
     free(oops);
 
-    if (!bad)
+    if (hash_str)
     {
         dd_save_text(dd, FILENAME_UUID, hash_str);
         dd_save_text(dd, FILENAME_DUPHASH, hash_str);
@@ -107,5 +106,5 @@ int main(int argc, char **argv)
 
     free_map_string(settings);
 
-    return bad;
+    return NULL != hash_str;
 }

--- a/tests/koops-parser.at
+++ b/tests/koops-parser.at
@@ -125,16 +125,14 @@ AT_TESTFUN([koops_hash_improve],
 
 int run_test(const struct test_struct *test)
 {
-	char *oops1 = fread_full(test->filename);
-	char *oops2 = fread_full(test->expected_results);
+	g_autofree char *oops1 = fread_full(test->filename);
+	g_autofree char *oops2 = fread_full(test->expected_results);
 
-	char hash_oops1[SHA1_RESULT_LEN*2 + 1];
-	koops_hash_str(hash_oops1, oops1);
-	free(oops1);
+	g_autofree char *hash_oops1 = koops_hash_str(oops1);
+	g_autofree char *hash_oops2 = koops_hash_str(oops2);
 
-	char hash_oops2[SHA1_RESULT_LEN*2 + 1];
-	koops_hash_str(hash_oops2, oops2);
-	free(oops2);
+	if (NULL == hash_oops1 || NULL == hash_oops2)
+	    return 1;
 
 	if (!strcmp(hash_oops1, hash_oops2))
 		return 0;


### PR DESCRIPTION
Change the API so that `koops_hash_str` and `koops_hash_str_ext` return the heap-allocated encoded digest instead of taking a pointer and returning a status code.

This eliminates the need to know the size of the resulting hash in advance, which should solve the build problems following recent libreport changes.