### PR TITLE
abrt-journal: call sd_journal_get_fd() right after sd_journal_open()

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     runs-on: ubuntu-latest
     steps:
       - name: Install build environment

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    container: fedora:latest
+    container: quay.io/fedora/fedora:latest
     runs-on: ubuntu-latest
     steps:
       - name: Check out sources

--- a/src/plugins/abrt-journal.c
+++ b/src/plugins/abrt-journal.c
@@ -35,12 +35,15 @@
 struct abrt_journal
 {
     sd_journal *j;
+    int fd;
 };
 
 static int abrt_journal_new_flags(abrt_journal_t **journal, int flags)
 {
     sd_journal *j;
     const int r = sd_journal_open(&j, flags);
+    const int fd = sd_journal_get_fd(j);
+
     if (r < 0)
     {
         log_notice("Failed to open journal: %s", strerror(-r));
@@ -49,6 +52,7 @@ static int abrt_journal_new_flags(abrt_journal_t **journal, int flags)
 
     *journal = g_malloc0(sizeof(**journal));
     (*journal)->j = j;
+    (*journal)->fd = fd;
 
     return 0;
 }
@@ -452,7 +456,7 @@ int abrt_journal_watch_run_sync(abrt_journal_watch_t *watch)
     sigdelset(&mask, SIGKILL);
 
     struct pollfd pollfd;
-    pollfd.fd = sd_journal_get_fd(watch->j->j);
+    pollfd.fd = watch->j->fd;
     pollfd.events = sd_journal_get_events(watch->j->j);
 
     int r = 0;


### PR DESCRIPTION
See: rhbz#2128662

Under certain circumstances, abrt-dump-journal can be running, but not receiving any event notifications from journal.

The culprit of the issue seems to be the delayed call to sd_journal_get_fd(), as discussed in various
issues and pull-requests in other projects.
See for example [1], [2], or [3].

[1]: https://github.com/systemd/systemd/issues/7998
[2]: https://github.com/ledbettj/systemd-journal/pull/78
[3]: https://github.com/rsyslog/rsyslog/issues/2436

Signed-off-by: Michal Srb <michal@redhat.com>