### PR TITLE
cli: Gracefully handle disappearance of problem directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - abrt-retrace-client: Created task ID is now printed in batch mode
 - Start versioning the abrt libraries
+- cli: Gracefully handle disappearance of problem directory during reporting
 
 ## [2.14.5]
 ### Fixed


### PR DESCRIPTION
Handle a previously unhandled exception which would crash abrt-cli in the corner case of the problem directory disappearing mid-reporting.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1914583