### PR TITLE
Remove #define's adding abrt_ to function names

### DIFF
--- a/src/applet/abrt-applet-application.c
+++ b/src/applet/abrt-applet-application.c
@@ -253,7 +253,7 @@ get_autoreport_event_name (void)
         return configured;
     }
 
-    return g_settings_autoreporting_event;
+    return abrt_g_settings_autoreporting_event;
 }
 
 static bool
@@ -1184,7 +1184,7 @@ abrt_applet_application_startup (GApplication *application)
     export_abrt_envvars (0);
     msg_prefix = g_progname;
 
-    load_abrt_conf ();
+    abrt_load_abrt_conf ();
     load_event_config_data ();
     load_user_settings (APP_NAME);
 

--- a/src/configuration-gui/abrt-config-widget.c
+++ b/src/configuration-gui/abrt-config-widget.c
@@ -427,7 +427,7 @@ abrt_config_widget_init(AbrtConfigWidget *self)
     }
 
     /* Load configuration */
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     self->priv->report_gtk_conf = abrt_app_configuration_new("report-gtk");
     self->priv->abrt_applet_conf = abrt_app_configuration_new("abrt-applet");
@@ -536,7 +536,7 @@ abrt_config_widget_init(AbrtConfigWidget *self)
     }
 
     self->priv->options[ABRT_OPT_SHORTENED_REPORTING].name = "ShortenedReporting";
-    self->priv->options[ABRT_OPT_SHORTENED_REPORTING].default_value = g_settings_shortenedreporting;
+    self->priv->options[ABRT_OPT_SHORTENED_REPORTING].default_value = abrt_g_settings_shortenedreporting;
     self->priv->options[ABRT_OPT_SHORTENED_REPORTING].config = self->priv->abrt_applet_conf;
 
     self->priv->options[ABRT_OPT_SILENT_SHORTENED_REPORTING].name = "SilentShortenedReporting";

--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -123,7 +123,7 @@ static void ParseCommon(map_string_t *settings, const char *conf_filename)
 static void load_gpg_keys(void)
 {
     map_string_t *settings = new_map_string();
-    if (!load_abrt_conf_file(GPG_CONF, settings))
+    if (!abrt_load_abrt_conf_file(GPG_CONF, settings))
     {
         error_msg("Can't load '%s'", GPG_CONF);
         return;
@@ -167,7 +167,7 @@ static int load_conf(const char *conf_filename)
     else
     {
         conf_filename = "abrt-action-save-package-data.conf";
-        if (!load_abrt_conf_file(conf_filename, settings))
+        if (!abrt_load_abrt_conf_file(conf_filename, settings))
             error_msg("Can't load '%s'", conf_filename);
     }
 
@@ -302,7 +302,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
 
     /* Do not implicitly query rpm database in process's root dir, if
      * ExploreChroots is disabled. */
-    if (g_settings_explorechroots && chroot == NULL)
+    if (abrt_g_settings_explorechroots && chroot == NULL)
         chroot = rootdir = dd_load_text_ext(dd, FILENAME_ROOTDIR,
                                DD_FAIL_QUIETLY_ENOENT | DD_LOAD_TEXT_RETURN_NULL_ON_FAILURE);
 

--- a/src/daemon/abrt-auto-reporting.c
+++ b/src/daemon/abrt-auto-reporting.c
@@ -57,7 +57,7 @@ set_abrt_reporting(map_string_t *conf, const char *opt_value)
        || (cur_value != NULL && strcmp(cur_value, opt_value) != 0))
     {
         replace_map_string_item(conf, xstrdup(OPTION_NAME), xstrdup(opt_value));
-        return save_abrt_conf_file(CONF_NAME, conf);
+        return abrt_save_abrt_conf_file(CONF_NAME, conf);
     }
 
     /* No changes needed -> success */
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
     map_string_t *ureport_conf = new_map_string();
     map_string_t *ureport_conf_bck = NULL;
 
-    if (!load_abrt_conf_file(CONF_NAME, conf))
+    if (!abrt_load_abrt_conf_file(CONF_NAME, conf))
         goto finito;
 
 #if AUTHENTICATED_AUTOREPORTING != 0

--- a/src/daemon/abrt-handle-event.c
+++ b/src/daemon/abrt-handle-event.c
@@ -237,7 +237,7 @@ static int is_crash_a_dup(const char *dump_dir_name, void *param)
     /* dump_dir_name can be relative */
     dump_dir_name = realpath(dump_dir_name, NULL);
 
-    DIR *dir = opendir(g_settings_dump_location);
+    DIR *dir = opendir(abrt_g_settings_dump_location);
     if (dir == NULL)
         goto end;
 
@@ -254,7 +254,7 @@ static int is_crash_a_dup(const char *dump_dir_name, void *param)
 
         dd = NULL;
 
-        char *tmp_concat_path = concat_path_file(g_settings_dump_location, dent->d_name);
+        char *tmp_concat_path = concat_path_file(abrt_g_settings_dump_location, dent->d_name);
 
         char *dump_dir_name2 = realpath(tmp_concat_path, NULL);
         if (g_verbose > 1 && !dump_dir_name2)
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
     if (!*argv || !event_name)
         show_usage_and_die(program_usage_string, program_options);
 
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     const char *const opt_env_nice = getenv("ABRT_EVENT_NICE");
     if (opt_env_nice != NULL && opt_env_nice[0] != '\0')

--- a/src/daemon/abrt-upload-watch.c
+++ b/src/daemon/abrt-upload-watch.c
@@ -90,12 +90,12 @@ run_abrt_handle_upload(struct process *proc, const char *name)
     {
         /* child */
         xchdir(proc->upload_directory);
-        if (g_settings_delete_uploaded)
+        if (abrt_g_settings_delete_uploaded)
             execlp("abrt-handle-upload", "abrt-handle-upload", "-d",
-                           g_settings_dump_location, proc->upload_directory, name, (char*)NULL);
+                           abrt_g_settings_dump_location, proc->upload_directory, name, (char*)NULL);
         else
             execlp("abrt-handle-upload", "abrt-handle-upload",
-                           g_settings_dump_location, proc->upload_directory, name, (char*)NULL);
+                           abrt_g_settings_dump_location, proc->upload_directory, name, (char*)NULL);
         perror_msg_and_die("Can't execute '%s'", "abrt-handle-upload");
     }
 }
@@ -312,11 +312,11 @@ main(int argc, char **argv)
 
     /* Initialization */
     log_info("Loading settings");
-    if (load_abrt_conf() != 0)
+    if (abrt_load_abrt_conf() != 0)
         return 1;
 
     if (!proc.upload_directory)
-        proc.upload_directory = g_settings_sWatchCrashdumpArchiveDir;
+        proc.upload_directory = abrt_g_settings_sWatchCrashdumpArchiveDir;
 
     if (!proc.upload_directory)
         error_msg_and_die("Neither UPLOAD_DIRECTORY nor WatchCrashdumpArchiveDir was specified");
@@ -379,7 +379,7 @@ main(int argc, char **argv)
     if (proc.main_loop)
         g_main_loop_unref(proc.main_loop);
 
-    free_abrt_conf_data();
+    abrt_free_abrt_conf_data();
 
     return 0;
 }

--- a/src/dbus/abrt_problems2.c
+++ b/src/dbus/abrt_problems2.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 
     glib_init();
     abrt_init(argv);
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     const char *program_usage_string = "& [options]";
 
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
     if (owner_id > 0)
         g_bus_unown_name(owner_id);
 
-    free_abrt_conf_data();
+    abrt_free_abrt_conf_data();
 
     return 0;
 }

--- a/src/dbus/abrt_problems2_entry.c
+++ b/src/dbus/abrt_problems2_entry.c
@@ -655,7 +655,7 @@ int abrt_p2_entry_save_elements_in_dump_dir(struct dump_dir *dd,
                 data_size = (off_t)size;
             }
 
-            if (allowed_new_user_problem_entry(caller_uid, name, data) == false)
+            if (abrt_new_user_problem_entry_allowed(caller_uid, name, data) == false)
             {
                 error_msg("Not allowed for user %lu: %s = %s",
                           (long unsigned)caller_uid,

--- a/src/dbus/abrt_problems2_service.c
+++ b/src/dbus/abrt_problems2_service.c
@@ -1547,7 +1547,7 @@ char *abrt_p2_service_save_problem( AbrtP2Service *service,
                         abrt_p2_service_elements_limit(service, caller_uid),
                         abrt_p2_service_data_size_limit(service, caller_uid));
 
-    struct dump_dir *dd = create_dump_dir(g_settings_dump_location,
+    struct dump_dir *dd = create_dump_dir(abrt_g_settings_dump_location,
                                           type_str,
                                           /*fs owner*/0,
                                           (save_data_call_back)entry_object_wrapped_abrt_p2_entry_save_elements,
@@ -2610,7 +2610,7 @@ int abrt_p2_service_register_objects(AbrtP2Service *service, GDBusConnection *co
     args.service = service;
     args.error = error;
 
-    for_each_problem_in_dir(g_settings_dump_location, (uid_t)-1, bridge_register_dump_dir_entry_node, &args);
+    for_each_problem_in_dir(abrt_g_settings_dump_location, (uid_t)-1, bridge_register_dump_dir_entry_node, &args);
 
     if (*args.error != NULL)
     {

--- a/src/dbus/abrt_problems2_task_new_problem.c
+++ b/src/dbus/abrt_problems2_task_new_problem.c
@@ -167,7 +167,7 @@ static int abrt_p2_task_new_problem_notify_directory_task(AbrtP2TaskNewProblem *
 
     char *message = NULL;
     const char *problem_id = abrt_p2_entry_problem_id(entry);
-    int r = notify_new_path_with_response(problem_id, &message);
+    int r = abrt_notify_new_path_with_response(problem_id, &message);
     if (r < 0)
     {
         log_debug("Task '%p': Failed to communicate with the problems daemon",

--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -31,76 +31,51 @@ int vdprintf(int d, const char *format, va_list ap);
 #endif
 
 
-#define low_free_space abrt_low_free_space
 /**
   @brief Checks if there is enough free space to store the problem data
 
   @param setting_MaxCrashReportsSize Maximum data size
   @param dump_location Location to check for the available space
 */
-int low_free_space(unsigned setting_MaxCrashReportsSize, const char *dump_location);
+int abrt_low_free_space(unsigned setting_MaxCrashReportsSize, const char *dump_location);
 
-#define trim_problem_dirs abrt_trim_problem_dirs
-void trim_problem_dirs(const char *dirname, double cap_size, const char *exclude_path);
-#define ensure_writable_dir_id abrt_ensure_writable_dir_uid_git
-void ensure_writable_dir_uid_gid(const char *dir, mode_t mode, uid_t uid, gid_t gid);
-#define ensure_writable_dir abrt_ensure_writable_dir
-void ensure_writable_dir(const char *dir, mode_t mode, const char *user);
-#define ensure_writable_dir_group abrt_ensure_writable_dir_group
-void ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, const char *group);
-#define run_unstrip_n abrt_run_unstrip_n
-char *run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
-#define get_backtrace abrt_get_backtrace
-char *get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char *debuginfo_dirs);
+void abrt_trim_problem_dirs(const char *dirname, double cap_size, const char *exclude_path);
+void abrt_ensure_writable_dir_uid_gid(const char *dir, mode_t mode, uid_t uid, gid_t gid);
+void abrt_ensure_writable_dir(const char *dir, mode_t mode, const char *user);
+void abrt_ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, const char *group);
+char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
+char *abrt_get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char *debuginfo_dirs);
 
-#define dir_is_in_dump_location abrt_dir_is_in_dump_location
-bool dir_is_in_dump_location(const char *dir_name);
+bool abrt_dir_is_in_dump_location(const char *dir_name);
 
 enum {
     DD_PERM_EVENTS  = 1 << 0,
     DD_PERM_DAEMONS = 1 << 1,
 };
-#define dir_has_correct_permissions abrt_dir_has_correct_permissions
-bool dir_has_correct_permissions(const char *dir_name, int flags);
-#define allowed_new_user_problem_entry abrt_allowed_new_user_problem_entry
-bool allowed_new_user_problem_entry(uid_t uid, const char *name, const char *value);
+bool abrt_dir_has_correct_permissions(const char *dir_name, int flags);
+bool abrt_new_user_problem_entry_allowed(uid_t uid, const char *name, const char *value);
 
-#define g_settings_nMaxCrashReportsSize abrt_g_settings_nMaxCrashReportsSize
-extern unsigned int  g_settings_nMaxCrashReportsSize;
-#define g_settings_sWatchCrashdumpArchiveDir abrt_g_settings_sWatchCrashdumpArchiveDir
-extern char *        g_settings_sWatchCrashdumpArchiveDir;
-#define g_settings_dump_location abrt_g_settings_dump_location
-extern char *        g_settings_dump_location;
-#define g_settings_delete_uploaded abrt_g_settings_delete_uploaded
-extern bool          g_settings_delete_uploaded;
-#define g_settings_autoreporting abrt_g_settings_autoreporting
-extern bool          g_settings_autoreporting;
-#define g_settings_autoreporting_event abrt_g_settings_autoreporting_event
-extern char *        g_settings_autoreporting_event;
-#define g_settings_shortenedreporting abrt_g_settings_shortenedreporting
-extern bool          g_settings_shortenedreporting;
-#define g_settings_explorechroots abrt_g_settings_explorechroots
-extern bool          g_settings_explorechroots;
-#define g_settings_debug_level abrt_g_settings_debug_level
-extern unsigned int  g_settings_debug_level;
+extern unsigned int  abrt_g_settings_nMaxCrashReportsSize;
+extern char *        abrt_g_settings_sWatchCrashdumpArchiveDir;
+extern char *        abrt_g_settings_dump_location;
+extern bool          abrt_g_settings_delete_uploaded;
+extern bool          abrt_g_settings_autoreporting;
+extern char *        abrt_g_settings_autoreporting_event;
+extern bool          abrt_g_settings_shortenedreporting;
+extern bool          abrt_g_settings_explorechroots;
+extern unsigned int  abrt_g_settings_debug_level;
 
 
-#define load_abrt_conf abrt_load_abrt_conf
-int load_abrt_conf(void);
-#define free_abrt_conf_data abrt_free_abrt_conf_data
-void free_abrt_conf_data(void);
+int abrt_load_abrt_conf(void);
+void abrt_free_abrt_conf_data(void);
 
-#define load_abrt_conf_file abrt_load_abrt_conf_file
-int load_abrt_conf_file(const char *file, map_string_t *settings);
+int abrt_load_abrt_conf_file(const char *file, map_string_t *settings);
 
-#define load_abrt_plugin_conf_file abrt_load_abrt_plugin_conf_file
-int load_abrt_plugin_conf_file(const char *file, map_string_t *settings);
+int abrt_load_abrt_plugin_conf_file(const char *file, map_string_t *settings);
 
-#define save_abrt_conf_file abrt_save_abrt_conf_file
-int save_abrt_conf_file(const char *file, map_string_t *settings);
+int abrt_save_abrt_conf_file(const char *file, map_string_t *settings);
 
-#define save_abrt_plugin_conf_file abrt_save_abrt_plugin_conf_file
-int save_abrt_plugin_conf_file(const char *file, map_string_t *settings);
+int abrt_save_abrt_plugin_conf_file(const char *file, map_string_t *settings);
 
 
 void migrate_to_xdg_dirs(void);
@@ -108,16 +83,14 @@ void migrate_to_xdg_dirs(void);
 int check_recent_crash_file(const char *filename, const char *executable);
 
 /* Returns 1 if abrtd daemon is running, 0 otherwise. */
-#define daemon_is_ok abrt_daemon_is_ok
-int daemon_is_ok(void);
+int abrt_daemon_is_ok(void);
 
 /**
 @brief Sends notification to abrtd that a new problem has been detected
 
 @param[in] path Path to the problem directory containing the problem data
 */
-#define notify_new_path abrt_notify_new_path
-void notify_new_path(const char *path);
+void abrt_notify_new_path(const char *path);
 
 /**
 @brief Sends notification to abrtd that a new problem has been detected and
@@ -127,26 +100,18 @@ wait for the reply
 @param message The abrtd reply
 @return -errno on error otherwise return value of abrtd
 */
-#define notify_new_path_with_response abrt_notify_new_path_with_response
-int notify_new_path_with_response(const char *path, char **message);
+int abrt_notify_new_path_with_response(const char *path, char **message);
 
 /* Note: should be public since unit tests need to call it */
-#define koops_extract_version abrt_koops_extract_version
-char *koops_extract_version(const char *line);
-#define kernel_tainted_short abrt_kernel_tainted_short
-char *kernel_tainted_short(const char *kernel_bt);
-#define kernel_tainted_long abrt_kernel_tainted_long
-char *kernel_tainted_long(const char *tainted_short);
-#define koops_hash_str_ext abrt_koops_hash_str_ext
-char *koops_hash_str_ext(const char *oops_buf, int frame_count, int duphas_flags);
-#define koops_hash_str abrt_koops_hash_str
-char *koops_hash_str(const char *oops_buf);
+char *abrt_koops_extract_version(const char *line);
+char *abrt_kernel_tainted_short(const char *kernel_bt);
+char *abrt_kernel_tainted_long(const char *tainted_short);
+char *abrt_koops_hash_str_ext(const char *oops_buf, int frame_count, int duphas_flags);
+char *abrt_koops_hash_str(const char *oops_buf);
 
 
-#define koops_line_skip_level abrt_koops_line_skip_level
-int koops_line_skip_level(const char **c);
-#define koops_line_skip_jiffies abrt_koops_line_skip_jiffies
-void koops_line_skip_jiffies(const char **c);
+int abrt_koops_line_skip_level(const char **c);
+void abrt_koops_line_skip_jiffies(const char **c);
 
 /*
  * extract_oops tries to find oops signatures in a log
@@ -156,24 +121,18 @@ struct abrt_koops_line_info {
     int level;
 };
 
-#define koops_extract_oopses_from_lines abrt_koops_extract_oopses_from_lines
-void koops_extract_oopses_from_lines(GList **oops_list, const struct abrt_koops_line_info *lines_info, int lines_info_size);
-#define koops_extract_oopses abrt_koops_extract_oopses
-void koops_extract_oopses(GList **oops_list, char *buffer, size_t buflen);
-#define koops_suspicious_strings_list abrt_koops_suspicious_strings_list
-GList *koops_suspicious_strings_list(void);
-#define koops_suspicious_strings_blacklist abrt_koops_suspicious_strings_blacklist
-GList *koops_suspicious_strings_blacklist(void);
-#define koops_print_suspicious_strings abrt_koops_print_suspicious_strings
-void koops_print_suspicious_strings(void);
+void abrt_koops_extract_oopses_from_lines(GList **oops_list, const struct abrt_koops_line_info *lines_info, int lines_info_size);
+void abrt_koops_extract_oopses(GList **oops_list, char *buffer, size_t buflen);
+GList *abrt_koops_suspicious_strings_list(void);
+GList *abrt_koops_suspicious_strings_blacklist(void);
+void abrt_koops_print_suspicious_strings(void);
 /**
  * Prints all suspicious strings that do not match any of the regular
  * expression in NULL terminated list.
  *
  * The regular expression should be compiled with REG_NOSUB flag.
  */
-#define koops_print_suspicious_strings_filtered abrt_koops_print_suspicious_strings_filtered
-void koops_print_suspicious_strings_filtered(const regex_t **filterout);
+void abrt_koops_print_suspicious_strings_filtered(const regex_t **filterout);
 
 /* dbus client api */
 

--- a/src/lib/abrt_conf.c
+++ b/src/lib/abrt_conf.c
@@ -20,26 +20,26 @@
 
 #define ABRT_CONF "abrt.conf"
 
-char *        g_settings_sWatchCrashdumpArchiveDir = NULL;
-unsigned int  g_settings_nMaxCrashReportsSize = 5000;
-char *        g_settings_dump_location = NULL;
-bool          g_settings_delete_uploaded = 0;
-bool          g_settings_autoreporting = 0;
-char *        g_settings_autoreporting_event = NULL;
-bool          g_settings_shortenedreporting = 0;
-bool          g_settings_explorechroots = 0;
-unsigned int  g_settings_debug_level = 0;
+char *        abrt_g_settings_sWatchCrashdumpArchiveDir = NULL;
+unsigned int  abrt_g_settings_nMaxCrashReportsSize = 5000;
+char *        abrt_g_settings_dump_location = NULL;
+bool          abrt_g_settings_delete_uploaded = 0;
+bool          abrt_g_settings_autoreporting = 0;
+char *        abrt_g_settings_autoreporting_event = NULL;
+bool          abrt_g_settings_shortenedreporting = 0;
+bool          abrt_g_settings_explorechroots = 0;
+unsigned int  abrt_g_settings_debug_level = 0;
 
-void free_abrt_conf_data()
+void abrt_free_abrt_conf_data()
 {
-    free(g_settings_sWatchCrashdumpArchiveDir);
-    g_settings_sWatchCrashdumpArchiveDir = NULL;
+    free(abrt_g_settings_sWatchCrashdumpArchiveDir);
+    abrt_g_settings_sWatchCrashdumpArchiveDir = NULL;
 
-    free(g_settings_dump_location);
-    g_settings_dump_location = NULL;
+    free(abrt_g_settings_dump_location);
+    abrt_g_settings_dump_location = NULL;
 
-    free(g_settings_autoreporting_event);
-    g_settings_autoreporting_event = NULL;
+    free(abrt_g_settings_autoreporting_event);
+    abrt_g_settings_autoreporting_event = NULL;
 }
 
 /* Beware - the function normalizes only slashes - that's the most often
@@ -72,7 +72,7 @@ static void ParseCommon(map_string_t *settings, const char *conf_filename)
     value = get_map_string_item_or_NULL(settings, "WatchCrashdumpArchiveDir");
     if (value)
     {
-        g_settings_sWatchCrashdumpArchiveDir = xstrdup_normalized_path(value);
+        abrt_g_settings_sWatchCrashdumpArchiveDir = xstrdup_normalized_path(value);
         remove_map_string_item(settings, "WatchCrashdumpArchiveDir");
     }
 
@@ -85,63 +85,63 @@ static void ParseCommon(map_string_t *settings, const char *conf_filename)
         if (errno || end == value || *end != '\0' || ul > INT_MAX)
             error_msg("Error parsing %s setting: '%s'", "MaxCrashReportsSize", value);
         else
-            g_settings_nMaxCrashReportsSize = ul;
+            abrt_g_settings_nMaxCrashReportsSize = ul;
         remove_map_string_item(settings, "MaxCrashReportsSize");
     }
 
     value = get_map_string_item_or_NULL(settings, "DumpLocation");
     if (value)
     {
-        g_settings_dump_location = xstrdup_normalized_path(value);
+        abrt_g_settings_dump_location = xstrdup_normalized_path(value);
         remove_map_string_item(settings, "DumpLocation");
     }
     else
-        g_settings_dump_location = xstrdup(DEFAULT_DUMP_LOCATION);
+        abrt_g_settings_dump_location = xstrdup(DEFAULT_DUMP_LOCATION);
 
     value = get_map_string_item_or_NULL(settings, "DeleteUploaded");
     if (value)
     {
-        g_settings_delete_uploaded = string_to_bool(value);
+        abrt_g_settings_delete_uploaded = string_to_bool(value);
         remove_map_string_item(settings, "DeleteUploaded");
     }
 
     value = get_map_string_item_or_NULL(settings, "AutoreportingEnabled");
     if (value)
     {
-        g_settings_autoreporting = string_to_bool(value);
+        abrt_g_settings_autoreporting = string_to_bool(value);
         remove_map_string_item(settings, "AutoreportingEnabled");
     }
 
     value = get_map_string_item_or_NULL(settings, "AutoreportingEvent");
     if (value)
     {
-        g_settings_autoreporting_event = xstrdup(value);
+        abrt_g_settings_autoreporting_event = xstrdup(value);
         remove_map_string_item(settings, "AutoreportingEvent");
     }
     else
-        g_settings_autoreporting_event = xstrdup("report_uReport");
+        abrt_g_settings_autoreporting_event = xstrdup("report_uReport");
 
     value = get_map_string_item_or_NULL(settings, "ShortenedReporting");
     if (value)
     {
-        g_settings_shortenedreporting = string_to_bool(value);
+        abrt_g_settings_shortenedreporting = string_to_bool(value);
         remove_map_string_item(settings, "ShortenedReporting");
     }
     else
     {
         /* Default: enabled for GNOME desktop, else disabled */
         const char *desktop_env = getenv("DESKTOP_SESSION");
-        g_settings_shortenedreporting = (desktop_env && strcasestr(desktop_env, "gnome") != NULL);
+        abrt_g_settings_shortenedreporting = (desktop_env && strcasestr(desktop_env, "gnome") != NULL);
     }
 
     value = get_map_string_item_or_NULL(settings, "ExploreChroots");
     if (value)
     {
-        g_settings_explorechroots = string_to_bool(value);
+        abrt_g_settings_explorechroots = string_to_bool(value);
         remove_map_string_item(settings, "ExploreChroots");
     }
     else
-        g_settings_explorechroots = false;
+        abrt_g_settings_explorechroots = false;
 
     value = get_map_string_item_or_NULL(settings, "DebugLevel");
     if (value)
@@ -152,7 +152,7 @@ static void ParseCommon(map_string_t *settings, const char *conf_filename)
         if (errno || end == value || *end != '\0' || ul > INT_MAX)
             error_msg("Error parsing %s setting: '%s'", "DebugLevel", value);
         else
-            g_settings_debug_level = ul;
+            abrt_g_settings_debug_level = ul;
         remove_map_string_item(settings, "DebugLevel");
     }
 
@@ -172,13 +172,13 @@ static const char *get_abrt_conf_file_name(void)
     return abrt_conf == NULL ? ABRT_CONF : abrt_conf;
 }
 
-int load_abrt_conf()
+int abrt_load_abrt_conf()
 {
-    free_abrt_conf_data();
+    abrt_free_abrt_conf_data();
 
     const char *const abrt_conf = get_abrt_conf_file_name();
     map_string_t *settings = new_map_string();
-    if (!load_abrt_conf_file(abrt_conf, settings))
+    if (!abrt_load_abrt_conf_file(abrt_conf, settings))
         perror_msg("Can't load '%s'", abrt_conf);
 
     ParseCommon(settings, abrt_conf);
@@ -187,7 +187,7 @@ int load_abrt_conf()
     return 0;
 }
 
-int load_abrt_conf_file(const char *file, map_string_t *settings)
+int abrt_load_abrt_conf_file(const char *file, map_string_t *settings)
 {
     const char *env_conf_dir = getenv("ABRT_CONF_DIR");
     const char *const conf_directories[] = {
@@ -198,14 +198,14 @@ int load_abrt_conf_file(const char *file, map_string_t *settings)
     return load_conf_file_from_dirs(file, conf_directories, settings, /*skip key w/o values:*/ false);
 }
 
-int load_abrt_plugin_conf_file(const char *file, map_string_t *settings)
+int abrt_load_abrt_plugin_conf_file(const char *file, map_string_t *settings)
 {
     static const char *const conf_directories[] = { PLUGINS_CONF_DIR, NULL };
 
     return load_conf_file_from_dirs(file, conf_directories, settings, /*skip key w/o values:*/ false);
 }
 
-int save_abrt_conf_file(const char *file, map_string_t *settings)
+int abrt_save_abrt_conf_file(const char *file, map_string_t *settings)
 {
     char *path = concat_path_file(CONF_DIR, file);
     int retval = save_conf_file(path, settings);
@@ -213,7 +213,7 @@ int save_abrt_conf_file(const char *file, map_string_t *settings)
     return retval;
 }
 
-int save_abrt_plugin_conf_file(const char *file, map_string_t *settings)
+int abrt_save_abrt_plugin_conf_file(const char *file, map_string_t *settings)
 {
     char *path = concat_path_file(PLUGINS_CONF_DIR, file);
     int retval = save_conf_file(path, settings);

--- a/src/lib/daemon_is_ok.c
+++ b/src/lib/daemon_is_ok.c
@@ -17,7 +17,7 @@
 */
 #include "libabrt.h"
 
-int daemon_is_ok()
+int abrt_daemon_is_ok()
 {
     int fd = open(VAR_RUN"/abrt/abrtd.pid", O_RDONLY);
     if (fd < 0)

--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -51,7 +51,7 @@ static void record_oops(GList **oops_list, const struct abrt_koops_line_info* li
         for (q = oopsstart; q <= oopsend; q++)
         {
             if (!version)
-                version = koops_extract_version(lines_info[q].ptr);
+                version = abrt_koops_extract_version(lines_info[q].ptr);
             if (lines_info[q].ptr[0])
             {
                 dst = stpcpy(dst, lines_info[q].ptr);
@@ -179,12 +179,12 @@ static bool suspicious_line(const char *line)
     return !*str;
 }
 
-void koops_print_suspicious_strings(void)
+void abrt_koops_print_suspicious_strings(void)
 {
-    koops_print_suspicious_strings_filtered(NULL);
+    abrt_koops_print_suspicious_strings_filtered(NULL);
 }
 
-GList *koops_suspicious_strings_list(void)
+GList *abrt_koops_suspicious_strings_list(void)
 {
     GList *strings = NULL;
     for (const char *const *str = s_koops_suspicious_strings; *str; ++str)
@@ -193,7 +193,7 @@ GList *koops_suspicious_strings_list(void)
     return strings;
 }
 
-GList *koops_suspicious_strings_blacklist(void)
+GList *abrt_koops_suspicious_strings_blacklist(void)
 {
     GList *strings = NULL;
     for (const char *const *str = s_koops_suspicious_strings_blacklist; *str; ++str)
@@ -221,7 +221,7 @@ static bool match_any(const regex_t **res, const char *str)
     return false;
 }
 
-void koops_print_suspicious_strings_filtered(const regex_t **filterout)
+void abrt_koops_print_suspicious_strings_filtered(const regex_t **filterout)
 {
     for (const char *const *str = s_koops_suspicious_strings; *str; ++str)
     {
@@ -231,7 +231,7 @@ void koops_print_suspicious_strings_filtered(const regex_t **filterout)
 }
 
 
-void koops_line_skip_jiffies(const char **c)
+void abrt_koops_line_skip_jiffies(const char **c)
 {
     /* remove jiffies time stamp counter if present
      * jiffies are unsigned long, so it can be 2^64 long, which is
@@ -250,7 +250,7 @@ void koops_line_skip_jiffies(const char **c)
     }
 }
 
-int koops_line_skip_level(const char **c)
+int abrt_koops_line_skip_level(const char **c)
 {
     int linelevel = 0;
     if (**c == '<')
@@ -275,7 +275,7 @@ int koops_line_skip_level(const char **c)
     return linelevel;
 }
 
-void koops_extract_oopses(GList **oops_list, char *buffer, size_t buflen)
+void abrt_koops_extract_oopses(GList **oops_list, char *buffer, size_t buflen)
 {
     char hostname[HOST_NAME_MAX + 1] = { 0 };
     g_autofree char *long_needle = NULL;
@@ -375,8 +375,8 @@ void koops_extract_oopses(GList **oops_list, char *buffer, size_t buflen)
         }
 
         /* store and remove kernel log level */
-        linelevel = koops_line_skip_level((const char **)&c);
-        koops_line_skip_jiffies((const char **)&c);
+        linelevel = abrt_koops_line_skip_level((const char **)&c);
+        abrt_koops_line_skip_jiffies((const char **)&c);
 
         if ((lines_info_size & 0xfff) == 0)
         {
@@ -389,11 +389,11 @@ next_line:
         c = c9 + 1;
     }
 
-    koops_extract_oopses_from_lines(oops_list, lines_info, lines_info_size);
+    abrt_koops_extract_oopses_from_lines(oops_list, lines_info, lines_info_size);
     free(lines_info);
 }
 
-void koops_extract_oopses_from_lines(GList **oops_list, const struct abrt_koops_line_info *lines_info, int lines_info_size)
+void abrt_koops_extract_oopses_from_lines(GList **oops_list, const struct abrt_koops_line_info *lines_info, int lines_info_size)
 {
     /* Analyze lines */
 
@@ -576,7 +576,7 @@ void koops_extract_oopses_from_lines(GList **oops_list, const struct abrt_koops_
     }
 }
 
-char *koops_hash_str_ext(const char *oops_buf, int frame_count, int duphash_flags)
+char *abrt_koops_hash_str_ext(const char *oops_buf, int frame_count, int duphash_flags)
 {
     g_autofree char *error = NULL;
     char *digest = NULL;
@@ -616,14 +616,14 @@ end:
     return digest;
 }
 
-char *koops_hash_str(const char *oops_buf)
+char *abrt_koops_hash_str(const char *oops_buf)
 {
     const int frame_count = 6;
     const int duphash_flags = SR_DUPHASH_NONORMALIZE|SR_DUPHASH_KOOPS_COMPAT;
-    return koops_hash_str_ext(oops_buf, frame_count, duphash_flags);
+    return abrt_koops_hash_str_ext(oops_buf, frame_count, duphash_flags);
 }
 
-char *koops_extract_version(const char *linepointer)
+char *abrt_koops_extract_version(const char *linepointer)
 {
     if (strstr(linepointer, "Pid")
      || strstr(linepointer, "comm")
@@ -723,7 +723,7 @@ static char *turn_off_flag(char *flags, char flag)
 }
 #endif
 
-char *kernel_tainted_short(const char *kernel_bt)
+char *abrt_kernel_tainted_short(const char *kernel_bt)
 {
     /* example of flags: 'Tainted: G    B       ' */
     char *tainted = strstr(kernel_bt, "Tainted: ");
@@ -799,7 +799,7 @@ static const char *const tnts_long[] = {
     /* Z */ NULL,
 };
 
-char *kernel_tainted_long(const char *tainted_short)
+char *abrt_kernel_tainted_long(const char *tainted_short)
 {
     struct strbuf *tnt_long = strbuf_new();
     while (tainted_short[0] != '\0')

--- a/src/lib/notify_new_path.c
+++ b/src/lib/notify_new_path.c
@@ -18,13 +18,13 @@
 #include <sys/un.h>
 #include "libabrt.h"
 
-void notify_new_path(const char *path)
+void abrt_notify_new_path(const char *path)
 {
     /* Ignore results and don't wait for response -> NULL */
-    notify_new_path_with_response(path, NULL);
+    abrt_notify_new_path_with_response(path, NULL);
 }
 
-int notify_new_path_with_response(const char *path, char **message)
+int abrt_notify_new_path_with_response(const char *path, char **message)
 {
     int retval;
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);

--- a/src/lib/problem_api.c
+++ b/src/lib/problem_api.c
@@ -88,7 +88,7 @@ int for_each_problem_in_dir(const char *path,
 
 static int add_dirname_to_GList(struct dump_dir *dd, void *arg)
 {
-    if (!dir_has_correct_permissions(dd->dd_dirname, DD_PERM_DAEMONS))
+    if (!abrt_dir_has_correct_permissions(dd->dd_dirname, DD_PERM_DAEMONS))
     {
         log_warning("Ignoring '%s': invalid owner, group or mode", dd->dd_dirname);
         /*Do not break*/
@@ -145,9 +145,9 @@ GList *get_problem_dirs_not_accessible_by_uid(uid_t uid, const char *dump_locati
 GList *get_problem_storages(void)
 {
     GList *paths = NULL;
-    load_abrt_conf();
-    paths = g_list_append(paths, xstrdup(g_settings_dump_location));
-    free_abrt_conf_data();
+    abrt_load_abrt_conf();
+    paths = g_list_append(paths, xstrdup(abrt_g_settings_dump_location));
+    abrt_free_abrt_conf_data();
 
     return paths;
 }

--- a/src/plugins/abrt-action-analyze-c.c
+++ b/src/plugins/abrt-action-analyze-c.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
     char *unstrip_n_output = NULL;
     char *coredump_path = xasprintf("%s/"FILENAME_COREDUMP, dump_dir_name);
     if (access(coredump_path, R_OK) == 0)
-        unstrip_n_output = run_unstrip_n(dump_dir_name, /*timeout_sec:*/ 30);
+        unstrip_n_output = abrt_run_unstrip_n(dump_dir_name, /*timeout_sec:*/ 30);
 
     free(coredump_path);
 

--- a/src/plugins/abrt-action-analyze-oops.c
+++ b/src/plugins/abrt-action-analyze-oops.c
@@ -78,10 +78,10 @@ int main(int argc, char **argv)
     }
     settings = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
-    load_abrt_plugin_conf_file("oops.conf", settings);
+    abrt_load_abrt_plugin_conf_file("oops.conf", settings);
 
     oops = dd_load_text(dd, FILENAME_BACKTRACE);
-    hash_str = koops_hash_str(oops);
+    hash_str = abrt_koops_hash_str(oops);
     if (NULL == hash_str)
     {
         error_msg("Can't find a meaningful backtrace for hashing in '%s'", dump_directory);
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
             /* We need UUID file for the local duplicates look-up and DUPHASH */
             /* file is also useful because user can force ABRT to report */
             /* the oops into a bug tracking system (Bugzilla). */
-            hash_str = koops_hash_str_ext(oops,
+            hash_str = abrt_koops_hash_str_ext(oops,
                     /* use no frame count limit */-1,
                     /* use every frame in stacktrace */0);
 

--- a/src/plugins/abrt-action-analyze-xorg.c
+++ b/src/plugins/abrt-action-analyze-xorg.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 
     map_string_t *settings = new_map_string();
     log_notice("Loading settings from '%s'", XORG_CONF);
-    load_abrt_plugin_conf_file(XORG_CONF, settings);
+    abrt_load_abrt_plugin_conf_file(XORG_CONF, settings);
     log_debug("Loaded '%s'", XORG_CONF);
 
     const char *value = get_map_string_item_or_NULL(settings, "BlacklistedXorgModules");

--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
     export_abrt_envvars(0);
 
     map_string_t *settings = new_map_string();
-    if (!load_abrt_plugin_conf_file(CCPP_CONF, settings))
+    if (!abrt_load_abrt_plugin_conf_file(CCPP_CONF, settings))
         error_msg("Can't load '%s'", CCPP_CONF);
 
     const char *value = get_map_string_item_or_NULL(settings, "DebuginfoLocation");
@@ -78,16 +78,16 @@ int main(int argc, char **argv)
         debuginfo_dirs = xasprintf("%s:%s", debuginfo_location, i_opt);
 
     /* Create gdb backtrace */
-    char *backtrace = get_backtrace(dump_dir_name, exec_timeout_sec,
+    char *backtrace = abrt_get_backtrace(dump_dir_name, exec_timeout_sec,
             (debuginfo_dirs) ? debuginfo_dirs : debuginfo_location);
     free(debuginfo_location);
     if (!backtrace)
     {
         backtrace = xstrdup("");
-        log_warning("get_backtrace() returns NULL, broken core/gdb?");
+        log_warning("abrt_get_backtrace() returns NULL, broken core/gdb?");
     }
     free(debuginfo_dirs);
-    free_abrt_conf_data();
+    abrt_free_abrt_conf_data();
 
     /* Store gdb backtrace */
 

--- a/src/plugins/abrt-action-generate-core-backtrace.c
+++ b/src/plugins/abrt-action-generate-core-backtrace.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     /* The value 240 was taken from abrt-action-generate-backtrace.c. */
     int exec_timeout_sec = 240;
 
-    char *gdb_output = get_backtrace(dump_dir_name, exec_timeout_sec, NULL);
+    char *gdb_output = abrt_get_backtrace(dump_dir_name, exec_timeout_sec, NULL);
     if (!gdb_output)
     {
         log_warning(_("Error: GDB did not return any data"));

--- a/src/plugins/abrt-action-trim-files.c
+++ b/src/plugins/abrt-action-trim-files.c
@@ -162,7 +162,7 @@ static void delete_dirs(gpointer data, gpointer exclude_path)
     double cap_size;
     const char *dir = parse_size_pfx(&cap_size, data);
 
-    trim_problem_dirs(dir, cap_size, exclude_path);
+    abrt_trim_problem_dirs(dir, cap_size, exclude_path);
 }
 
 static void delete_files(gpointer data, gpointer void_preserve_list)

--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -361,7 +361,7 @@ abrt_journal_core_to_abrt_problem(struct crash_info *info, const char *dump_loca
     {
         char *path = xstrdup(dd->dd_dirname);
         dd_close(dd);
-        notify_new_path(path);
+        abrt_notify_new_path(path);
         log_debug("ABRT daemon has been notified about directory: '%s'", path);
         free(path);
     }
@@ -583,7 +583,7 @@ main(int argc, char *argv[])
         error_msg_and_die(_("You need to specify either -c CURSOR or -e"));
 
     /* Initialize ABRT configuration */
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     if ((opts & OPT_o))
         run_flags |= ABRT_CORE_PRINT_STDOUT;
@@ -592,12 +592,12 @@ main(int argc, char *argv[])
     {
         if (opts & OPT_d)
             show_usage_and_die(program_usage_string, program_options);
-        dump_location = g_settings_dump_location;
+        dump_location = abrt_g_settings_dump_location;
     }
 
     {   /* Load CCpp.conf */
         map_string_t *settings = new_map_string();
-        load_abrt_plugin_conf_file("CCpp.conf", settings);
+        abrt_load_abrt_plugin_conf_file("CCpp.conf", settings);
         const char *value;
 
         value = get_map_string_item_or_NULL(settings, "VerboseLog");
@@ -667,7 +667,7 @@ main(int argc, char *argv[])
         abrt_journal_dump_core(journal, dump_location, run_flags);
 
     abrt_journal_free(journal);
-    free_abrt_conf_data();
+    abrt_free_abrt_conf_data();
 
     return EXIT_SUCCESS;
 }

--- a/src/plugins/abrt-dump-journal-oops.c
+++ b/src/plugins/abrt-dump-journal-oops.c
@@ -46,8 +46,8 @@ static GList* abrt_journal_extract_kernel_oops(abrt_journal_t *journal)
         }
 
         char *orig_line = line;
-        lines_info[lines_info_count].level = koops_line_skip_level((const char **)&line);
-        koops_line_skip_jiffies((const char **)&line);
+        lines_info[lines_info_count].level = abrt_koops_line_skip_level((const char **)&line);
+        abrt_koops_line_skip_jiffies((const char **)&line);
 
         memmove(orig_line, line, strlen(line) + 1);
 
@@ -59,7 +59,7 @@ static GList* abrt_journal_extract_kernel_oops(abrt_journal_t *journal)
             && abrt_journal_next(journal) > 0);
 
     GList *oops_list = NULL;
-    koops_extract_oopses_from_lines(&oops_list, lines_info, lines_info_count);
+    abrt_koops_extract_oopses_from_lines(&oops_list, lines_info, lines_info_count);
 
     log_debug("Extracted: %d oopses", g_list_length(oops_list));
 
@@ -118,7 +118,7 @@ static void abrt_journal_watch_extract_kernel_oops(abrt_journal_watch_t *watch, 
 
 static void watch_journald(abrt_journal_t *journal, const char *dump_location, int flags)
 {
-    GList *koops_strings = koops_suspicious_strings_list();
+    GList *koops_strings = abrt_koops_suspicious_strings_list();
 
     char *oops_string_filter_regex = abrt_oops_string_filter_regex();
     if (oops_string_filter_regex)
@@ -149,7 +149,7 @@ static void watch_journald(abrt_journal_t *journal, const char *dump_location, i
         free(oops_string_filter_regex);
     }
 
-    GList *koops_strings_blacklist = koops_suspicious_strings_blacklist();
+    GList *koops_strings_blacklist = abrt_koops_suspicious_strings_blacklist();
 
     struct watch_journald_settings watch_conf = {
         .dump_location = dump_location,
@@ -252,10 +252,10 @@ int main(int argc, char *argv[])
     {
         if (opts & OPT_d)
             show_usage_and_die(program_usage_string, program_options);
-        load_abrt_conf();
-        dump_location = g_settings_dump_location;
-        g_settings_dump_location = NULL;
-        free_abrt_conf_data();
+        abrt_load_abrt_conf();
+        dump_location = abrt_g_settings_dump_location;
+        abrt_g_settings_dump_location = NULL;
+        abrt_free_abrt_conf_data();
     }
 
     int oops_utils_flags = 0;

--- a/src/plugins/abrt-dump-journal-xorg.c
+++ b/src/plugins/abrt-dump-journal-xorg.c
@@ -219,10 +219,10 @@ int main(int argc, char *argv[])
     {
         if (opts & OPT_d)
             show_usage_and_die(program_usage_string, program_options);
-        load_abrt_conf();
-        dump_location = g_settings_dump_location;
-        g_settings_dump_location = NULL;
-        free_abrt_conf_data();
+        abrt_load_abrt_conf();
+        dump_location = abrt_g_settings_dump_location;
+        abrt_g_settings_dump_location = NULL;
+        abrt_free_abrt_conf_data();
     }
 
     int xorg_utils_flags = 0;
@@ -253,7 +253,7 @@ int main(int argc, char *argv[])
     {
         map_string_t *settings = new_map_string();
         log_notice("Loading settings from '%s'", XORG_CONF);
-        load_abrt_plugin_conf_file(XORG_CONF, settings);
+        abrt_load_abrt_plugin_conf_file(XORG_CONF, settings);
         log_debug("Loaded '%s'", XORG_CONF);
 
         const char *conf_journal_filters = get_map_string_item_or_NULL(settings, "JournalFilters");

--- a/src/plugins/abrt-dump-oops.c
+++ b/src/plugins/abrt-dump-oops.c
@@ -54,7 +54,7 @@ static void scan_syslog_file(GList **oops_list, int fd)
         if (r <= 0)
             break;
         log_debug("Read %u bytes", r);
-        koops_extract_oopses(oops_list, buffer, r);
+        abrt_koops_extract_oopses(oops_list, buffer, r);
 //TODO: rewind to last newline?
     }
 
@@ -128,13 +128,13 @@ int main(int argc, char **argv)
 
             const regex_t *filter[] = { &filter_re, NULL };
 
-            koops_print_suspicious_strings_filtered(filter);
+            abrt_koops_print_suspicious_strings_filtered(filter);
 
             regfree(&filter_re);
             free(oops_string_filter_regex);
         }
         else
-            koops_print_suspicious_strings();
+            abrt_koops_print_suspicious_strings();
 
         return 1;
     }
@@ -143,10 +143,10 @@ int main(int argc, char **argv)
     {
         if (opts & OPT_d)
             show_usage_and_die(program_usage_string, program_options);
-        load_abrt_conf();
-        dump_location = g_settings_dump_location;
-        g_settings_dump_location = NULL;
-        free_abrt_conf_data();
+        abrt_load_abrt_conf();
+        dump_location = abrt_g_settings_dump_location;
+        abrt_g_settings_dump_location = NULL;
+        abrt_free_abrt_conf_data();
     }
 
     int oops_utils_flags = 0;

--- a/src/plugins/abrt-dump-xorg.c
+++ b/src/plugins/abrt-dump-xorg.c
@@ -77,10 +77,10 @@ int main(int argc, char **argv)
     {
         if (opts & OPT_d)
             show_usage_and_die(program_usage_string, program_options);
-        load_abrt_conf();
-        dump_location = g_settings_dump_location;
-        g_settings_dump_location = NULL;
-        free_abrt_conf_data();
+        abrt_load_abrt_conf();
+        dump_location = abrt_g_settings_dump_location;
+        abrt_g_settings_dump_location = NULL;
+        abrt_free_abrt_conf_data();
     }
 
     argv += optind;

--- a/src/plugins/bodhi.c
+++ b/src/plugins/bodhi.c
@@ -622,7 +622,7 @@ int main(int argc, char **argv)
      */
 
     map_string_t *settings = new_map_string();
-    load_abrt_plugin_conf_file("CCpp.conf", settings);
+    abrt_load_abrt_plugin_conf_file("CCpp.conf", settings);
 
     const char *value;
     strbuf_prepend_str(q, " update --enablerepo=fedora --enablerepo=updates --enablerepo=updates-testing");

--- a/src/plugins/oops-utils.c
+++ b/src/plugins/oops-utils.c
@@ -38,7 +38,7 @@ int abrt_oops_process_list(GList *oops_list, const char *dump_location, const ch
             while (i < oops_cnt)
             {
                 char *kernel_bt = (char*)g_list_nth_data(oops_list, i++);
-                char *tainted_short = kernel_tainted_short(kernel_bt);
+                char *tainted_short = abrt_kernel_tainted_short(kernel_bt);
                 if (tainted_short)
                     log_warning("Kernel is tainted '%s'", tainted_short);
 
@@ -128,7 +128,7 @@ unsigned abrt_oops_create_dump_dirs(GList *oops_list, const char *dump_location,
             if ((flags & ABRT_OOPS_WORLD_READABLE))
                 dd_set_no_owner(dd);
             dd_close(dd);
-            notify_new_path(path);
+            abrt_notify_new_path(path);
         }
         else
             errors++;
@@ -235,13 +235,13 @@ void abrt_oops_save_data_in_dump_dir(struct dump_dir *dd, char *oops, const char
                   "therefore kernel maintainers are unable to fix this problem."));
     else
     {
-        char *tainted_short = kernel_tainted_short(second_line);
+        char *tainted_short = abrt_kernel_tainted_short(second_line);
         if (tainted_short)
         {
             log_notice("Kernel is tainted '%s'", tainted_short);
             dd_save_text(dd, FILENAME_TAINTED_SHORT, tainted_short);
 
-            char *tnt_long = kernel_tainted_long(tainted_short);
+            char *tnt_long = abrt_kernel_tainted_long(tainted_short);
             dd_save_text(dd, FILENAME_TAINTED_LONG, tnt_long);
 
             struct strbuf *reason = strbuf_new();
@@ -305,7 +305,7 @@ char *abrt_oops_string_filter_regex(void)
 {
     map_string_t *settings = new_map_string();
 
-    load_abrt_plugin_conf_file("oops.conf", settings);
+    abrt_load_abrt_plugin_conf_file("oops.conf", settings);
 
     int only_fatal_mce = 0;
     try_get_map_string_item_as_bool(settings, "OnlyFatalMCE", &only_fatal_mce);

--- a/src/plugins/xorg-utils.c
+++ b/src/plugins/xorg-utils.c
@@ -134,7 +134,7 @@ void xorg_crash_info_create_dump_dir(struct xorg_crash_info *crash_info, const c
 
     char *path = xstrdup(dd->dd_dirname);
     dd_close(dd);
-    notify_new_path(path);
+    abrt_notify_new_path(path);
     free(path);
 }
 

--- a/src/python-problem/problem/pyabrt.c
+++ b/src/python-problem/problem/pyabrt.c
@@ -21,7 +21,7 @@
 #include "problem_data.h"
 #include "common.h"
 
-/* C: void notify_new_path(const char *path); */
+/* C: void abrt_notify_new_path(const char *path); */
 PyObject *p_notify_new_path(PyObject *pself, PyObject *args)
 {
     const char *path;
@@ -29,7 +29,7 @@ PyObject *p_notify_new_path(PyObject *pself, PyObject *args)
     {
         return NULL;
     }
-    notify_new_path(path);
+    abrt_notify_new_path(path);
     Py_RETURN_NONE;
 }
 
@@ -70,7 +70,7 @@ lacf_error:
     return NULL;
 }
 
-/* C: void load_abrt_conf_file(const char *file, map_string_t *settings); */
+/* C: void abrt_load_abrt_conf_file(const char *file, map_string_t *settings); */
 PyObject *p_load_conf_file(PyObject *pself, PyObject *args)
 {
     const char *file;
@@ -78,10 +78,10 @@ PyObject *p_load_conf_file(PyObject *pself, PyObject *args)
     {
         return NULL;
     }
-    return load_settings_to_dict(file, load_abrt_conf_file);
+    return load_settings_to_dict(file, abrt_load_abrt_conf_file);
 }
 
-/* C: void load_abrt_plugin_conf_file(const char *file, map_string_t *settings); */
+/* C: void abrt_load_abrt_plugin_conf_file(const char *file, map_string_t *settings); */
 PyObject *p_load_plugin_conf_file(PyObject *pself, PyObject *args)
 {
     const char *file;
@@ -89,5 +89,5 @@ PyObject *p_load_plugin_conf_file(PyObject *pself, PyObject *args)
     {
         return NULL;
     }
-    return load_settings_to_dict(file, load_abrt_plugin_conf_file);
+    return load_settings_to_dict(file, abrt_load_abrt_plugin_conf_file);
 }

--- a/tests/abrt_conf.at
+++ b/tests/abrt_conf.at
@@ -48,7 +48,7 @@ void test(struct result **res)
     dup2(errpipe[1], STDERR_FILENO);
     */
 
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     /*
     dup2(old_stderr, STDERR_FILENO);
@@ -72,7 +72,7 @@ void test(struct result **res)
         }
     }
 
-    free_abrt_conf_data();
+    abrt_free_abrt_conf_data();
 }
 
 int main(int argc, char *argv[])
@@ -82,13 +82,13 @@ int main(int argc, char *argv[])
     {
         struct result res_dump_location = {
             .line = "DumpLocation = /foo/blah/abrt\n",
-            .global_option = (const char *const *)&g_settings_dump_location,
+            .global_option = (const char *const *)&abrt_g_settings_dump_location,
             .expected = "/foo/blah/abrt",
         };
 
         struct result res_archive_dir = {
             .line = "WatchCrashdumpArchiveDir = /opt/bar/abrt\n",
-            .global_option = (const char *const *)&g_settings_sWatchCrashdumpArchiveDir,
+            .global_option = (const char *const *)&abrt_g_settings_sWatchCrashdumpArchiveDir,
             .expected = "/opt/bar/abrt",
         };
 
@@ -104,13 +104,13 @@ int main(int argc, char *argv[])
     {
         struct result res_dump_location = {
             .line = "DumpLocation = /foo/blah/abrt////\n",
-            .global_option = (const char *const *)&g_settings_dump_location,
+            .global_option = (const char *const *)&abrt_g_settings_dump_location,
             .expected = "/foo/blah/abrt",
         };
 
         struct result res_archive_dir = {
             .line = "WatchCrashdumpArchiveDir = /opt/bar/abrt////\n",
-            .global_option = (const char *const *)&g_settings_sWatchCrashdumpArchiveDir,
+            .global_option = (const char *const *)&abrt_g_settings_sWatchCrashdumpArchiveDir,
             .expected = "/opt/bar/abrt",
         };
 
@@ -126,13 +126,13 @@ int main(int argc, char *argv[])
     {
         struct result res_dump_location = {
             .line = "DumpLocation = /foo//blah///abrt\n",
-            .global_option = (const char *const *)&g_settings_dump_location,
+            .global_option = (const char *const *)&abrt_g_settings_dump_location,
             .expected = "/foo/blah/abrt",
         };
 
         struct result res_archive_dir = {
             .line = "WatchCrashdumpArchiveDir = /opt//bar///abrt\n",
-            .global_option = (const char *const *)&g_settings_sWatchCrashdumpArchiveDir,
+            .global_option = (const char *const *)&abrt_g_settings_sWatchCrashdumpArchiveDir,
             .expected = "/opt/bar/abrt",
         };
 
@@ -148,13 +148,13 @@ int main(int argc, char *argv[])
     {
         struct result res_dump_location = {
             .line = "DumpLocation = /////\n",
-            .global_option = (const char *const *)&g_settings_dump_location,
+            .global_option = (const char *const *)&abrt_g_settings_dump_location,
             .expected = "/",
         };
 
         struct result res_archive_dir = {
             .line = "WatchCrashdumpArchiveDir = /////\n",
-            .global_option = (const char *const *)&g_settings_sWatchCrashdumpArchiveDir,
+            .global_option = (const char *const *)&abrt_g_settings_sWatchCrashdumpArchiveDir,
             .expected = "/",
         };
 

--- a/tests/hooklib.at
+++ b/tests/hooklib.at
@@ -2,14 +2,14 @@
 
 AT_BANNER([hooklib])
 
-AT_TESTFUN([dir_is_in_dump_location],
+AT_TESTFUN([abrt_dir_is_in_dump_location],
 [[
 #include "libabrt.h"
 #include <assert.h>
 
 void test(char *name, bool expected)
 {
-    if (dir_is_in_dump_location(name) != expected)
+    if (abrt_dir_is_in_dump_location(name) != expected)
     {
         fprintf(stderr, "Bad: %s", name);
         abort();
@@ -21,63 +21,63 @@ void test(char *name, bool expected)
 int main(void)
 {
     g_verbose = 3;
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     g_verbose = 3;
 
     char *name;
 
-    assert(dir_is_in_dump_location("/") == false);
+    assert(abrt_dir_is_in_dump_location("/") == false);
 
-    asprintf(&name, "%s", g_settings_dump_location);
+    asprintf(&name, "%s", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s..evil", g_settings_dump_location);
+    asprintf(&name, "%s..evil", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/", g_settings_dump_location);
+    asprintf(&name, "%s/", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s///", g_settings_dump_location);
+    asprintf(&name, "%s///", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/.", g_settings_dump_location);
+    asprintf(&name, "%s/.", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s///.", g_settings_dump_location);
+    asprintf(&name, "%s///.", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/./", g_settings_dump_location);
+    asprintf(&name, "%s/./", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/.///", g_settings_dump_location);
+    asprintf(&name, "%s/.///", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/..", g_settings_dump_location);
+    asprintf(&name, "%s/..", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s///..", g_settings_dump_location);
+    asprintf(&name, "%s///..", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/../", g_settings_dump_location);
+    asprintf(&name, "%s/../", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/..///", g_settings_dump_location);
+    asprintf(&name, "%s/..///", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/good/../../../evil", g_settings_dump_location);
+    asprintf(&name, "%s/good/../../../evil", abrt_g_settings_dump_location);
     test(name, false);
 
-    asprintf(&name, "%s/good..still", g_settings_dump_location);
+    asprintf(&name, "%s/good..still", abrt_g_settings_dump_location);
     test(name, true);
 
-    asprintf(&name, "%s/good.new", g_settings_dump_location);
+    asprintf(&name, "%s/good.new", abrt_g_settings_dump_location);
     test(name, true);
 
-    asprintf(&name, "%s/.meta", g_settings_dump_location);
+    asprintf(&name, "%s/.meta", abrt_g_settings_dump_location);
     test(name, true);
 
-    asprintf(&name, "%s/..data", g_settings_dump_location);
+    asprintf(&name, "%s/..data", abrt_g_settings_dump_location);
     test(name, true);
 
     return 0;
@@ -92,7 +92,7 @@ AT_TESTFUN([abrt_problem_entry_is_post_create_condition],
 int main(void)
 {
     g_verbose = 3;
-    load_abrt_conf();
+    abrt_load_abrt_conf();
 
     assert(problem_entry_is_post_create_condition(FILENAME_TYPE));
     assert(problem_entry_is_post_create_condition(FILENAME_ANALYZER));

--- a/tests/koops-parser.at
+++ b/tests/koops-parser.at
@@ -2,7 +2,7 @@
 
 AT_BANNER([kernel oops parser])
 
-AT_TESTFUN([koops_extract_version],
+AT_TESTFUN([abrt_koops_extract_version],
 [[
 #include "libabrt.h"
 #include "koops-test.h"
@@ -15,7 +15,7 @@ int run_test(const struct test_struct *test)
 	char *version;
 	while ((line = xmalloc_fgetline(fp)) != NULL)
 	{
-		version = koops_extract_version(line);
+		version = abrt_koops_extract_version(line);
 		free(line);
 		if (version && !strcmp(version, test->expected_results))
 			break;
@@ -62,7 +62,7 @@ int run_test(const struct test_struct *test, int flags)
 {
 	char *koops_bt = fread_full(test->filename);
 
-	char *tnt = kernel_tainted_short(koops_bt);
+	char *tnt = abrt_kernel_tainted_short(koops_bt);
 	free(koops_bt);
 	int ret = 0;
 	switch (flags) {
@@ -128,8 +128,8 @@ int run_test(const struct test_struct *test)
 	g_autofree char *oops1 = fread_full(test->filename);
 	g_autofree char *oops2 = fread_full(test->expected_results);
 
-	g_autofree char *hash_oops1 = koops_hash_str(oops1);
-	g_autofree char *hash_oops2 = koops_hash_str(oops2);
+	g_autofree char *hash_oops1 = abrt_koops_hash_str(oops1);
+	g_autofree char *hash_oops2 = abrt_koops_hash_str(oops2);
 
 	if (NULL == hash_oops1 || NULL == hash_oops2)
 	    return 1;
@@ -188,7 +188,7 @@ int run_test(const struct test_struct *test)
 
 	/* for testing purpose, I will record only one koops */
 	GList *oops_list = NULL;
-	koops_extract_oopses(&oops_list, oops_test, strlen(oops_test));
+	abrt_koops_extract_oopses(&oops_list, oops_test, strlen(oops_test));
 
 	int result = !(oops_list && !strcmp((char *)oops_list->data, oops_expected));
 	if (result)


### PR DESCRIPTION
See commit, per @ernestask 's suggestion. I couldn't find an obvious reason for these with blame, so unless it's a case of some clever (ob)fuscery like assembling function names out of substrings before calling them, this should be safe.

Signed-off-by: Michal Fabik <mfabik@redhat.com>