### PR TITLE
spec: bump reqired libreport version

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -43,7 +43,7 @@
     %define docdirversion -%{version}
 %endif
 
-%define libreport_ver 2.10.0
+%define libreport_ver 2.12.0
 %define satyr_ver 0.24
 
 Summary: Automatic bug detection and reporting tool


### PR DESCRIPTION
New libreport changes are incompatible with older abrt releases.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>