### PR TITLE
spec: Add %ghost for /var/run/abrt

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -746,7 +746,7 @@ killall abrt-dbus >/dev/null 2>&1 || :
 %dir %attr(@DEFAULT_DUMP_LOCATION_MODE@, root, abrt) %{default_dump_dir}
 %dir %attr(0700, abrt, abrt) %{_localstatedir}/spool/%{name}-upload
 # abrtd runs as root
-%dir %attr(0755, root, root) %{_localstatedir}/run/%{name}
+%ghost %dir %attr(0755, root, root) %{_localstatedir}/run/%{name}
 %ghost %attr(0666, -, -) %{_localstatedir}/run/%{name}/abrt.socket
 %ghost %attr(0644, -, -) %{_localstatedir}/run/%{name}/abrtd.pid
 


### PR DESCRIPTION
Since /var/run is typically symlinked to /run, which is mounted as tmpfs, the directory will disappear after a reboot if abrtd.service is disabled. Adding a %ghost directive makes sure that RPM verification succeeds even if the directory had been nuked.

https://bugzilla.redhat.com/show_bug.cgi?id=1805728