### PR TITLE
Drop creates-items tag from event definitions

### DIFF
--- a/src/plugins/analyze_CCpp.xml.in
+++ b/src/plugins/analyze_CCpp.xml.in
@@ -6,7 +6,6 @@
     Pros: no need for debuginfo downloads. Retrace server's database of debuginfos is more complete. Retrace server may generate better backtraces.
     Cons: coredump you upload contains all the data from the crashed program, including your private data, if any.
     </_long-description>
-    <creates-items>backtrace</creates-items>
     <gui-review-elements>no</gui-review-elements>
 
     <!-- The event shows a message about sensitive data on its own.

--- a/src/plugins/analyze_LocalGDB.xml.in
+++ b/src/plugins/analyze_LocalGDB.xml.in
@@ -5,6 +5,5 @@
     <_long-description>Needs to downloads debuginfo packages, which might take significant time, and take up disk space.
     However, unlike RetraceServer, doesn't send coredump to remote machines.
     </_long-description>
-    <creates-items>backtrace</creates-items>
     <gui-review-elements>no</gui-review-elements>
 </event>

--- a/src/plugins/analyze_RetraceServer.xml.in
+++ b/src/plugins/analyze_RetraceServer.xml.in
@@ -6,7 +6,6 @@
     Pros: no need for debuginfo downloads. Retrace server's database of debuginfos is more complete. Retrace server may generate better backtraces.
     Cons: coredump you upload contains all the data from the crashed program, including your private data, if any.
     </_long-description>
-    <creates-items>backtrace</creates-items>
     <gui-review-elements>no</gui-review-elements>
     <sending-sensitive-data>yes</sending-sensitive-data>
     <options>

--- a/src/plugins/analyze_VMcore.xml.in
+++ b/src/plugins/analyze_VMcore.xml.in
@@ -4,6 +4,5 @@
     <_description>Install kernel debuginfo packages, generate kernel log and oops message</_description>
     <_long-description>Needs to install kernel debuginfo packages, which might take significant time, and take up disk space.
     </_long-description>
-    <creates-items>backtrace</creates-items>
     <gui-review-elements>no</gui-review-elements>
 </event>

--- a/src/plugins/collect_GConf.xml.in
+++ b/src/plugins/collect_GConf.xml.in
@@ -3,6 +3,5 @@
     <_name>Collect GConf configuration</_name>
     <_description>Save configuration from application's GConf directory</_description>
     <_long-description>Runs gconftool-2 --recursive-list /apps/executable and saves it as 'gconf_subtree' element.</_long-description>
-    <creates-items>gconf_subtree</creates-items>
     <gui-review-elements>no</gui-review-elements>
 </event>

--- a/src/plugins/collect_vimrc_system.xml.in
+++ b/src/plugins/collect_vimrc_system.xml.in
@@ -3,6 +3,5 @@
     <_name>Collect system-wide vim configuration files</_name>
     <_description>Save /etc/vimrc and /etc/gvimrc</_description>
     <_long-description>Checks if there are vimrc and gvimrc files in /etc and saves them as system_vimrc and system_gvimrc, respectively.</_long-description>
-    <creates-items>system_vimrc,system_gvimrc</creates-items>
     <gui-review-elements>no</gui-review-elements>
 </event>

--- a/src/plugins/collect_vimrc_user.xml.in
+++ b/src/plugins/collect_vimrc_user.xml.in
@@ -3,6 +3,5 @@
     <_name>Collect yours vim configuration files</_name>
     <_description>Save .vimrc and .gvimrc from your home directory</_description>
     <_long-description>Checks if there are .vimrc and .gvimrc in your home directory and saves them as user_vimrc and user_gvimrc, respectively.</_long-description>
-    <creates-items>user_vimrc,user_gvimrc</creates-items>
     <gui-review-elements>no</gui-review-elements>
 </event>

--- a/src/plugins/collect_xsession_errors.xml.in
+++ b/src/plugins/collect_xsession_errors.xml.in
@@ -6,6 +6,5 @@
     Scans through ~/.xsession-errors file and saves those lines which contain executable's name.
     The result is saved as 'xsession_errors' element.
     </_long-description>
-    <creates-items>xsession_errors</creates-items>
     <gui-review-elements>no</gui-review-elements>
 </event>

--- a/tests/runtests/localized-reporting/test_event_lr.xml
+++ b/tests/runtests/localized-reporting/test_event_lr.xml
@@ -3,6 +3,5 @@
     <name>Local GNU Debugger</name>
     <description>Download debuginfo packages and generate backtrace locally using GDB</description>
     <long-description>Needs to downloads debuginfo packages, which might take significant time, and take up disk space. However, unlike RetraceServer, doesn't send coredump to remote machines.</long-description>
-    <creates-items>backtrace</creates-items>
     <gui-review-elements>yes</gui-review-elements>
 </event>

--- a/tests/runtests/verify-that-report-edits/test_event_vtre.xml
+++ b/tests/runtests/verify-that-report-edits/test_event_vtre.xml
@@ -3,6 +3,5 @@
     <name>Local GNU Debugger</name>
     <description>Download debuginfo packages and generate backtrace locally using GDB</description>
     <long-description>Needs to downloads debuginfo packages, which might take significant time, and take up disk space. However, unlike RetraceServer, doesn't send coredump to remote machines.</long-description>
-    <creates-items>backtrace</creates-items>
     <gui-review-elements>yes</gui-review-elements>
 </event>


### PR DESCRIPTION
The information is not used anywhere in libreport (anymore).

See https://github.com/abrt/libreport/pull/623.