### PR TITLE
tests: Fix calls to deprecated methods

### DIFF
--- a/tests/runtests/dbus-problems2-sanity/cases/abrt_p2_testing/__init__.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/abrt_p2_testing/__init__.py
@@ -378,7 +378,7 @@ def wait_for_task_status(test, bus, task_path, status):
     task.getobjectproperties().connect_to_signal("PropertiesChanged",
                                                  on_properties_changed)
     test.wait_for_signals(["PropertiesChanged"], 30000)
-    test.assertEquals(task.getproperty("Status"), status)
+    test.assertEqual(task.getproperty("Status"), status)
 
     return task
 

--- a/tests/runtests/dbus-problems2-sanity/cases/test_concurency.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_concurency.py
@@ -62,10 +62,10 @@ class TestConcurency(abrt_p2_testing.TestCase):
                 if status == 4:
                     results, code = t.Finish()
                     self.assertIn("Error.Message", results)
-                    self.assertRegexpMatches(results["Error.Message"],
-                                             "Failed to create new problem "
-                                             "directory: Problem data is "
-                                             "too big")
+                    self.assertRegex(results["Error.Message"],
+                                     "Failed to create new problem "
+                                     "directory: Problem data is "
+                                     "too big")
                     tasks.remove(t)
                 elif not status == 1:
                     self.fail("Unexpected task status: %s" % (str(status)))

--- a/tests/runtests/dbus-problems2-sanity/cases/test_get_problem_data.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_get_problem_data.py
@@ -51,7 +51,7 @@ class TestGetProblemDataSanity(abrt_p2_testing.TestCase):
 
             g = p[k]
 
-            self.assertRegexpMatches(g[2], v[2], "invalid contents of '%s'" % (k))
+            self.assertRegex(g[2], v[2], "invalid contents of '%s'" % (k))
             self.assertEqual(v[1], g[1], "invalid length '%s'" % (k))
             self.assertEqual(v[0], g[0], "invalid flags %s" % (k))
 

--- a/tests/runtests/dbus-problems2-sanity/cases/test_get_problems.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_get_problems.py
@@ -33,7 +33,7 @@ class TestGetProblems(abrt_p2_testing.TestCase):
         time.sleep(1)
 
         new_problems = self.p2.GetProblems(0x2, dict())
-        self.assertEquals(0, len(new_problems))
+        self.assertEqual(0, len(new_problems))
 
     def test_get_new_foreign_problem(self):
         description = {"analyzer": "problems2testsuite_analyzer",
@@ -59,7 +59,7 @@ class TestGetProblems(abrt_p2_testing.TestCase):
         time.sleep(1)
 
         new_problems = self.p2.GetProblems(0x1 | 0x2, dict())
-        self.assertEquals(0, len(new_problems))
+        self.assertEqual(0, len(new_problems))
 
 
 if __name__ == "__main__":

--- a/tests/runtests/dbus-problems2-sanity/cases/test_new_problem.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_new_problem.py
@@ -28,7 +28,8 @@ class TestNewProblem(abrt_p2_testing.TestCase):
             details = self.task.getproperty("Details")
 
             self.assertIn("NewProblem.TemporaryEntry", details)
-            self.assertRegexpMatches(details["NewProblem.TemporaryEntry"], "/org/freedesktop/Problems2/Entry/.+");
+            self.assertRegex(details["NewProblem.TemporaryEntry"],
+                             "/org/freedesktop/Problems2/Entry/.+")
 
             self.task.Start(dict())
         elif changed["status"] == 3:
@@ -50,7 +51,7 @@ class TestNewProblem(abrt_p2_testing.TestCase):
         with abrt_p2_testing.create_fully_initialized_details(True) as description:
             task_path = self.p2.NewProblem(description, 0x1 | 0x2)
 
-        self.assertRegexpMatches(task_path, session_path + "/Task/.+");
+        self.assertRegex(task_path, session_path + "/Task/.+");
 
         self.task = abrt_p2_testing.Problems2Task(self.bus, task_path)
         self.task.getobjectproperties().connect_to_signal("PropertiesChanged", self.handle_properties_changed_signal)
@@ -73,7 +74,7 @@ class TestNewProblem(abrt_p2_testing.TestCase):
         self.assertEqual(0, code)
 
         self.assertIn("NewProblem.Entry", results)
-        self.assertRegexpMatches(results["NewProblem.Entry"], "/org/freedesktop/Problems2/Entry/.+");
+        self.assertRegex(results["NewProblem.Entry"], "/org/freedesktop/Problems2/Entry/.+");
 
         self.p2.DeleteProblems([str(results["NewProblem.Entry"])])
 

--- a/tests/runtests/dbus-problems2-sanity/cases/test_problem_entry_properties.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_problem_entry_properties.py
@@ -21,7 +21,7 @@ class TestProblemEntryProperties(abrt_p2_testing.TestCase):
     def test_problem_entry_properties(self):
         p2e = Problems2Entry(self.bus, self.p2_entry_path)
 
-        self.assertRegexpMatches(
+        self.assertRegex(
                 p2e.getproperty("ID"),
                 "/var/spool/abrt/problems2testsuite_type[^/]*",
                 "strange problem ID")

--- a/tests/runtests/dbus-problems2-sanity/cases/test_session_get_authorize_close.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_session_get_authorize_close.py
@@ -25,7 +25,7 @@ class TestSession(abrt_p2_testing.TestCase):
                 self.logger.debug("Calling Authorize(): expecting pending")
 
                 if not exp_message is None:
-                    self.assertEquals(message, exp_message)
+                    self.assertEqual(message, exp_message)
 
                 # Verify that Authorize returns 2 if there is a pending request
                 ret = p2_session.Authorize(dict())

--- a/tests/runtests/dbus-problems2-sanity/cases/test_session_limits.py
+++ b/tests/runtests/dbus-problems2-sanity/cases/test_session_limits.py
@@ -124,7 +124,7 @@ class TestSessionLimits(abrt_p2_testing.TestCase):
                 self.logger.debug("Authorizing own session")
 
                 r = p2s.Authorize(dict())
-                self.assertEquals(r, 1, "Session is being authorized")
+                self.assertEqual(r, 1, "Session is being authorized")
 
                 self.ac_signal_occurrences = list()
 


### PR DESCRIPTION
The methods `assert(Not)?Equals()` and `assertRegexpMatches()` have been deprecated since Python 3.2 and were removed in Python 3.11.