### PR TITLE
Fix a few memory leaks

### DIFF
--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -354,6 +354,7 @@ static int SavePackageDescriptionToDebugDump(const char *dump_dir_name, const ch
         if (is_path_blacklisted(executable))
         {
             log_warning("Blacklisted executable '%s'", executable);
+            pkg_name = script_pkg;
             goto ret; /* return 1 (failure) */
         }
         if (!script_pkg)

--- a/src/plugins/abrt-retrace-client.c
+++ b/src/plugins/abrt-retrace-client.c
@@ -600,6 +600,7 @@ static int create(SoupSession  *session,
 
             unpacked_size += (long long)file_stat.st_size;
             ++i;
+            g_free(path);
         }
 
         if (task_type == TASK_RETRACE || task_type == TASK_DEBUG)
@@ -719,8 +720,10 @@ static int create(SoupSession  *session,
     }
 
     int tempfd = create_archive(delete_temp_archive);
-    if (-1 == tempfd)
+    if (-1 == tempfd) {
+        free_settings(settings);
         return 1;
+    }
 
     /* Get the file size. */
     if (-1 == fstat(tempfd, &file_stat))

--- a/src/plugins/xorg-utils.c
+++ b/src/plugins/xorg-utils.c
@@ -253,6 +253,8 @@ struct xorg_crash_info *process_xorg_bt(char *(*get_next_line)(void *), void *da
 
         return crash_info;
     }
-    return NULL;
 
+    g_free(exe);
+
+    return NULL;
 }


### PR DESCRIPTION
get_script_name allocates memory to script_pkg which must be freed.
If we assign script_pkg to pkg_name, then when it goes to ret, it
will call free_pkg_nevra on the memory to free it.

g_build_filename allocates memory to path that must be freed.
get_settings allocates memory to settings that must be freed

g_strdup allocates memory to exe. If it is not added to crash_info,
the it must be freed.