### PR TITLE
tests: Fix leaks

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -87,7 +87,7 @@ check-local: $(check_DATA)
 maintainer-check-valgrind: $(check_DATA)
 	$(MAKE) check-local \
 		PRE_AT_CHECK='$(abs_top_builddir)/libtool --mode=execute $(VALGRIND)' \
-		VALGRIND_OPTS='--tool=memcheck --leak-check=full --show-reachable=yes --error-exitcode=1 --suppressions=$(abs_top_builddir)/tests/GList_append.supp -q'
+		VALGRIND_OPTS='--tool=memcheck --leak-check=full --show-reachable=yes --errors-for-leak-kinds=definite,indirect --error-exitcode=1 --suppressions=$(abs_top_builddir)/tests/GList_append.supp -q'
 
 .PHONY: maintainer-check
 maintainer-check: maintainer-check-valgrind

--- a/tests/koops-parser.at
+++ b/tests/koops-parser.at
@@ -11,19 +11,22 @@ int run_test(const struct test_struct *test)
 {
 	FILE *fp = xfopen_ro(test->filename);
 	fprintf(stderr, "%s\t", test->filename);
-	g_autofree char *line = NULL;
-	g_autofree char *version = NULL;
+	char *line = NULL;
+	char *version = NULL;
 	while ((line = libreport_xmalloc_fgetline(fp)) != NULL)
 	{
 		version = abrt_koops_extract_version(line);
+        free(line);
 		if (version && !strcmp(version, test->expected_results))
 			break;
+		free(version);
 		version = NULL;
 	}
 	if (version)
 		log_warning("version %s", version);
 	else
 		log_warning("version was not found");
+	free(version);
 	fclose(fp);
 	return version == NULL;
 }


### PR DESCRIPTION
Just tweak valgrind setup a bit and fix a few minor memory issues in tests. More errors that were popping up in the ABRT testsuite originated in Satyr code and were fixed in https://github.com/abrt/satyr/pull/310