### PR TITLE
Fix Coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,6 +2,7 @@ name: Coverity build
 on:
   schedule:
     - cron: "0 3 * * 0"
+  workflow_dispatch:
 jobs:
   build:
     container: fedora:latest

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -37,7 +37,7 @@ jobs:
           tar --extract --file=/tmp/coverity_tool.tar.gz --directory=/tmp/coverity --strip-components=1
 
       - name: Add Coverity tools to PATH
-        run: echo '::add-path::/tmp/coverity/bin'
+        run: echo '/tmp/coverity/bin' >> "$GITHUB_PATH"
 
       - name: Build
         run: cov-build --dir cov-int make


### PR DESCRIPTION
Are you tired of getting failure emails every weekend? Don’t answer that - a rhetorical question.

Then this is for you!

With the changes, the workflow itself finishes and can be triggered manually, but there is still the problem of Coverity Scan not supporting GCC 10 (though I forget the details now, but I recall complaining to them about some header-parsing thing). That one might take a year or two before they release a fixed-up version, given their cadence so far.