### PR TITLE
cli: Correct debug directories in config

### DIFF
--- a/src/cli/abrtcli/config.py.in
+++ b/src/cli/abrtcli/config.py.in
@@ -58,7 +58,12 @@ DEBUGINFO_INSTALL_CMD = '''
 abrt-action-analyze-ccpp-local --without-bz --without-bodhi
 '''
 
-DEBUGINFO_PATH = '/usr/lib/debug:/var/cache/abrt-di/usr/lib/debug'
+DEBUGINFO_PATH = ':'.join([
+    '/usr/lib/debug',
+    '/usr/lib',
+    '/var/cache/abrt-di/usr/lib/debug',
+    '/var/cache/abrt-di/usr/lib'
+])
 
 GDB_CMD = '''
 gdb -iex "set debug-file-directory {di_path}" \


### PR DESCRIPTION
Forgot about this little bugger here.

Follow-up to 8ebe0be1.