### PR TITLE
ccpp: don't fail bug reporting on ureport failure

### DIFF
--- a/src/plugins/ccpp_event.conf
+++ b/src/plugins/ccpp_event.conf
@@ -98,11 +98,11 @@ EVENT=report_Bugzilla type=CCpp duphash!=
 
 # Send micro report
 EVENT=report_uReport type=CCpp
-        /usr/libexec/abrt-action-ureport
+        /usr/libexec/abrt-action-ureport || :
 
 # update ABRT database after successful report to bugzilla
 EVENT=post_report type=CCpp
-        reporter-ureport -A -B
+        reporter-ureport -A -B || :
 
 EVENT=analyze_CCpp type=CCpp
         test -f coredump.zst && /usr/libexec/abrt-action-coredump -x || :


### PR DESCRIPTION
Related: gh#1656

ureport works with the core backtrace retrieved from coredumpctl, but the backtrace is sometimes quite useless:

    Stack trace of thread 3219:
    #0  0x0000aaaaca9d02dc crash.constprop.0 (will_segfault + 0x102dc)
    #1  0x0070aaaaca9d0370 n/a (n/a + 0x0)
    ...
    #9  0x0013ffff8dd40abc n/a (n/a + 0x0)
    #10 0x0076aaaaca9d0170 n/a (n/a + 0x0)
    ELF object binary architecture: AARCH64

abrt (understadably) complains about such low value backtrace and refuses to continue. However, when we later run gdb on the coredump, we actually get a good backtrace out of it.

This commit makes ureport failures non-blocking and thus there is a chance that we will get a good quality backtrace from gdb later.