### PR TITLE
Revert coredump retrieval optimization patches (rhbz#2052872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Don't die on corrupt journal data in follow mode
+- Revert coredump retrieval optimization patches (rhbz#2052872)
 
 ## [2.15.0]
 ### Fixed

--- a/src/include/libabrt.h
+++ b/src/include/libabrt.h
@@ -45,7 +45,6 @@ void abrt_ensure_writable_dir(const char *dir, mode_t mode, const char *user);
 void abrt_ensure_writable_dir_group(const char *dir, mode_t mode, const char *user, const char *group);
 char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec);
 char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *debuginfo_dirs);
-void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec);
 
 bool abrt_dir_is_in_dump_location(const char *dir_name);
 

--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -410,38 +410,6 @@ char *abrt_get_backtrace(struct dump_dir *dd, unsigned timeout_sec, const char *
     return bt;
 }
 
-void abrt_save_coredump(struct dump_dir *dd, unsigned timeout_sec)
-{
-    INITIALIZE_LIBABRT();
-
-    char *time = NULL;
-    char *pid = NULL;
-    char *executable = NULL;
-    time = dd_load_text(dd, FILENAME_TIME);
-    pid = dd_load_text(dd, FILENAME_PID);
-    executable = dd_load_text(dd, FILENAME_EXECUTABLE);
-
-    /* Let user know what's going on */
-    log_warning(_("Retrieving coredump with coredumpctl"));
-
-    unsigned i = 0;
-    char *args[7];
-    args[i++] = (char *)"/usr/bin/coredumpctl";
-    args[i++] = (char *)"dump";
-    args[i++] = g_strdup(time);
-    args[i++] = g_strdup(pid);
-    args[i++] = g_strdup(executable);
-    args[i++] = g_strdup_printf("--output=%s/"FILENAME_COREDUMP, dd->dd_dirname);
-    args[i++] = NULL;
-
-    exec_vp(args, /*redirect_stderr:*/ 1, timeout_sec, NULL);
-
-    g_free(args[2]);
-    g_free(args[3]);
-    g_free(args[4]);
-    g_free(args[5]);
-}
-
 char* problem_data_save(problem_data_t *pd)
 {
     abrt_load_abrt_conf();

--- a/src/lib/libabrt.sym
+++ b/src/lib/libabrt.sym
@@ -17,7 +17,6 @@ global:
     abrt_ensure_writable_dir;
     abrt_ensure_writable_dir_group;
     abrt_run_unstrip_n;
-    abrt_save_coredump;
     abrt_get_backtrace;
     abrt_dir_is_in_dump_location;
     abrt_dir_has_correct_permissions;

--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -80,12 +80,6 @@ int main(int argc, char **argv)
     struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
     if (!dd)
         return 1;
-
-    if (!dd_exist(dd, FILENAME_COREDUMP))
-    {
-        abrt_save_coredump(dd, exec_timeout_sec);
-    }
-
     g_autofree char *backtrace = abrt_get_backtrace(dd, exec_timeout_sec,
             (debuginfo_dirs) ? debuginfo_dirs : debuginfo_location);
     if (!backtrace)

--- a/src/plugins/abrt-action-generate-core-backtrace.c
+++ b/src/plugins/abrt-action-generate-core-backtrace.c
@@ -63,25 +63,17 @@ int main(int argc, char **argv)
     g_autofree char *error_message = NULL;
     bool success;
 
-    struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
-    if (!dd)
-    {
-        log_warning("Can't open problem directory '%s'", dump_dir_name);
-        return 1;
-    }
-
-    /* The value 240 was taken from abrt-action-generate-backtrace.c. */
-    int exec_timeout_sec = 240;
-
-    if (!dd_exist(dd, FILENAME_COREDUMP))
-    {
-        abrt_save_coredump(dd, exec_timeout_sec);
-    }
 #ifdef ENABLE_NATIVE_UNWINDER
 
     success = sr_abrt_create_core_stacktrace(dump_dir_name, false, &error_message);
 #else /* ENABLE_NATIVE_UNWINDER */
 
+    /* The value 240 was taken from abrt-action-generate-backtrace.c. */
+    int exec_timeout_sec = 240;
+
+    struct dump_dir *dd = dd_opendir(dump_dir_name, /*flags:*/ 0);
+    if (!dd)
+        return 1;
     g_autofree char *gdb_output = abrt_get_backtrace(dd, exec_timeout_sec, NULL);
     if (!gdb_output)
     {
@@ -92,9 +84,9 @@ int main(int argc, char **argv)
     success = sr_abrt_create_core_stacktrace_from_gdb(dump_dir_name,
                                                       gdb_output, false,
                                                       &error_message);
+    dd_close(dd);
 
 #endif /* ENABLE_NATIVE_UNWINDER */
-    dd_close(dd);
 
     if (!success)
     {


### PR DESCRIPTION
This is the easiest way for now. Otherwise we would need to make sure that the SELinux problems are fixed not just in Fedora, but in other channels as well.
