### PR TITLE
Remove libreport_ namespace from python code

### DIFF
--- a/src/plugins/abrt-action-analyze-core.in
+++ b/src/plugins/abrt-action-analyze-core.in
@@ -35,7 +35,7 @@ def error_msg_and_die(s):
     sys.stderr.write("%s\n" % s)
     sys.exit(1)
 
-def libreport_xopen(name, mode):
+def xopen(name, mode):
     try:
         r = open(name, mode)
     except IOError as ex:
@@ -145,7 +145,7 @@ if __name__ == "__main__":
         oldmask = os.umask(0o002)
         for bid in b_ids:
             if outname:
-                outfile = libreport_xopen(outname, "w")
+                outfile = xopen(outname, "w")
                 outname = None
             outfile.write("%s\n" % bid)
         outfile.close()

--- a/src/plugins/abrt-action-install-debuginfo.in
+++ b/src/plugins/abrt-action-install-debuginfo.in
@@ -282,7 +282,7 @@ if __name__ == "__main__":
     if not config.cachedirs:
         config.cachedirs = ["/var/cache/abrt-di"]
         try:
-            conf = problem.libreport_load_plugin_conf_file("CCpp.conf")
+            conf = problem.load_plugin_conf_file("CCpp.conf")
         except OSError as ex:
             print(ex)
         else:


### PR DESCRIPTION
Revert erroneous changes from a349b2c7cb26a3cddb673dd8e62455f17016ad15

Signed-off-by: Michal Fabik <mfabik@redhat.com>