### PR TITLE
init-scripts: Add directories to systemd-tmpfiles config

### DIFF
--- a/init-scripts/abrt.conf
+++ b/init-scripts/abrt.conf
@@ -1,3 +1,9 @@
-#Type Path          Mode UID  GID
-d     /var/tmp/abrt 0755 abrt abrt
+#Type Path                  Mode UID  GID
+d     /var/tmp/abrt         0755 abrt abrt
 x     /var/tmp/abrt/*
+
+d     /run/abrt             0755 root root
+r!    /run/abrt/abrt.pid
+r!    /run/abrt/abrt.socket
+
+d     /var/cache/abrt-di    0775 abrt abrt


### PR DESCRIPTION
This commit adds /var/cache/abrt-di and /var/run/abrt to the
systemd-tmpfiles config for automatic creation and, should the user want
it, timed cleanup.

Closes https://github.com/abrt/abrt/issues/1366