### PR TITLE
cli: use python3-argcomplete global completion

### DIFF
--- a/abrt.spec
+++ b/abrt.spec
@@ -947,7 +947,6 @@ killall abrt-dbus >/dev/null 2>&1 || :
 
 %files tui
 %if %{with python3}
-%config(noreplace) %{_sysconfdir}/bash_completion.d/abrt.bash_completion
 %{_bindir}/abrt
 %{_bindir}/abrt-cli
 %{python3_sitelib}/abrtcli/

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -2,9 +2,6 @@ SUBDIRS = abrtcli tests
 
 bin_SCRIPTS = abrt
 
-bashcompdir = $(sysconfdir)/bash_completion.d
-dist_bashcomp_DATA = abrt.bash_completion
-
 profileconfigdir = $(sysconfdir)/profile.d
 dist_profileconfig_DATA = abrt-console-notification.sh
 

--- a/src/cli/abrt
+++ b/src/cli/abrt
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# PYTHON_ARGCOMPLETE_OK
 
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import sys

--- a/src/cli/abrt.bash_completion
+++ b/src/cli/abrt.bash_completion
@@ -1,1 +1,0 @@
-eval "$(register-python-argcomplete abrt)"


### PR DESCRIPTION
Advertise support for argcomplete global completion. [1]

Remove the abrt specific bash completion script.

The bash completion script from python3-argcomplete in
`/etc/bash_completion.d/python-argcomplete`
will do the completion for `abrt`.

This change avoids the bash startup calling `register-python-argcomplete abrt`,
which takes some time.

[1]: https://github.com/kislyuk/argcomplete#global-completion