### PR TITLE
doc: Remove or replace some fedorahosted links

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -52,7 +52,7 @@ the tests/helpers directory.
 ## Verify ABRT plays nice with the rest of OS
 
 ABRT integration tests live in the test/runtest directory. The test are based
-on [BeakerLib](http://fedorahosted.org/beakerlib).
+on [BeakerLib](https://github.com/beakerlib/beakerlib).
 
 Caution! It is not recommended to run the tests unless you really know what
 you are doing. Lot of tests changes configuration of the system they are

--- a/doc/abrt-retrace-client.txt
+++ b/doc/abrt-retrace-client.txt
@@ -57,7 +57,7 @@ OPTIONS
    log to syslog
 
 -k, --insecure::
-   allow insecure connection to retrace server
+   allow insecure connection to retrace server (with self-signed or expired certificate)
 
 --url URL::
    retrace server URL

--- a/doc/implementation
+++ b/doc/implementation
@@ -3,9 +3,11 @@ Implementation:
 C/C++ handling:
 ==============
 
+NOTE: This document describes legacy abrt-hook-cpp that was removed in favour of systemd-coredump.
+
 We change /proc/sys/kernel/core_pattern to invoke abrtd helper to save
 the coredump of the crashing app:
-* helper source code: http://git.fedorahosted.org/git/abrt.git?p=abrt.git;a=blob_plain;f=src/Hooks/abrt-hook-python.cpp
+* helper source code:
 the code responsible for this:
 
     #define CORE_PATTERN            "|/usr/libexec/abrt-hook-ccpp" "/var/tmp/abrt" %p %s %u"
@@ -64,8 +66,6 @@ the coredump and extract the backtrace. This is done on user demand by calling t
 getReport(UUID) method, or is done automatically if configured in /etc/abrt/abrt.conf
 * UUID is a unique id of the crash in the database, every user is allowed to see only
   their own crashes or kerneloops crashes.
-- See http://git.fedorahosted.org/git/abrt.git?p=abrt.git;a=blob;f=lib/Plugins/SQLite3.cpp line 394
-  for more details.
 
 1. processing coredump:
     a) determine if the crashed binary belongs to some installed package
@@ -76,9 +76,8 @@ execlp("abrt-action-install-debuginfo", "abrt-action-install-debuginfo", coredum
 
 abrt-action-install-debuginfo is a shell script using elfutils to get build-ids from a coredump and then use
 "yum provides" and "yumdownloader" to determine and download the missing debuginfo packages
-* script source code: http://git.fedorahosted.org/git/abrt.git?p=abrt.git;a=blob_plain;f=src/Daemon/abrt-action-install-debuginfo
+* script source code: https://github.com/abrt/abrt/blob/master/src/plugins/abrt-action-install-debuginfo.in
     c) Run gdb and get a backtrace from the coredump:
-    see http://git.fedorahosted.org/git/abrt.git?p=abrt.git;a=blob_plain;f=lib/Plugins/CCpp.cpp line 260
     - gdb is run with the same privileges as the crashed app (setregid, setreuid).
     d) The backtrace is saved to the same directory as the coredump.
 

--- a/doc/plugins-howto
+++ b/doc/plugins-howto
@@ -138,4 +138,4 @@ PLUGIN_INFO(REPORTER,
             "0.0.1",
             "Sends an email with a report via mailx command",
             "zprikryl@redhat.com",
-            "https://fedorahosted.org/crash-catcher/wiki");
+            "https://github.com/abrt/abrt/wiki");

--- a/src/dbus/abrt_polkit.policy
+++ b/src/dbus/abrt_polkit.policy
@@ -12,7 +12,7 @@ Copyright (c) 2012 ABRT Team <crash-catcher@fedorahosted.com>
 
 <policyconfig>
   <vendor>The ABRT Team</vendor>
-  <vendor_url>https://fedorahosted.org/abrt/</vendor_url>
+  <vendor_url>https://github.com/abrt/abrt</vendor_url>
 
   <!-- by default only root can see other users problems -->
   <action id="org.freedesktop.problems.getall">

--- a/src/plugins/analyze_RetraceServer.xml.in
+++ b/src/plugins/analyze_RetraceServer.xml.in
@@ -21,7 +21,7 @@
            <_label>Insecure</_label>
            <allow-empty>yes</allow-empty>
            <_description>Whether or not to use insecure connection</_description>
-           <_note-html>Write "insecure" to allow insecure connection &lt;a href="https://fedorahosted.org/abrt/wiki/AbrtRetraceServerInsecureConnection" &gt;(warning)&lt;/a&gt;</_note-html>
+           <_note-html>Write "insecure" to allow SSL to use self-signed or expired certificates.</_note-html>
        </option>
 
     </options>

--- a/src/python-problem/doc/index.rst
+++ b/src/python-problem/doc/index.rst
@@ -7,7 +7,7 @@ abrt-python
 ===========
 
 High-level API for querying, creating and manipulating
-problems handled by `ABRT <https://fedorahosted.org/abrt/>`_ 
+problems handled by `ABRT <https://github.com/abrt/abrt/>`_ 
 in Python.
 
 It works on top of low-level DBus or socket API provided
@@ -16,7 +16,7 @@ for systems without new DBus problem API
 as it can only handle the creation of new problems.
 
 This project lives in the
-`abrt repository <http://git.fedorahosted.org/git/abrt.git>`_ 
+`abrt repository <https://github.com/abrt/abrt.git>`_ 
 and is distributed under GPLv2 license.
 
 Contents:

--- a/tests/helpers/docs/index.rst
+++ b/tests/helpers/docs/index.rst
@@ -1,14 +1,14 @@
 ABRT integration test suite documentation
 =========================================
 :Author: Richard Marko <rmarko@redhat.com>
-:Description: Since 2011, `ABRT <https://fedorahosted.org/abrt/>`_ is using `BeakerLib library <https://fedorahosted.org/beakerlib/>`_ based test suite for integration testing. This document describes the usage and the architecture of the test suite.
+:Description: Since 2011, `ABRT <https://github.com/abrt/abrt/>`_ is using `BeakerLib library <https://github.com/beakerlib/beakerlib/>`_ based test suite for integration testing. This document describes the usage and the architecture of the test suite.
 
 .. contents:: Table of Contents
 
 About
 -----
 
-At the time of writing this document, we have 32 tests which tests `ABRT <https://fedorahosted.org/abrt/>`_, `libreport <https://fedorahosted.org/libreport/>`_ and `btparser <https://fedorahosted.org/btparser/>`_.
+At the time of writing this document, we have 32 tests which tests `ABRT <https://github.com/abrt/abrt/>`_, `libreport <https://github.com/abrt/libreport/>`_ and `btparser <https://github.com/abrt/btparser/>`_.
 These tests are run nightly for each of the currently supported releases of Fedora and Red Hat Enterprise Linux. You can find the results on our `public mirror <http://rmarko.fedorapeople.org/abrt/>`_.
 
 
@@ -19,7 +19,7 @@ Running the test suite
         Don't run the test suite on your machine **directly**, use virtual machine or machine dedicated for the testing.
 
 In your virtual machine or dedicated machine:
- - clone the ABRT repository: *git clone git://git.fedorahosted.org/abrt.git*
+ - clone the ABRT repository: *git clone https://github.com/abrt/abrt.git*
  - go to *abrt/tests/runtest/*
  - run *./run*
 
@@ -65,7 +65,7 @@ To create a new test you have to:
    * PURPOSE file
  - add the test to *./aux/test_order*
 
-The tests are written in bash using `BeakerLib library <https://fedorahosted.org/beakerlib/>`_. BeakerLib Quick Reference [`PDF <https://fedorahosted.org/beakerlib/attachment/wiki/Download/BeakerLib%20Quick%20Reference.pdf?format=raw>`_] is what you need.
+The tests are written in bash using `BeakerLib library <https://github.com/beakerlib/beakerlib/>`_.
 
 It's always good to copy one of the existing tests as a base for your test. Good candidates are:
  - run-abrtd which basically serves as an example,

--- a/tests/helpers/test_beaker_f15.xml
+++ b/tests/helpers/test_beaker_f15.xml
@@ -29,7 +29,7 @@
 <![CDATA[
 %post --interpreter=/bin/bash
 
-git clone git://git.fedorahosted.org/abrt /usr/local/share/abrt-tests/
+git clone https://github.com/abrt/abrt.git /usr/local/share/abrt-tests/
 
 cat >> /etc/crontab <<_END_
 0 3 * * * root /usr/local/share/abrt-tests/tests/runtests/abrt-nightly-test.sh | tee -a /tmp/abrt-nightly-test.log

--- a/tests/runtests/abrt-make-check/runtest.sh
+++ b/tests/runtests/abrt-make-check/runtest.sh
@@ -43,7 +43,7 @@ rlJournalStart
 
         yum-builddep -y --nogpgcheck abrt
         rpmquery btparser-devel > /dev/null 2>&1 || yum install -y btparser-devel --enablerepo="updates-testing"
-        rlRun "git clone git://git.fedorahosted.org/abrt.git" 0 "Clone abrt.git"
+        rlRun "git clone https://github.com/abrt/btparser.git" 0 "Clone abrt.git"
         pushd abrt/
         rlRun "./autogen.sh" 0 "Autogen"
         rlRun "rpm --eval '%configure' | sh" 0 "Configure"

--- a/tests/runtests/abrt-nightly-build/runtest.sh
+++ b/tests/runtests/abrt-nightly-build/runtest.sh
@@ -79,7 +79,7 @@ rlJournalStart
 
     for package in $TARGETS; do
         rlPhaseStartTest "Build $package"
-            rlRun "git clone git://git.fedorahosted.org/$package.git" 0 "Clone $package.git"
+            rlRun "git clone https://github.com/abrt/$package.git" 0 "Clone $package.git"
 
             pushd $package
             rlLog "Git short rev: $(git rev-parse --short HEAD)"

--- a/tests/runtests/btparser-make-check/runtest.sh
+++ b/tests/runtests/btparser-make-check/runtest.sh
@@ -39,7 +39,7 @@ rlJournalStart
         TmpDir=$(mktemp -d)
         pushd $TmpDir
 
-        rlRun "git clone git://git.fedorahosted.org/btparser.git" 0 "Clone btparser.git"
+        rlRun "git clone https://github.com/abrt/btparser.git" 0 "Clone btparser.git"
         pushd btparser/
         short_rev=$(git rev-parse --short HEAD)
         rlLog "Git short rev: $short_rev"

--- a/tests/runtests/libreport-make-check/runtest.sh
+++ b/tests/runtests/libreport-make-check/runtest.sh
@@ -39,7 +39,7 @@ rlJournalStart
         TmpDir=$(mktemp -d)
         pushd $TmpDir
 
-        rlRun "git clone git://git.fedorahosted.org/libreport.git" 0 "Clone libreport.git"
+        rlRun "git clone https://github.com/abrt/abrt.git" 0 "Clone libreport.git"
         pushd libreport/
         short_rev=$(git rev-parse --short HEAD)
         rlLog "Git short rev: $short_rev"


### PR DESCRIPTION
fedorahosted.org has been partially decomissioned, but
some of our links were still pointing to it. Unfortunatelly
some of the pages were not migraated, so there is not always
a new alternative so the text was slightly modified in
some cases.

Resolves:
https://github.com/abrt/abrt/issues/1251