### PR TITLE
spec: Fix macro expansion

### DIFF
--- a/abrt.spec
+++ b/abrt.spec
@@ -22,7 +22,7 @@
 %bcond_without retrace
 
 # rpmbuild --define 'desktopvendor mystring'
-%if "x%{desktopvendor}" == "x"
+%if "x%{?desktopvendor}" == "x"
     %define desktopvendor %(source /etc/os-release; echo ${ID})
 %endif
 


### PR DESCRIPTION
Not sure what the %{desktopvendor} macro does but if undefined, it
doesn't expand to anything without the '?', meaning the condition is
never true.