### PR TITLE
abrtd: remove livesys.service reference from the systemd unit file

### DIFF
--- a/init-scripts/abrtd.service
+++ b/init-scripts/abrtd.service
@@ -1,9 +1,5 @@
 [Unit]
 Description=ABRT Daemon
-# livesys.service has been added because of live distributions mounting tmpfs
-# to /var/tmp after abrtd.service was started which was hiding /var/tmp/abrt
-# which was created before the mount to tmpfs happened
-After=livesys.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
ABRT no longer uses /var/tmp/abrt/ for storing problem data. Therefore we are not concerned about livesys re-mounting /var/tmp/ as tmpfs and thus hiding it from abrtd.

Fixes: rhbz#2171200