### PR TITLE
abrt-oops: Follow journal from the end if the position cannot be restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
-## [2.15.1]
+### Fixed
+- abrt-oops: Follow journal from the end if the position cannot be restored (gh#1604)
 
 ## [2.15.1]
 ### Fixed


### PR DESCRIPTION
See: https://github.com/abrt/abrt/issues/1604

The service would not start if the cursor state file was missing or invalid.
With this patch, the service will simply start following journal from the end.

Signed-off-by: Michal Srb <michal@redhat.com>