### PR TITLE
plugins: abrt-journal-core: Don’t assume anything about uid_t

### DIFF
--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -190,7 +190,7 @@ abrt_journal_update_occurrence(const char *executable, unsigned ts)
 static int
 abrt_journal_core_retrieve_information(abrt_journal_t *journal, struct crash_info *info)
 {
-    if (abrt_journal_get_int_field(journal, "COREDUMP_SIGNAL", &(info->ci_signal_no)) != 0)
+    if (abrt_journal_get_int_field(journal, "COREDUMP_SIGNAL", (long *)&(info->ci_signal_no)) != 0)
     {
         log_info("Failed to get signal number from journal message");
         return -EINVAL;
@@ -220,14 +220,14 @@ abrt_journal_core_retrieve_information(abrt_journal_t *journal, struct crash_inf
         return 1;
     }
 
-    if (abrt_journal_get_unsigned_field(journal, "COREDUMP_UID", &(info->ci_uid)))
+    if (abrt_journal_get_int_field(journal, "COREDUMP_UID", (long *)&(info->ci_uid)))
     {
         log_info("Failed to get UID from journal message");
         return -EINVAL;
     }
 
     /* This is not fatal, the pid is used only in dumpdir name */
-    if (abrt_journal_get_int_field(journal, "COREDUMP_PID", &(info->ci_pid)))
+    if (abrt_journal_get_int_field(journal, "COREDUMP_PID", (long *)&(info->ci_pid)))
     {
         log_notice("Failed to get PID from journal message.");
         info->ci_pid = getpid();

--- a/src/plugins/abrt-journal.h
+++ b/src/plugins/abrt-journal.h
@@ -54,7 +54,7 @@ int abrt_journal_get_field(abrt_journal_t *journal,
 
 int abrt_journal_get_int_field(abrt_journal_t *journal,
                                const char *field,
-                               int *value);
+                               long *value);
 
 int abrt_journal_get_unsigned_field(abrt_journal_t *journal,
                                     const char *field,


### PR DESCRIPTION
Sure, maybe glibc defines uid_t as a uint32_t, but POSIX does not impose
any limits on the underlying type, so let’s just accept whatever systemd
gives us. If what systemd gives us is non-compliant, then we are already
in trouble and it makes no sense to defend against nasal demons.
Moreover, using a long for bounds and passing UINT_MAX is just asking
for trouble (i.e. it fails on 32-bit systems).