### PR TITLE
a-a-generate-backtrace: Fail on missing coredump

### DIFF
--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -45,7 +45,7 @@ void abrt_ensure_writable_dir(const char *dir, mode_t mode, const char *user);
 void abrt_ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, const char *group);
 char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
 char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *debuginfo_dirs);
-void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec);
+int abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec);
 
 bool abrt_dir_is_in_dump_location(const char *dir_name);
 

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -410,7 +410,7 @@ char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *
     return bt;
 }
 
-void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec)
+int abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec)
 {
     INITIALIZE_LIBABRT();
 
@@ -422,7 +422,7 @@ void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec)
     executable = dd_load_text(dd, FILENAME_EXECUTABLE);
 
     /* Let user know what's going on */
-    log_warning(_("Retrieving coredump with coredumpctl"));
+    log_info(_("Retrieving coredump with coredumpctl"));
 
     unsigned i = 0;
     char *args[7];
@@ -433,13 +433,16 @@ void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec)
     args[i++] = g_strdup(executable);
     args[i++] = g_strdup_printf("--output=%s/"FILENAME_COREDUMP, dd->dd_dirname);
     args[i++] = NULL;
+    int status = 0;
 
-    exec_vp(args, /*redirect_stderr:*/ 1, timeout_sec, NULL);
+    exec_vp(args, /*redirect_stderr:*/ 1, timeout_sec, &status);
 
     g_free(args[2]);
     g_free(args[3]);
     g_free(args[4]);
     g_free(args[5]);
+
+    return status;
 }
 
 char* problem_data_save(problem_data_t *pd)

--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -83,7 +83,12 @@ int main(int argc, char **argv)
 
     if (!dd_exist(dd, FILENAME_COREDUMP))
     {
-        abrt_save_coredump(dd, exec_timeout_sec);
+        if (abrt_save_coredump(dd, exec_timeout_sec))
+        {
+            dd_delete_item(dd, FILENAME_COREDUMP);
+            dd_close(dd);
+            error_msg_and_die("Error: Couldn't retrieve coredump");
+        }
     }
 
     g_autofree char *backtrace = abrt_get_backtrace(dd, exec_timeout_sec,

--- a/src/plugins/abrt-action-generate-core-backtrace.c
+++ b/src/plugins/abrt-action-generate-core-backtrace.c
@@ -75,7 +75,12 @@ int main(int argc, char **argv)
 
     if (!dd_exist(dd, FILENAME_COREDUMP))
     {
-        abrt_save_coredump(dd, exec_timeout_sec);
+        if (abrt_save_coredump(dd, exec_timeout_sec))
+        {
+            dd_delete_item(dd, FILENAME_COREDUMP);
+            dd_close(dd);
+            error_msg_and_die("Error: Couldn't retrieve coredump");
+        }
     }
 #ifdef ENABLE_NATIVE_UNWINDER
 


### PR DESCRIPTION
Don't save an empty coredump when coredump is no longer available to
coredumpctl. This typically happens when running
abrt-action-generate[-core]-backtrace by hand after the coredump has
been rotated away from /var/lib/systemd/coredump or, as the case may be,
when SELinux prevents the ABRT daemon from retrieving the coredump using coredumpctl.