### PR TITLE
sosreport_event: Update plugin name

### DIFF
--- a/src/plugins/sosreport_event.conf
+++ b/src/plugins/sosreport_event.conf
@@ -7,7 +7,7 @@ EVENT=post-create remote!=1
                 --only=filesys --only=hardware --only=kernel --only=libraries \
                 --only=memory --only=networking --only=nfsserver --only=pam \
                 --only=process --only=rpm -k rpm.rpmva=off --only=ssh \
-                --only=startup --only=yum --only=date --only=host --only=x11 \
+                --only=services --only=yum --only=date --only=host --only=x11 \
                 --only=cups --only=logs --only=grub2 --only=cron --only=pci \
                 --only=auditd --only=selinux --only=lvm2 --only=sar \
                 --only=processor \


### PR DESCRIPTION
The "startup" plugin was renamed to "services" a long time ago:
https://github.com/sosreport/sos/commit/b502b9f51b4d314ed6fa76d66a6db8aea7d32c12  
  
See also: `sosreport -l`

Signed-off-by: Michal Fabik <mfabik@redhat.com>