### PR TITLE
Accomodate for multiple debug directories

### DIFF
--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -272,7 +272,7 @@ char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char 
     }
     else
     {
-        strbuf_append_str(set_debug_file_directory, "set debug-file-directory /usr/lib/debug");
+        strbuf_append_str(set_debug_file_directory, "set debug-file-directory /usr/lib/debug:/usr/lib");
 
         struct strbuf *debug_directories = strbuf_new();
         const char *p = debuginfo_dirs;
@@ -283,8 +283,11 @@ char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char 
             if (*p == '\0')
                 break;
             const char *colon_or_nul = strchrnul(p, ':');
-            strbuf_append_strf(debug_directories, "%s%.*s/usr/lib/debug", (debug_directories->len == 0 ? "" : ":"),
-                                                                          (int)(colon_or_nul - p), p);
+            strbuf_append_strf(debug_directories,
+                               "%s%.*s/usr/lib/debug:%.*s/usr/lib",
+                               (debug_directories->len == 0 ? "" : ":"),
+                               (int)(colon_or_nul - p), p,
+                               (int)(colon_or_nul - p), p);
             p = colon_or_nul;
         }
 

--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -52,7 +52,6 @@ def init_gettext():
     gettext.bindtextdomain(GETTEXT_PROGNAME, "@localedir@")
     gettext.textdomain(GETTEXT_PROGNAME)
 
-#eu_unstrip_OUT=`eu-unstrip "--core=$core" -n 2>eu_unstrip.ERR`
 def extract_info_from_core(coredump_name):
     """
     Extracts builds with filenames,
@@ -66,23 +65,7 @@ def extract_info_from_core(coredump_name):
 
     log_warning(_("Analyzing coredump '%s'") % coredump_name)
     eu_unstrip_OUT = Popen(["eu-unstrip","--core=%s" % coredump_name, "-n"], stdout=PIPE, bufsize=-1, universal_newlines=True).communicate()[0]
-    # parse eu_unstrip_OUT and return the list of build_ids
 
-    # eu_unstrip_OUT = (
-    # "0x7f42362ca000+0x204000 c4d35d993598a6242f7525d024b5ec3becf5b447@0x7f42362ca1a0 /usr/lib64/libcanberra-gtk.so.0 - libcanberra-gtk.so.0\n"
-    # "0x3afa400000+0x210000 607308f916c13c3ad9ee503008d31fa671ba73ce@0x3afa4001a0 /usr/lib64/libcanberra.so.0 - libcanberra.so.0\n"
-    # "0x3afa400000+0x210000 607308f916c13c3ad9ee503008d31fa671ba73ce@0x3afa4001a0 /usr/lib64/libcanberra.so.0 - libcanberra.so.0\n"
-    # "0x3bc7000000+0x208000 3be016bb723e85779a23e111a8ab1a520b209422@0x3bc70001a0 /usr/lib64/libvorbisfile.so.3 - libvorbisfile.so.3\n"
-    # "0x7f423609e000+0x22c000 87f9c7d9844f364c73aa2566d6cfc9c5fa36d35d@0x7f423609e1a0 /usr/lib64/libvorbis.so.0 - libvorbis.so.0\n"
-    # "0x7f4235e99000+0x205000 b5bc98c125a11b571cf4f2746268a6d3cfa95b68@0x7f4235e991a0 /usr/lib64/libogg.so.0 - libogg.so.0\n"
-    # "0x7f4235c8b000+0x20e000 f1ff6c8ee30dba27e90ef0c5b013df2833da2889@0x7f4235c8b1a0 /usr/lib64/libtdb.so.1 - libtdb.so.1\n"
-    # "0x3bc3000000+0x209000 8ef56f789fd914e8d0678eb0cdfda1bfebb00b40@0x3bc30001a0 /usr/lib64/libltdl.so.7 - libltdl.so.7\n"
-    # "0x7f4231b64000+0x22b000 3ca5b83798349f78b362b1ea51c8a4bc8114b8b1@0x7f4231b641a0 /usr/lib64/gio/modules/libgvfsdbus.so - libgvfsdbus.so\n"
-    # "0x7f423192a000+0x218000 ad024a01ad132737a8cfc7c95beb7c77733a652d@0x7f423192a1a0 /usr/lib64/libgvfscommon.so.0 - libgvfscommon.so.0\n"
-    # "0x7f423192a000+0x218000 ad024a01ad132737a8cfc7c95beb7c77733a652d@0x7f423192a1a0 /usr/lib64/libgvfscommon.so.0 - libgvfscommon.so.0\n"
-    # "0x3bb8e00000+0x20e000 d240ac5755184a95c783bb98a2d05530e0cf958a@0x3bb8e001a0 /lib64/libudev.so.0 - libudev.so.0\n"
-    # )
-    #print eu_unstrip_OUT
     # we failed to get build ids from the core -> die
     if not eu_unstrip_OUT:
         error_msg_and_die("Can't get build ids from %s" % coredump_name)
@@ -113,14 +96,6 @@ def extract_info_from_core(coredump_name):
     log1("Found %i build_ids" % len(build_ids))
     log1("Found %i libs" % len(libraries))
     return build_ids
-
-def build_ids_to_path(build_ids):
-    """
-    build_id1=${build_id:0:2}
-    build_id2=${build_id:2}
-    file="usr/lib/debug/.build-id/$build_id1/$build_id2.debug"
-    """
-    return ["/usr/lib/debug/.build-id/%s/%s.debug" % (b_id[:2], b_id[2:]) for b_id in build_ids]
 
 if __name__ == "__main__":
     # localization

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -9,8 +9,9 @@ import errno
 import getopt
 from reportclient import log2, set_verbosity, error_msg_and_die, error_msg
 import time
-from reportclient.debuginfo import filter_installed_debuginfos, build_ids_to_path, clean_up
+from reportclient.debuginfo import filter_installed_debuginfos, build_ids_to_paths, clean_up
 import problem
+import signal
 
 # everything was ok
 RETURN_OK = 0
@@ -46,7 +47,42 @@ def init_gettext():
     gettext.bindtextdomain(GETTEXT_PROGNAME, '/usr/share/locale')
     gettext.textdomain(GETTEXT_PROGNAME)
 
-import signal
+def measure_disposable_files(cache_dir, subdirectories, build_paths):
+    """
+    Compute the sum of the sizes of debuginfo files which are not needed anymore.
+    """
+
+    size_sum = 0
+
+    for subdir in subdirectories:
+        for dirpath, _, filenames in os.walk(os.path.join(cache_dir, subdir)):
+            for name in filenames:
+                if not name.endswith(".debug"):
+                    continue
+                full_path = os.path.join(dirpath, name)
+                if os.path.isfile(full_path) and full_path not in build_paths:
+                    size_sum += os.stat(full_path).st_size / (1024 * 1024)
+
+    return size_sum
+
+def trim_files(cache_dir, size, build_paths):
+    """
+    Call abrt-action-trim-files to clean up at least 'size' MiB worth of files
+    inside 'cache_dir' leaving 'build_paths' intact.
+    """
+
+    try:
+        pid = os.fork()
+        if pid == 0:
+            argv = ["abrt-action-trim-files", "-f", "%um:%s" % (size, cache_dir), "--"]
+            argv.extend(build_paths)
+            log2("abrt-action-trim-files %s", argv)
+            os.execvp("abrt-action-trim-files", argv)
+            error_msg_and_die("Can't execute '%s'", "abrt-action-trim-files")
+        if pid > 0:
+            os.waitpid(pid, 0)
+    except Exception as e:
+        error_msg("Can't execute abrt-action-trim-files: %s", e)
 
 def run(config):
     missing = config.missing
@@ -75,7 +111,7 @@ def run(config):
         # it makes sense to NOT setuid abrt-action-trim-files too,
         # but instead run it as our child:
         sys.stdout.flush()
-        build_paths = build_ids_to_path(config.cachedirs[0], b_ids)
+        build_paths = build_ids_to_paths(config.cachedirs[0], b_ids)
         print("Cleaning cache...")
         try:
             pid = os.fork()
@@ -132,28 +168,14 @@ def run(config):
             free_space = float(res.f_bsize * res.f_bavail) / (1024 * 1024)
             all_space = float(res.f_bsize * res.f_blocks) / (1024 * 1024)
             install_size = downloader.get_install_size() / (1024 * 1024)
-            if install_size > free_space:
-                unnecessary_files_size = 0
-                for dirpath, dirnames, filenames in os.walk(os.path.join(config.cachedirs[0], "usr/lib/debug/.build-id")):
-                    for filename in [f for f in filenames if f.endswith(".debug")]:
-                        fl = os.path.join(dirpath, filename)
-                        if os.path.isfile(fl) and fl not in build_paths:
-                            unnecessary_files_size += os.stat(fl).st_size / (1024*1024)
 
-                if unnecessary_files_size + free_space >= install_size:
+            if install_size > free_space:
+                debuginfo_dirs = ["usr/lib/debug/.build-id", "usr/lib/.build-id"]
+                disposable_size = measure_disposable_files(config.cachedirs[0], debuginfo_dirs, build_paths)
+
+                if disposable_size + free_space >= install_size:
                     config.size_mb = all_space - install_size
-                    try:
-                        pid = os.fork()
-                        if pid == 0:
-                            argv = ["abrt-action-trim-files", "-f", "%um:%s" % (config.size_mb, config.cachedirs[0]), "--"]
-                            argv.extend(build_paths)
-                            log2("abrt-action-trim-files %s", argv)
-                            os.execvp("abrt-action-trim-files", argv)
-                            error_msg_and_die("Can't execute '%s'", "abrt-action-trim-files")
-                        if pid > 0:
-                            os.waitpid(pid, 0)
-                    except Exception as e:
-                        error_msg("Can't execute abrt-action-trim-files: %s", e)
+                    trim_files(config.cachedirs[0], config.size_mb, build_paths)
 
             result = downloader.download(missing, download_exact_files=config.exact_fls)
 


### PR DESCRIPTION
A change was introduced in Fedora 27 to allow for installing multiple versions of debuginfo packages in parallel. In effect, `/usr/lib/.build-id` may contain debug files as well in addition to `/usr/lib/debug/.build-id`.

See https://fedoraproject.org/wiki/Changes/ParallelInstallableDebuginfo for more details.

Follow-up to abrt/faf#851 and abrt/libreport#606.