### PR TITLE
Hardcode subcomponents for RHBZ reports

### DIFF
--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -273,6 +273,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
     char *fingerprint = NULL;
     struct pkg_envra *pkg_name = NULL;
     char *component = NULL;
+    char *sub_components = NULL;
     char *kernel = NULL;
     int error = 1;
     /* note: "goto ret" statements below free all the above variables,
@@ -411,6 +412,7 @@ skip_interpreter:
     }
 
     component = rpm_get_component(executable, chroot);
+    sub_components = get_sub_components(component);
 
     dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
@@ -449,6 +451,8 @@ skip_interpreter:
 
     if (component)
         dd_save_text(dd, FILENAME_COMPONENT, component);
+    if (sub_components)
+        dd_save_text(dd, FILENAME_SUBCOMPONENTS, sub_components);
 
  ret0:
     error = 0;

--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -52,6 +52,8 @@ void ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, c
 char *run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
 #define get_backtrace abrt_get_backtrace
 char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char *debuginfo_dirs);
+#define get_sub_components abrt_get_sub_components
+char *get_sub_components(const char *component);
 
 #define dir_is_in_dump_location abrt_dir_is_in_dump_location
 bool dir_is_in_dump_location(const char *dir_name);

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -415,6 +415,28 @@ char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char 
     return bt;
 }
 
+char *get_sub_components(const char *component)
+{
+    if (!strcmp(component, "binutils"))      return (char *)"system-version";
+    if (!strcmp(component, "Documentation")) return (char *)"default";
+    if (!strcmp(component, "dwz"))           return (char *)"system-version";
+    if (!strcmp(component, "dynist"))        return (char *)"system-version";
+    if (!strcmp(component, "elfutils"))      return (char *)"system-version";
+    if (!strcmp(component, "gcc"))           return (char *)"system-version";
+    if (!strcmp(component, "gdb"))           return (char *)"system-version";
+    if (!strcmp(component, "kernel"))        return (char *)"Other";
+    if (!strcmp(component, "kernel-rt"))     return (char *)"Other";
+    if (!strcmp(component, "kpatch"))        return (char *)"kpatch-utility";
+    if (!strcmp(component, "ltrace"))        return (char *)"system-version";
+    if (!strcmp(component, "lvm2"))          return (char *)"Default / Unclassified";
+    if (!strcmp(component, "make"))          return (char *)"system-version";
+    if (!strcmp(component, "systemtap"))     return (char *)"system-version";
+    if (!strcmp(component, "test"))          return (char *)"sub1";
+    if (!strcmp(component, "valgrind"))      return (char *)"system-version";
+    if (!strcmp(component, "virtio-win"))    return (char *)"distribution";
+    return NULL;
+}
+
 char* problem_data_save(problem_data_t *pd)
 {
     load_abrt_conf();


### PR DESCRIPTION
This PR adds default (for lack of a better word) subcomponents for components that require them, as offered in the BZ form for submitting a new bug. The subcomponents are stored in `sub_components` file in the problem directory, to be read by `reporter-bugzilla` (see https://github.com/abrt/libreport/pull/608).  
  
(Not quite sure where to put the function since unlike `rpm_get_component()`, it doesn't rely on rpm's in any way, so putting it in `rpm.c` didn't really feel appropriate.)

Signed-off-by: Michal Fabik <mfabik@redhat.com>