### PR TITLE
rpm: Correct NEVRA format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix invalid free (rhbz#1895660)
 - Fix crash during local processing (rhbz#1881745)
 - Fix reported numbers of missing debuginfo packages in abrt-action-install-debuginfo
+- Correct the format of NEVRA generated for packages where a problem occurred ([rhbz#1900982](https://bugzilla.redhat.com/show_bug.cgi?id=1900982))
 
 ### Removed
 - Drop --raw flag in abrt-action-generate-core-backtrace

--- a/src/daemon/rpm.c
+++ b/src/daemon/rpm.c
@@ -339,7 +339,7 @@ struct pkg_nevra *rpm_get_package_nvr(const char *filename, const char *rootdir_
     if (strcmp(p->p_epoch, "0") == 0)
         p->p_nvr = g_strdup_printf("%s-%s-%s", p->p_name, p->p_version, p->p_release);
     else
-        p->p_nvr = g_strdup_printf("%s:%s-%s-%s", p->p_name, p->p_epoch, p->p_version, p->p_release);
+        p->p_nvr = g_strdup_printf("%s-%s:%s-%s", p->p_name, p->p_epoch, p->p_version, p->p_release);
 
     rpmdbFreeIterator(iter);
     rpmtsFree(ts);


### PR DESCRIPTION
The string format was changed in 7013e4e to the correct NEVRA form used by libdnf, but it was somehow botched by changes in 7e7cc101.

Resolves [rhbz#1900982](https://bugzilla.redhat.com/show_bug.cgi?id=1900982)