### PR TITLE
plugins: journal: Fix ci_mapping being overwritten

### DIFF
--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -190,7 +190,7 @@ abrt_journal_update_occurrence(const char *executable, unsigned ts)
 static int
 abrt_journal_core_retrieve_information(abrt_journal_t *journal, struct crash_info *info)
 {
-    if (abrt_journal_get_int_field(journal, "COREDUMP_SIGNAL", (long *)&(info->ci_signal_no)) != 0)
+    if (!abrt_journal_get_int(journal, "COREDUMP_SIGNAL", &info->ci_signal_no) != 0)
     {
         log_info("Failed to get signal number from journal message");
         return -EINVAL;
@@ -220,14 +220,14 @@ abrt_journal_core_retrieve_information(abrt_journal_t *journal, struct crash_inf
         return 1;
     }
 
-    if (abrt_journal_get_int_field(journal, "COREDUMP_UID", (long *)&(info->ci_uid)))
+    if (!abrt_journal_get_uid(journal, "COREDUMP_UID", &info->ci_uid))
     {
         log_info("Failed to get UID from journal message");
         return -EINVAL;
     }
 
     /* This is not fatal, the pid is used only in dumpdir name */
-    if (abrt_journal_get_int_field(journal, "COREDUMP_PID", (long *)&(info->ci_pid)))
+    if (!abrt_journal_get_pid(journal, "COREDUMP_PID", &info->ci_pid))
     {
         log_notice("Failed to get PID from journal message.");
         info->ci_pid = getpid();

--- a/src/plugins/abrt-journal.h
+++ b/src/plugins/abrt-journal.h
@@ -16,6 +16,7 @@
 #define _ABRT_JOURNAL_H_
 
 #include <glib.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,14 +52,15 @@ int abrt_journal_get_field(abrt_journal_t *journal,
                            const char *field,
                            const void **value,
                            size_t *value_len);
-
-int abrt_journal_get_int_field(abrt_journal_t *journal,
-                               const char *field,
-                               long *value);
-
-int abrt_journal_get_unsigned_field(abrt_journal_t *journal,
-                                    const char *field,
-                                    unsigned *value);
+bool abrt_journal_get_int(abrt_journal_t *journal,
+                          const char *key,
+                          int *value);
+bool abrt_journal_get_pid(abrt_journal_t *journal,
+                          const char *key,
+                          pid_t *value);
+bool abrt_journal_get_uid(abrt_journal_t *journal,
+                          const char *key,
+                          uid_t *value);
 
 /* Returns allocated memory if value is NULL; otherwise makes copy of journald
  * field to memory pointed by value arg. */


### PR DESCRIPTION
Builds on top of 98c4205a717dbca34c3a889c6c133ed06feb335f, which was a
horrible mess. In systems that use the LP64 data model (Linux), writing
to ci_pid in struct crash_info through a long pointer would result in
ci_mapping being overwritten, leading to crashes when collecting core
dumps from the journal. This commit address the original issue in a
different - several wrappers are provided for a macro that casts the
result from strtol() to a suitable type. The potential issue with
insufficient range or unexpectedly negative numbers is left unaddressed,
as that would only happen in cases of journal corruption, so it is
likely that the problem directory would contain a bunch of garbage
anyway.