### PR TITLE
Fix mismatched allocation / free

### DIFF
--- a/src/daemon/abrt-action-save-container-data.c
+++ b/src/daemon/abrt-action-save-container-data.c
@@ -118,7 +118,7 @@ void dump_docker_info(struct dump_dir *dd, const char *root_dir)
         {
             log_debug("Unsupported container ID: '%s'", container_id);
 
-            free(container_id);
+            g_free(container_id);
             container_id = NULL;
 
             output = NULL;
@@ -230,7 +230,7 @@ void dump_lxc_info(struct dump_dir *dd, const char *lxc_cmd)
     dd_save_text(dd, FILENAME_CONTAINER_ID, container_id);
     dd_save_text(dd, FILENAME_CONTAINER_UUID, container_id);
 
-    free(container_id);
+    g_free(container_id);
 
     /* TODO: make a copy of 'config' */
     /* get mount point for MOUNTINFO_MOUNT_SOURCE(mntnf) + MOUNTINFO_ROOT(mntnf) */

--- a/src/daemon/abrt-handle-event.c
+++ b/src/daemon/abrt-handle-event.c
@@ -260,7 +260,7 @@ static int is_crash_a_dup(const char *dump_dir_name, void *param)
         if (libreport_g_verbose > 1 && !dump_dir_name2)
             perror_msg("realpath(%s)", tmp_concat_path);
 
-        free(tmp_concat_path);
+        g_free(tmp_concat_path);
 
         if (!dump_dir_name2)
             continue;

--- a/src/daemon/abrt-upload-watch.c
+++ b/src/daemon/abrt-upload-watch.c
@@ -110,7 +110,7 @@ handle_new_path(struct process *proc, char *name)
     if (proc->children < proc->max_children)
     {
         run_abrt_handle_upload(proc, name);
-        free(name);
+        g_free(name);
         return;
     }
 
@@ -118,7 +118,7 @@ handle_new_path(struct process *proc, char *name)
     if (!queue_push(&proc->queue, name))
     {
         error_msg(_("No free workers and full buffer. Omitting archive '%s'"), name);
-        free(name);
+        g_free(name);
         return;
     }
 }

--- a/src/daemon/rpm.c
+++ b/src/daemon/rpm.c
@@ -398,6 +398,6 @@ void free_pkg_nevra(struct pkg_nevra *p)
     free(p->p_version);
     free(p->p_release);
     free(p->p_arch);
-    free(p->p_nvr);
-    free(p);
+    g_free(p->p_nvr);
+    g_free(p);
 }

--- a/src/dbus/abrt_problems2_service.c
+++ b/src/dbus/abrt_problems2_service.c
@@ -223,7 +223,7 @@ static void abrt_p2_object_free(AbrtP2Object *obj)
 
     obj->p2o_service = NULL;
 
-    free(obj);
+    g_free(obj);
 }
 
 static AbrtP2Service *abrt_p2_object_service(AbrtP2Object *object)
@@ -534,7 +534,7 @@ static AbrtP2Object *session_object_register(AbrtP2Service *service,
         g_set_error(error, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                     "Too many sessions opened");
 
-        free(path);
+        g_free(path);
         return NULL;
     }
 
@@ -605,7 +605,7 @@ static AbrtP2Object *abrt_p2_service_get_session_for_caller(
                                        error);
     }
 
-    free(session_path);
+    g_free(session_path);
 
     AbrtP2Session *session = abrt_p2_object_get_node(obj);
     if (abrt_p2_session_check_sanity(session, caller, caller_uid, error) != 0)
@@ -1890,7 +1890,7 @@ static void task_object_dbus_method_call(GDBusConnection *connection,
         if (error != NULL)
         {
             g_signal_handler_disconnect(task, s);
-            free(tca);
+            g_free(tca);
         }
     }
     else if (strcmp("Finish", method_name) == 0)

--- a/src/dbus/abrt_problems2_session.c
+++ b/src/dbus/abrt_problems2_session.c
@@ -368,7 +368,7 @@ const char *abrt_p2_session_generate_token(AbrtP2Session *session,
     {
         g_set_error(error, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
                     "Cannot get current time");
-        free(token);
+        g_free(token);
         return NULL;
     }
 

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -320,7 +320,7 @@ char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *
     args[i++] = (char*)"-ex";
     const unsigned file_cmd_index = i++;
     args[file_cmd_index] = g_strdup_printf("file %s", executable);
-    free(executable);
+    g_free(executable);
 
     args[i++] = (char*)"-ex";
     const unsigned core_cmd_index = i++;

--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -354,7 +354,7 @@ void abrt_koops_extract_oopses(GList **oops_list, char *buffer, size_t buflen)
                 if (strstr(c, "kernel oopses to Abrt"))
                 {
                     log_debug("Found our marker at line %d", linecount);
-                    free(lines_info);
+                    g_free(lines_info);
                     lines_info = NULL;
                     lines_info_size = 0;
                     g_list_free_full(g_steal_pointer(oops_list), free);
@@ -387,7 +387,7 @@ next_line:
     }
 
     abrt_koops_extract_oopses_from_lines(oops_list, lines_info, lines_info_size);
-    free(lines_info);
+    g_free(lines_info);
 }
 
 void abrt_koops_extract_oopses_from_lines(GList **oops_list, const struct abrt_koops_line_info *lines_info, int lines_info_size)
@@ -744,7 +744,7 @@ char *abrt_kernel_tainted_short(const char *kernel_bt)
     if (cnt == 0)
     {   /* this should not happen
          * cnt eq 0 means that a tainted string contains only spaces */
-        free(tnt);
+        g_free(tnt);
         return NULL;
     }
 

--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -406,7 +406,7 @@ abrt_journal_dump_core(abrt_journal_t *journal, const char *dump_location, int r
 
 dump_cleanup:
     if (info.ci_executable_path != NULL)
-        free(info.ci_executable_path);
+        g_free(info.ci_executable_path);
 
     return r;
 }
@@ -484,7 +484,7 @@ watch_cleanup:
     abrt_journal_save_current_position(info.ci_journal, ABRT_JOURNAL_WATCH_STATE_FILE);
 
     if (info.ci_executable_path != NULL)
-        free(info.ci_executable_path);
+        g_free(info.ci_executable_path);
 
     return;
 }

--- a/src/plugins/abrt-dump-journal-oops.c
+++ b/src/plugins/abrt-dump-journal-oops.c
@@ -66,7 +66,7 @@ static GList* abrt_journal_extract_kernel_oops(abrt_journal_t *journal)
     for (size_t i = 0; i < lines_info_count; ++i)
         free(lines_info[i].ptr);
 
-    free(lines_info);
+    g_free(lines_info);
 
     return oops_list;
 }

--- a/src/plugins/abrt-journal.c
+++ b/src/plugins/abrt-journal.c
@@ -89,7 +89,7 @@ void abrt_journal_free(abrt_journal_t *journal)
     sd_journal_close(journal->j);
     journal->j = (void *)0xDEADBEAF;
 
-    free(journal);
+    g_free(journal);
 }
 
 int abrt_journal_set_journal_filter(abrt_journal_t *journal, GList *journal_filter_list)
@@ -425,7 +425,7 @@ int abrt_journal_watch_new(abrt_journal_watch_t **watch, abrt_journal_t *journal
 void abrt_journal_watch_free(abrt_journal_watch_t *watch)
 {
     watch->j = (void *)0xDEADBEAF;
-    free(watch);
+    g_free(watch);
 }
 
 abrt_journal_t *abrt_journal_watch_get_journal(abrt_journal_watch_t *watch)

--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -394,12 +394,12 @@ static void free_settings(struct retrace_settings *settings)
 
     int i;
     for (i = 0; i < MAX_FORMATS; ++i)
-        free(settings->supported_formats[i]);
+        g_free(settings->supported_formats[i]);
 
     for (i = 0; i < MAX_RELEASES; ++i)
-        free(settings->supported_releases[i]);
+        g_free(settings->supported_releases[i]);
 
-    free(settings);
+    g_free(settings);
 }
 
 /* returns release identifier as dist-ver-arch */
@@ -410,7 +410,7 @@ static char *get_release_id(GHashTable *osinfo, const char *architecture)
 
     if (strcmp("i686", arch) == 0 || strcmp("i586", arch) == 0)
     {
-        free(arch);
+        g_free(arch);
         arch = g_strdup("i386");
     }
 

--- a/src/plugins/bodhi.c
+++ b/src/plugins/bodhi.c
@@ -149,7 +149,7 @@ static void free_bodhi_item(struct bodhi *b)
 
     free(b->nvr);
 
-    free(b);
+    g_free(b);
 }
 
 static void bodhi_read_value(json_object *json, const char *item_name,

--- a/src/plugins/xorg-utils.c
+++ b/src/plugins/xorg-utils.c
@@ -45,10 +45,10 @@ void xorg_crash_info_free(struct xorg_crash_info *crash_info)
 {
     if (crash_info == NULL)
         return;
-    free(crash_info->backtrace);
-    free(crash_info->reason);
-    free(crash_info->exe);
-    free(crash_info);
+    g_free(crash_info->backtrace);
+    g_free(crash_info->reason);
+    g_free(crash_info->exe);
+    g_free(crash_info);
 }
 
 char *skip_pfx(char *str)


### PR DESCRIPTION
There are a number of places where memory was allocated with a glib2
function and then freed with the glibc free function. This patch
corrects the mismatch so that memory allocated by glib2 is freed by
glib2.