### PR TITLE
Add debuginfod support to abrt-retrace-client

### DIFF
--- a/doc/abrt-action-generate-backtrace.txt
+++ b/doc/abrt-action-generate-backtrace.txt
@@ -16,6 +16,11 @@ gdb(1) generates backtrace and other diagnostic information about the state
 of the application at the moment when coredump was generated.
 Then the tool saves it as new element 'backtrace' in this problem directory.
 
+If gdb(1) is built with debuginfod(8) support, gdb(1) will automatically
+attempt to aquire all debugging resources needed to generate the backtrace.
+This allows users to skip downloading these resources in advance through
+abrt-action-install-debuginfo or any other means.
+
 Integration with libreport events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 'abrt-action-generate-backtrace' can be used as an analyzer for

--- a/doc/abrt-retrace-client.txt
+++ b/doc/abrt-retrace-client.txt
@@ -65,6 +65,9 @@ OPTIONS
 --headers::
    (debug) show received HTTP headers
 
+-D, --debuginfod::
+   use debuginfod to aquire necessary debugging resources when generating backtrace
+
 -d, --dir DIR::
    read data from ABRT problem directory
 


### PR DESCRIPTION
Debuginfod is an HTTP server for distributing ELF, DWARF and source
code.

This patch adds a '--debuginfod' option to abrt-retrace-client which
causes a 'X-Debuginfod' header to be added to the request.

This header will indicate to retrace-server that it shouldn't attempt
to aquire any packages needed to produce a backtrace (assuming retrace-server
is configured to allow debuginfod support).

Instead GDB's built-in debuginfod client will query debuginfod servers for any
missing debugging resources when retrace-server invokes it to generate a
backtrace from a corefile.

This patch also updates documentation to mention debuginfod support.

For more information regarding debuginfod, see
https://sourceware.org/elfutils/Debuginfod.html

Also see https://github.com/abrt/retrace-server/pull/433

Note that upstream improvements to GDB's debuginfod corefile support
are currently in the works. Until these improvements are available
in the Fedora builds of GDB available from DNF, it is recommended
that retrace-server uses the following GDB rpms for the best
debuginfod performance when testing or experimenting with this PR:
https://copr.fedorainfracloud.org/coprs/amerey/gdb-debuginfod-core/