### PR TITLE
Use coredumpctl to retrieve coredump

### DIFF
--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -45,6 +45,7 @@ void abrt_ensure_writable_dir(const char *dir, mode_t mode, const char *user);
 void abrt_ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, const char *group);
 char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
 char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *debuginfo_dirs);
+void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec);
 
 bool abrt_dir_is_in_dump_location(const char *dir_name);
 

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -410,6 +410,38 @@ char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *
     return bt;
 }
 
+void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec)
+{
+    INITIALIZE_LIBABRT();
+
+    char *time = NULL;
+    char *pid = NULL;
+    char *executable = NULL;
+    time = dd_load_text(dd, FILENAME_TIME);
+    pid = dd_load_text(dd, FILENAME_PID);
+    executable = dd_load_text(dd, FILENAME_EXECUTABLE);
+
+    /* Let user know what's going on */
+    log_warning(_("Retrieving coredump with coredumpctl"));
+
+    unsigned i = 0;
+    char *args[7];
+    args[i++] = (char *)"/usr/bin/coredumpctl";
+    args[i++] = (char *)"dump";
+    args[i++] = g_strdup(time);
+    args[i++] = g_strdup(pid);
+    args[i++] = g_strdup(executable);
+    args[i++] = g_strdup_printf("--output=%s/"FILENAME_COREDUMP, dd->dd_dirname);
+    args[i++] = NULL;
+
+    exec_vp(args, /*redirect_stderr:*/ 1, timeout_sec, NULL);
+
+    g_free(args[2]);
+    g_free(args[3]);
+    g_free(args[4]);
+    g_free(args[5]);
+}
+
 char* problem_data_save(problem_data_t *pd)
 {
     abrt_load_abrt_conf();

--- a/src/lib/libabrt.sym
+++ b/src/lib/libabrt.sym
@@ -17,6 +17,7 @@ global:
     abrt_ensure_writable_dir;
     abrt_ensure_writable_dir_group;
     abrt_run_unstrip_n;
+    abrt_save_coredump;
     abrt_get_backtrace;
     abrt_dir_is_in_dump_location;
     abrt_dir_has_correct_permissions;

--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -80,6 +80,12 @@ int main(int argc, char **argv)
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
         return 1;
+
+    if (!dd_exist(dd, FILENAME_COREDUMP))
+    {
+        abrt_save_coredump(dd, exec_timeout_sec);
+    }
+
     g_autofree char *backtrace = abrt_get_backtrace(dd, exec_timeout_sec,
             (debuginfo_dirs) ? debuginfo_dirs : debuginfo_location);
     if (!backtrace)

--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -260,36 +260,6 @@ abrt_journal_core_retrieve_information(abrt_journal_t *journal, struct crash_inf
 static int
 save_systemd_coredump_in_dump_directory(struct dump_dir *dd, struct crash_info *info)
 {
-    char coredump_path[PATH_MAX + 1] = { '\0' };
-    if (coredump_path != abrt_journal_get_string_field(info->ci_journal, "COREDUMP_FILENAME", coredump_path))
-        log_debug("Processing coredumpctl entry without a real file");
-
-    if (g_str_has_suffix(coredump_path, ".lz4") ||
-        g_str_has_suffix(coredump_path, ".xz") ||
-        g_str_has_suffix(coredump_path, ".zst"))
-    {
-        if (dd_copy_file_unpack(dd, FILENAME_COREDUMP, coredump_path))
-            return -1;
-    }
-    else if (strlen(coredump_path) > 0)
-    {
-        if (dd_copy_file(dd, FILENAME_COREDUMP, coredump_path))
-            return -1;
-    }
-    else
-    {
-        const char *data = NULL;
-        size_t data_len = 0;
-        int r = abrt_journal_get_field(info->ci_journal, "COREDUMP", (const void **)&data, &data_len);
-        if (r < 0)
-        {
-            log_info("Ignoring coredumpctl entry without core dump file.");
-            return -1;
-        }
-
-        dd_save_binary(dd, FILENAME_COREDUMP, data, data_len);
-    }
-
     dd_save_text(dd, FILENAME_ABRT_VERSION, VERSION);
     dd_save_text(dd, FILENAME_TYPE, "CCpp");
     dd_save_text(dd, FILENAME_ANALYZER, "abrt-journal-core");


### PR DESCRIPTION
This PR moves the coredump retrieval to a later stage of the problem dir creation, namely by integrating it into `abrt-action-generate-backtrace` and `abrt-action-generate-core-backtrace`. The coredump is retrieved by calling `coredumpctl` directly, rather than by using `sd_journal_get_data`.