### PR TITLE
Update regex for matching interpreters

### DIFF
--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -27,13 +27,15 @@
 #define DEFAULT_BLACKLISTED_PKGS "bash, mono-core, nspluginwrapper, strace, valgrind"
 #define DEFAULT_GPG_KEYS_DIR "/etc/pki/rpm-gpg"
 /**
-  * The regexes should cover interpreters with basename:
+  * The regexes should cover interpreters with basenames such as:
+  *
   * Python:
   *   python
   *   python2
   *   python3
   *   python2.7
   *   python3.8
+  *   python3.10
   *   platform-python
   *   platform-python3
   *   platform-python3.8
@@ -56,7 +58,7 @@
 #define DEFAULT_INTERPRETERS_REGEX \
     "^(perl ([[:digit:]][.][[:digit:]]+[.][[:digit:]])? |" \
     "php (-cgi)? |" \
-    "(platform-)? python ([[:digit:]]([.][[:digit:]])?)? |" \
+    "(platform-)? python ([[:digit:]]([.][[:digit:]]+)?)? |" \
     "R |" \
     "tclsh ([[:digit:]][.][[:digit:]])?)$"
 

--- a/src/daemon/abrt-action-save-package-data.c
+++ b/src/daemon/abrt-action-save-package-data.c
@@ -42,7 +42,7 @@
   *
   * Perl:
   *   perl
-  *   perl5.30.1
+  *   perl5.31.11
   *
   * PHP:
   *   php
@@ -56,7 +56,7 @@
   *   tclsh8.6
   **/
 #define DEFAULT_INTERPRETERS_REGEX \
-    "^(perl ([[:digit:]][.][[:digit:]]+[.][[:digit:]])? |" \
+    "^(perl ([[:digit:]][.][[:digit:]]+[.][[:digit:]]+)? |" \
     "php (-cgi)? |" \
     "(platform-)? python ([[:digit:]]([.][[:digit:]]+)?)? |" \
     "R |" \


### PR DESCRIPTION
Update regex for matching interpreter executables to match Python 3.10 as well as Perl 5.31.11.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1979762