### PR TITLE
daemon: rpm: Use NEVRA instead of ENVRA

### DIFF
--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -228,7 +228,7 @@ static bool is_path_blacklisted(const char *path)
     return false;
 }
 
-static struct pkg_envra *get_script_name(const char *cmdline, char **executable, const char *chroot)
+static struct pkg_nevra *get_script_name(const char *cmdline, char **executable, const char *chroot)
 {
 // TODO: we don't verify that python executable is not modified
 // or that python package is properly signed
@@ -237,7 +237,7 @@ static struct pkg_envra *get_script_name(const char *cmdline, char **executable,
      * This will work only if the cmdline contains the whole path.
      * Example: python /usr/bin/system-control-network
      */
-    struct pkg_envra *script_pkg = NULL;
+    struct pkg_nevra *script_pkg = NULL;
     char *script_name = get_argv1_if_full_path(cmdline);
     if (script_name)
     {
@@ -271,7 +271,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
     char *rootdir = NULL;
     char *package_short_name = NULL;
     char *fingerprint = NULL;
-    struct pkg_envra *pkg_name = NULL;
+    struct pkg_nevra *pkg_name = NULL;
     char *component = NULL;
     char *kernel = NULL;
     int error = 1;
@@ -353,7 +353,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
     if (g_regex_match_simple(DEFAULT_INTERPRETERS_REGEX, basename, G_REGEX_EXTENDED, /*MatchFlags*/0) ||
         g_list_find_custom(settings_Interpreters, basename, (GCompareFunc)g_strcmp0))
     {
-        struct pkg_envra *script_pkg = get_script_name(cmdline, &executable, chroot);
+        struct pkg_nevra *script_pkg = get_script_name(cmdline, &executable, chroot);
         /* executable may have changed, check it again */
         if (is_path_blacklisted(executable))
         {
@@ -379,7 +379,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
             goto ret0;
         }
 
-        free_pkg_envra(pkg_name);
+        free_pkg_nevra(pkg_name);
         pkg_name = script_pkg;
     }
 
@@ -460,7 +460,7 @@ skip_interpreter:
     free(executable);
     free(rootdir);
     free(package_short_name);
-    free_pkg_envra(pkg_name);
+    free_pkg_nevra(pkg_name);
     free(component);
     free(fingerprint);
 

--- a/src/daemon/rpm.h
+++ b/src/daemon/rpm.h
@@ -26,17 +26,17 @@
 extern "C" {
 #endif
 
-struct pkg_envra {
+struct pkg_nevra {
     char *p_nvr;
-    char *p_epoch;
     char *p_name;
+    char *p_epoch;
     char *p_version;
     char *p_release;
     char *p_arch;
     char *p_vendor;
 };
 
-void free_pkg_envra(struct pkg_envra *p);
+void free_pkg_nevra(struct pkg_nevra *p);
 
 /**
  * Checks if an application is modified by third party.
@@ -85,7 +85,7 @@ char *rpm_get_fingerprint(const char* pkg);
  * @param filename A file name.
  * @return A package name (malloc'ed string)
  */
-struct pkg_envra *rpm_get_package_nvr(const char *filename, const char *rootdir_or_NULL);
+struct pkg_nevra *rpm_get_package_nvr(const char *filename, const char *rootdir_or_NULL);
 /**
  * Finds a main package for given file. This package contains particular
  * file. If the file doesn't belong to any package, empty string is


### PR DESCRIPTION
libdnf is only able to parse package names in the NEVRA form, leading to
retrace-server bailing when retracing dumps from, say, gedit.

Closes https://github.com/abrt/abrt/issues/1378
Fixes https://github.com/abrt/retrace-server/issues/233