### PR TITLE
change obscure "signalize" to "indicate" in string

### DIFF
--- a/src/plugins/abrt-action-analyze-oops.c
+++ b/src/plugins/abrt-action-analyze-oops.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
             dd_save_text(dd, FILENAME_NOT_REPORTABLE,
             _("The backtrace does not contain enough meaningful function frames "
               "to be reported. It is annoying but it does not necessarily "
-              "signalize a problem with your computer. ABRT will not allow "
+              "indicate a problem with your computer. ABRT will not allow "
               "you to create a report in a bug tracking system but you "
               "can contact kernel maintainers via e-mail.")
             );


### PR DESCRIPTION
Fixes issue #1563

This doesn't change the corresponding `msgid` in the po files, but in a comment on the issue someone remarked
>  You don't have to deal with the .po files  