### PR TITLE
Allow editing CHANGELOG.md before release commit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,16 +76,17 @@ release-major:
 
 .PHONY: release
 release:
-	echo "* $$(LC_TIME='en_US.UTF-8' date +'%a %b %d %Y') $$(git config --get user.name) <$$(git config --get user.email)> $$NEW_VER-1" | sort > /tmp/changelog.tmp; \
-	git log --oneline $$OLD_VER..HEAD | awk '{$$1=""; if (a[$$0]++ == 0) print "-" $$0} END {print ""}' | grep -v -e "- Merge" -e "- testsuite:" -e "- make:" >> /tmp/changelog.tmp; \
-	sed "$$(grep -n changelog abrt.spec.in | cut -f1 -d: | head -1)"'r /tmp/changelog.tmp' -i abrt.spec.in; \
-	sed -e "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$$NEW_VER]/" \
+	echo "* $$(LC_TIME='en_US.UTF-8' date +'%a %b %d %Y') $$(git config --get user.name) <$$(git config --get user.email)> $$NEW_VER-1" | sort > /tmp/changelog.tmp
+	git log --oneline $$OLD_VER..HEAD | awk '{$$1=""; if (a[$$0]++ == 0) print "-" $$0} END {print ""}' | grep -v -e "- Merge" -e "- testsuite:" -e "- make:" >> /tmp/changelog.tmp
+	sed "$$(grep -n changelog abrt.spec.in | cut -f1 -d: | head -1)"'r /tmp/changelog.tmp' -i abrt.spec.in
+	sed -e "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$$NEW_VER]\n[\/\/] # (Please sum up added, changed, removed and fixed features here. See below for examples.)/" \
 	    -e "s/^\[Unreleased\]: \(https:\/\/.*\/compare\)\(\/.*\)\.\.\.HEAD/[Unreleased]: \1\/$$NEW_VER...HEAD\n[$$NEW_VER]: \1\2...$$NEW_VER/" \
-	    -i CHANGELOG.md; \
-	sed 's|DEF_VER=.*$$|DEF_VER='$$NEW_VER'|' -i gen-version; \
-	git add gen-version abrt.spec.in CHANGELOG.md; \
-	git commit -m "New version $$NEW_VER"; \
-	git tag "$$NEW_VER"; \
+	    -i CHANGELOG.md
+	$${EDITOR:-vi} CHANGELOG.md
+	sed 's|DEF_VER=.*$$|DEF_VER='$$NEW_VER'|' -i gen-version
+	git add gen-version abrt.spec.in CHANGELOG.md
+	git commit -m "New version $$NEW_VER"
+	git tag "$$NEW_VER"
 	echo -n "$$NEW_VER" > abrt-version
 	autoconf --force
 	$(MAKE) dist


### PR DESCRIPTION
`$ make release-{major|minor|bug}` creates a new empty entry in CHANGELOG.md
but commits the change before the user has a chance to fill it, making
it necessary to amend and re-tag the release commit. This commit opens
an editor to let the user edit the changelog in time.

Signed-off-by: Michal Fabik <mfabik@redhat.com>