### PR TITLE
Use lazy imports in abrt_exception_handler3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Added dependency of the abrt-addon-vmcore package on python3-systemd
+- Use lazy imports in the Python exception handler to avoid slowing down every Python startup (rhbz#2007664)
 
 ## [2.14.5]
 ### Fixed

--- a/src/hooks/abrt_exception_handler3.py.in
+++ b/src/hooks/abrt_exception_handler3.py.in
@@ -20,13 +20,15 @@
 Module for the ABRT exception handling hook
 """
 
+# Avoid importing anything but sys here, use lazy imports.
+# This file is imported on every Python startup,
+# all unused imports only increase the startup time and memory usage.
 import sys
-import os
 
-from systemd import journal
 
 def syslog(msg):
     """Log message to system logger (journal)"""
+    from systemd import journal
 
     journal.send(msg)
 
@@ -68,6 +70,8 @@ def send(data):
 
 
 def write_dump(tb_text, tb):
+    import os
+
     if sys.argv[0][0] == "/":
         executable = os.path.abspath(sys.argv[0])
     else:
@@ -118,6 +122,7 @@ def handle_exception(etype, value, tb):
         sys.excepthook = sys.__excepthook__  # pylint: disable-msg=E1101
 
         import errno
+        import os
 
         # Ignore Ctrl-C
         # SystemExit rhbz#636913 -> this exception is not an error


### PR DESCRIPTION
The abrt_exception_handler3 module is always imported when Python starts,
but all the modules imported from it (except sys) are only used during crashes.

Especially the systemd.journal import is really expensive.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2007664