### PR TITLE
readme: Add diagram of related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ solution.
 The solution in this context might be a bugzilla ticket, knowledge base article
 or a suggestion to update a package to a version containing a fix.
 
+This repository is one among a suite of related projects. The following diagram
+summarizes the dependencies between the individual packages comprising the ABRT
+suite.
+
+```mermaid
+flowchart BT
+    abrt-java-connector --> abrt
+    abrt-java-connector -. build .-> satyr
+    abrt:::focus --> libreport & satyr
+    abrt-java-connector --> libreport
+    gnome-abrt --> abrt & libreport
+    reportd --> libreport
+    libreport --> satyr
+    retrace-server[Retrace Server] -. "optional, for<br>packages only" .-> faf
+    faf["ABRT Analytics (FAF)"] --> satyr
+
+click abrt "https://github.com/abrt/abrt" "abrt GitHub repository" _blank
+click abrt-java-connector "https://github.com/abrt/abrt-java-connector" "abrt-java-connector GitHub repository" _blank
+click faf "https://github.com/abrt/faf" "ABRT Analytics GitHub repository" _blank
+click gnome-abrt "https://github.com/abrt/gnome-abrt" "gnome-abrt GitHub repository" _blank
+click libreport "https://github.com/abrt/libreport" "libreport GitHub repository" _blank
+click reportd "https://github.com/abrt/reportd" "reportd GitHub repository" _blank
+click satyr "https://github.com/abrt/satyr" "satyr GitHub repository" _blank
+click retrace-server "https://github.com/abrt/retrace-server" "Retrace Server GitHub repository" _blank
+
+classDef focus stroke-width: 4
+```
+
 ### Documentation
 
 Every ABRT program and configuration file has a man page describing it. It is


### PR DESCRIPTION
Use the native Mermaid.js integration in GitHub Markdown to display a clickable diagram of related repositories, i.e. the relevant repos in the abrt organization.