### PR TITLE
Add dependency on python3-systemd for abrt-addon-vmcore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - abrt-retrace-client: Created task ID is now printed in batch mode
 
+### Changed
+- Added dependency of the abrt-addon-vmcore package on python3-systemd
+
 ## [2.14.5]
 ### Fixed
 - Fix invalid free (rhbz#1895660)

--- a/abrt.spec.in
+++ b/abrt.spec.in
@@ -255,6 +255,7 @@ Requires: kexec-tools
 %if %{with python3}
 Requires: python3-abrt
 Requires: python3-augeas
+Requires: python3-systemd
 %endif # with python3
 Requires: util-linux
 

--- a/src/hooks/abrt_exception_handler3.py.in
+++ b/src/hooks/abrt_exception_handler3.py.in
@@ -23,22 +23,12 @@ Module for the ABRT exception handling hook
 import sys
 import os
 
+from systemd import journal
 
 def syslog(msg):
     """Log message to system logger (journal)"""
 
-    from systemd import journal
-
-    # required as a workaround for rhbz#1023041
-    # where journal tries to log into non-existent log
-    # and fails (during %check in mock)
-    #
-    # try/except block should be removed when the bug is fixed
-
-    try:
-        journal.send(msg)
-    except:
-        pass
+    journal.send(msg)
 
 
 def send(data):


### PR DESCRIPTION
`abrt-action-check-oops-for-hw-error` from the abrt-addon-vmcore package imports `systemd.journal` but the python3-systemd package is not declared as a dependency, which causes the script to crash if python3-systemd is not installed on the system.
    
This commit fixes this by adding the formal dependency in the spec file.
    
Resolves [rhbz#1914170](https://bugzilla.redhat.com/show_bug.cgi?id=1914170)
