### PR TITLE
abrt-vmcore: Fix SyntaxWarning with python3.8

### DIFF
--- a/src/hooks/abrt_harvest_vmcore.py.in
+++ b/src/hooks/abrt_harvest_vmcore.py.in
@@ -161,7 +161,7 @@ def harvest_vmcore(crash_dir):
 
     # Wait for abrtd to start. Give it at least 1 second to initialize.
     for i in range(10):
-        if i is 9:
+        if i == 9:
             sys.exit(1)
         elif os.system('pidof abrtd >/dev/null'):
             time.sleep(1)


### PR DESCRIPTION
python3.8 raises SyntaxWarning when comparing literals using `is` and it appears in `systemctl status abrt-vmcore`

Signed-off-by: Michal Fabik <mfabik@redhat.com>