### PR TITLE
Make CCpp journal catalog messages great again 

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -811,6 +811,7 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %{_libexecdir}/abrt-gdb-exploitable
 %config(noreplace) %{_sysconfdir}/libreport/plugins/catalog_journal_ccpp_format.conf
 %{_unitdir}/abrt-journal-core.service
+%{_journalcatalogdir}/abrt_ccpp.catalog
 
 %dir %{_localstatedir}/lib/abrt
 

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -81,6 +81,7 @@ endif
 journalcatalogdir = $(JOURNAL_CATALOG_DIR)
 
 dist_journalcatalog_DATA = \
+    abrt_ccpp.catalog \
     abrt_koops.catalog \
     abrt_xorg.catalog
 

--- a/src/plugins/abrt_ccpp.catalog.in
+++ b/src/plugins/abrt_ccpp.catalog.in
@@ -1,0 +1,26 @@
+#  This file is part of ABRT.
+#
+#  Copyright (C) 2016  ABRT team
+#  Copyright (C) 2016  RedHat Inc
+#
+#  ABRT is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  ABRT is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+
+-- 5ab0271ecf1941a2b89299716e880661
+Subject: ABRT has detected unexpected termination: @PROBLEM_BINARY@
+Defined-By: ABRT
+Support: @SUPPORT_URL@
+Documentation: man:abrt(1)
+@PROBLEM_REPORT@
+Use the abrt command-line tool for further analysis or to report
+the problem to the appropriate support site.

--- a/src/plugins/catalog_journal_ccpp_format.conf
+++ b/src/plugins/catalog_journal_ccpp_format.conf
@@ -1,3 +1,5 @@
 %summary:: Process %pid% (%binary%) crashed in %crash_function%()
 
 ::%bare_reason
+
+::%bare_%short_backtrace

--- a/tests/runtests/reporter-systemd-journal/runtest.sh
+++ b/tests/runtests/reporter-systemd-journal/runtest.sh
@@ -356,6 +356,9 @@ Process #PID# (will_stackoverflow) crashed in f()
 -- 
 -- will_stackoverflow killed by SIGSEGV
 -- 
+-- #1 [will_stackoverflow] f
+-- #2 [will_stackoverflow] main
+--
 -- Use the abrt command-line tool for further analysis or to report
 -- the problem to the appropriate support site.
 END


### PR DESCRIPTION
abrt_ccpp.catalog was accidently deleted in #1419 

and ...

Short backtrace was missing in journal catalog messages.

In case of will_stackoverflow:
```
-- #1 [will_stackoverflow] f
-- #2 [will_stackoverflow] main
```