### PR TITLE
lib: Use time_t for timestamps

### DIFF
--- a/src/lib/hooklib.c
+++ b/src/lib/hooklib.c
@@ -121,12 +121,12 @@ static char* exec_vp(char **args, int redirect_stderr, int exec_timeout_sec, int
      * Therefore we have a (largish) timeout, after which we kill the child.
      */
     libreport_ndelay_on(pipeout[0]);
-    int t = time(NULL); /* int is enough, no need to use time_t */
-    int endtime = t + exec_timeout_sec;
+    time_t starttime = time(NULL);
+    time_t endtime = starttime + exec_timeout_sec;
     GString *buf_out = g_string_new(NULL);
     while (1)
     {
-        int timeout = endtime - t;
+        double timeout = difftime(endtime, starttime);
         if (timeout < 0)
         {
             kill(child, SIGKILL);
@@ -158,7 +158,7 @@ static char* exec_vp(char **args, int redirect_stderr, int exec_timeout_sec, int
         buff[r] = '\0';
         g_string_append(buf_out, buff);
  next:
-        t = time(NULL);
+        starttime = time(NULL);
     }
     close(pipeout[0]);
 
@@ -186,12 +186,12 @@ char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec)
      * Therefore we have a (largish) timeout, after which we kill the child.
      */
     libreport_ndelay_on(pipeout[0]);
-    int t = time(NULL); /* int is enough, no need to use time_t */
-    int endtime = t + timeout_sec;
+    time_t starttime = time(NULL);
+    time_t endtime = starttime + timeout_sec;
     GString *buf_out = g_string_new(NULL);
     while (1)
     {
-        int timeout = endtime - t;
+        double timeout = difftime(endtime, starttime);
         if (timeout < 0)
         {
             kill(child, SIGKILL);
@@ -218,7 +218,7 @@ char *abrt_run_unstrip_n(const char *dump_dir_name, unsigned timeout_sec)
         buff[r] = '\0';
         g_string_append(buf_out, buff);
  next:
-        t = time(NULL);
+        starttime = time(NULL);
     }
     close(pipeout[0]);
 

--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -108,7 +108,7 @@ struct occurrence_queue
 
     struct last_occurrence
     {
-        unsigned oqlc_stamp;
+        time_t oqlc_stamp;
         char *oqlc_executable;
     } oq_occurrences[8];
 
@@ -117,7 +117,7 @@ struct occurrence_queue
     .oq_size = 8,
 };
 
-static unsigned
+static time_t
 abrt_journal_get_last_occurrence(const char *executable)
 {
     if (s_queue.oq_head < 0)
@@ -140,7 +140,7 @@ abrt_journal_get_last_occurrence(const char *executable)
 }
 
 static void
-abrt_journal_update_occurrence(const char *executable, unsigned ts)
+abrt_journal_update_occurrence(const char *executable, time_t ts)
 {
     if (s_queue.oq_head < 0)
         s_queue.oq_head = 0;
@@ -440,8 +440,8 @@ abrt_journal_watch_cores(abrt_journal_watch_t *watch, void *user_data)
 
     // do not dump too often
     //   ignore crashes of a single executable appearing in THROTTLE s (keep last 10 executable)
-    const unsigned current = time(NULL);
-    const unsigned last = abrt_journal_get_last_occurrence(info.ci_executable_path);
+    const time_t current = time(NULL);
+    const time_t last = abrt_journal_get_last_occurrence(info.ci_executable_path);
 
     if (current < last)
     {
@@ -453,11 +453,11 @@ abrt_journal_watch_cores(abrt_journal_watch_t *watch, void *user_data)
         goto watch_cleanup;
     }
 
-    const unsigned sub = current - last;
+    const double sub = difftime(current, last);
     if (sub < conf->awc_throttle)
     {
         /* We don't want to update the counter here. */
-        error_msg(_("Not saving repeating crash after %ds (limit is %ds)"), sub, conf->awc_throttle);
+        error_msg(_("Not saving repeating crash after %.0fs (limit is %ds)"), sub, conf->awc_throttle);
         goto watch_cleanup;
     }
 


### PR DESCRIPTION
Use the appropriate standard type for timestamps instead of just `int` or `unsigned` in order to prevent any possible headaches down the road.

Problem reported by Coverity.