### PR TITLE
spec: plugin-bodhi requires abrt-libs

### DIFF
--- a/abrt.spec
+++ b/abrt.spec
@@ -274,6 +274,7 @@ This package contains plugin for collecting kernel oopses from pstore storage.
 %package plugin-bodhi
 Summary: %{name}'s bodhi plugin
 Requires: %{name} = %{version}-%{release}
+Requires: abrt-libs = %{version}-%{release}
 Obsoletes: libreport-plugin-bodhi <= 2.0.10
 Provides: libreport-plugin-bodhi = %{version}-%{release}
 


### PR DESCRIPTION
This issue was reported by rpminspect:

"""
Subpackage abrt-plugin-bodhi on x86_64 carries 'Requires: libabrt.so.0()(64bit)' which comes from subpackage abrt-libs but does not carry an explicit package version requirement.
"""