### PR TITLE
Keep problem dirs locked while (core) backtrace is being generated

### DIFF
--- a/src/daemon/abrtd.c
+++ b/src/daemon/abrtd.c
@@ -174,19 +174,13 @@ static void queue_post_create_process(struct abrt_server_proc *proc)
 
     char *worst_dir = NULL;
     const double max_size = 1024 * 1024 * abrt_g_settings_nMaxCrashReportsSize;
-    while (libreport_get_dirsize_find_largest_dir(abrt_g_settings_dump_location, &worst_dir, ignored) >= max_size
+    while (libreport_get_dirsize_find_largest_dir(abrt_g_settings_dump_location, &worst_dir, ignored, proc->dirname) >= max_size
            && worst_dir)
     {
         const char *kind = "old";
 
         GList *proc_of_deleted_item = NULL;
-        if (proc != NULL && strcmp(worst_dir, proc->dirname) == 0)
-        {
-            kind = "new";
-            stop_abrt_server(proc);
-            proc = NULL;
-        }
-        else if ((proc_of_deleted_item = g_list_find_custom(s_dir_queue, worst_dir, (GCompareFunc)abrt_server_compare_dirname)))
+        if ((proc_of_deleted_item = g_list_find_custom(s_dir_queue, worst_dir, (GCompareFunc)abrt_server_compare_dirname)))
         {
             kind = "unprocessed";
             struct abrt_server_proc *removed_proc = (struct abrt_server_proc *)proc_of_deleted_item->data;

--- a/src/daemon/abrtd.c
+++ b/src/daemon/abrtd.c
@@ -154,7 +154,7 @@ static void notify_next_post_create_process(struct abrt_server_proc *finished)
 
 /* Queueing the process will also lead to cleaning up the dump location.
  */
-static void queue_post_craete_process(struct abrt_server_proc *proc)
+static void queue_post_create_process(struct abrt_server_proc *proc)
 {
     abrt_load_abrt_conf();
     struct abrt_server_proc *running = s_dir_queue == NULL ? NULL
@@ -278,7 +278,7 @@ static gboolean abrt_server_output_cb(GIOChannel *channel, GIOCondition conditio
 
             proc->dirname = libreport_xstrdup(line + strlen("NEW_PROBLEM_DETECTED: "));
             log_notice("abrt-server(%d): handling new problem: %s", proc->pid, proc->dirname);
-            queue_post_craete_process(proc);
+            queue_post_create_process(proc);
         }
         else
             log_warning("abrt-server(%d): not recognized message: '%s'", proc->pid, line);

--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -44,7 +44,7 @@ void abrt_ensure_writable_dir_uid_gid(const char *dir, mode_t mode, uid_t uid, g
 void abrt_ensure_writable_dir(const char *dir, mode_t mode, const char *user);
 void abrt_ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, const char *group);
 char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
-char *abrt_get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char *debuginfo_dirs);
+char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *debuginfo_dirs);
 
 bool abrt_dir_is_in_dump_location(const char *dir_name);
 

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -68,7 +68,7 @@ void abrt_trim_problem_dirs(const char *dirname, double cap_size, const char *ex
     {
         /* We exclude our own dir from candidates for deletion (3rd param): */
         char *worst_basename = NULL;
-        double cur_size = libreport_get_dirsize_find_largest_dir(dirname, &worst_basename, excluded_basename);
+        double cur_size = libreport_get_dirsize_find_largest_dir(dirname, &worst_basename, excluded_basename, NULL);
         if (cur_size <= cap_size || !worst_basename)
         {
             log_info("cur_size:%.0f cap_size:%.0f, no (more) trimming", cur_size, cap_size);

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -239,21 +239,15 @@ char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec)
     return libreport_strbuf_free_nobuf(buf_out);
 }
 
-char *abrt_get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const char *debuginfo_dirs)
+char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *debuginfo_dirs)
 {
     INITIALIZE_LIBABRT();
-
-    struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
-    if (!dd)
-        return NULL;
 
     char *executable = NULL;
     if (dd_exist(dd, FILENAME_BINARY))
         executable = libreport_concat_path_file(dd->dd_dirname, FILENAME_BINARY);
     else
         executable = dd_load_text(dd, FILENAME_EXECUTABLE);
-
-    dd_close(dd);
 
     /* Let user know what's going on */
     log_warning(_("Generating backtrace"));
@@ -333,7 +327,7 @@ char *abrt_get_backtrace(const char *dump_dir_name, unsigned timeout_sec, const 
 
     args[i++] = (char*)"-ex";
     const unsigned core_cmd_index = i++;
-    args[core_cmd_index] = libreport_xasprintf("core-file %s/"FILENAME_COREDUMP, dump_dir_name);
+    args[core_cmd_index] = libreport_xasprintf("core-file %s/"FILENAME_COREDUMP, dd->dd_dirname);
 
     args[i++] = (char*)"-ex";
     const unsigned bt_cmd_index = i++;

--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -78,7 +78,10 @@ int main(int argc, char **argv)
         debuginfo_dirs = libreport_xasprintf("%s:%s", debuginfo_location, i_opt);
 
     /* Create gdb backtrace */
-    char *backtrace = abrt_get_backtrace(dump_dir_name, exec_timeout_sec,
+    struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
+    if (!dd)
+        return 1;
+    char *backtrace = abrt_get_backtrace(dd, exec_timeout_sec,
             (debuginfo_dirs) ? debuginfo_dirs : debuginfo_location);
     free(debuginfo_location);
     if (!backtrace)
@@ -91,9 +94,6 @@ int main(int argc, char **argv)
 
     /* Store gdb backtrace */
 
-    struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
-    if (!dd)
-        return 1;
     dd_save_text(dd, FILENAME_BACKTRACE, backtrace);
     dd_close(dd);
 

--- a/src/plugins/abrt-action-generate-core-backtrace.c
+++ b/src/plugins/abrt-action-generate-core-backtrace.c
@@ -75,7 +75,10 @@ int main(int argc, char **argv)
     /* The value 240 was taken from abrt-action-generate-backtrace.c. */
     int exec_timeout_sec = 240;
 
-    char *gdb_output = abrt_get_backtrace(dump_dir_name, exec_timeout_sec, NULL);
+    struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
+    if (!dd)
+        return 1;
+    char *gdb_output = abrt_get_backtrace(dd, exec_timeout_sec, NULL);
     if (!gdb_output)
     {
         log_warning(_("Error: GDB did not return any data"));
@@ -86,6 +89,7 @@ int main(int argc, char **argv)
                                                       gdb_output,
                                                       !raw_fingerprints,
                                                       &error_message);
+    dd_close(dd);
     free(gdb_output);
 
 #endif /* ENABLE_NATIVE_UNWINDER */


### PR DESCRIPTION
See commits.  
  
Resolves https://github.com/abrt/abrt/issues/1357  
  
See also https://github.com/abrt/libreport/pull/629