### PR TITLE
Drop libcap dependency

### DIFF
--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -112,7 +112,6 @@ BuildRequires: libreport-gtk-devel >= %{libreport_ver}
 BuildRequires: gsettings-desktop-schemas-devel >= 3.15
 #addon-ccpp
 BuildRequires: gdb-headless
-BuildRequires: libcap-devel
 #addon-kerneloops
 BuildRequires: systemd-devel
 BuildRequires: %{libjson_devel}

--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,6 @@ PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0])
 PKG_CHECK_MODULES([SATYR], [satyr])
 PKG_CHECK_MODULES([SYSTEMD], [libsystemd])
 PKG_CHECK_MODULES([GSETTINGS_DESKTOP_SCHEMAS], [gsettings-desktop-schemas >= 3.15.1])
-PKG_CHECK_MODULES([LIBCAP], [libcap])
 
 PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([dbusinterfacedir],


### PR DESCRIPTION
No longer needed after 77653d7a367a756e796f5b820d9bea3c8feb117e.