### PR TITLE
abrt-dump-journal: Don't die on corrupt data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Don't die on corrupt journal data in follow mode
 
 ## [2.15.0]
 ### Fixed

--- a/src/plugins/abrt-journal.c
+++ b/src/plugins/abrt-journal.c
@@ -496,10 +496,13 @@ void abrt_journal_watch_notify_strings(abrt_journal_watch_t *watch, void *data)
 {
     struct abrt_journal_watch_notify_strings *conf = (struct abrt_journal_watch_notify_strings *)data;
 
-    char message[JOURNALD_MAX_FIELD_SIZE + 1];
+    char message[JOURNALD_MAX_FIELD_SIZE + 1] = "\0";
 
     if (abrt_journal_get_string_field(abrt_journal_watch_get_journal(watch), "MESSAGE", (char *)message) == NULL)
-        error_msg_and_die("Cannot read journal data.");
+    {
+        error_msg("Cannot read journal data, skipping.");
+        return;
+    }
 
     GList *cur = conf->strings;
     for (; cur; cur = g_list_next(cur))


### PR DESCRIPTION
abrt-dump-journal-xorg and abrt-dump-journal-oops die when they
encounter a corrupt journal file. This makes restarting their
respective daemons impossible because the program crashes before it has
a chance to set and save its journal read cursor past the corrupt data.

This commit makes the programs go on with just a warning so there's an
opportunity to save the read cursor and thus recover from the condition.

This only affects abrt-dump-journal-xorg and abrt-dump-journal-oops when
run in the follow/daemon mode (i.e. with the -f option).

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1433652
https://bugzilla.redhat.com/show_bug.cgi?id=2043495