### PR TITLE
Output task ID in retrace-client console

### DIFF
--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -1261,7 +1261,7 @@ int main(int argc, char **argv)
     };
 
     const char *usage = _("abrt-retrace-client <operation> [options]\n"
-        "Operations: create/status/backtrace/log/batch/exploitable");
+        "Operations: create, status, backtrace, log, batch, exploitable");
 
     char *env_uri = getenv("RETRACE_SERVER_URI");
     if (env_uri)

--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -856,7 +856,7 @@ static int create(SoupSession  *session,
 
     if (delay)
     {
-        puts(_("Retrace job started"));
+        printf(_("Retrace job #%s started\n"), task_id);
         fflush(stdout);
     }
 


### PR DESCRIPTION
This should help debugging some retrace server issues. In particular, we should be able to traces server failures back to a particular retrace task, which is near impossible right now.

