### PR TITLE
Fix typo in dbus error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed typo in src/dbus/abrt-dbus.c
 
 ## [2.17.6]
 ### Fixed

--- a/src/dbus/abrt-dbus.c
+++ b/src/dbus/abrt-dbus.c
@@ -119,7 +119,7 @@ bool allowed_problem_dir(const char *dir_name)
 
     if (!abrt_dir_has_correct_permissions(dir_name, DD_PERM_DAEMONS))
     {
-        error_msg("Problem directory '%s' has invalid owner, groop or mode", dir_name);
+        error_msg("Problem directory '%s' has invalid owner, group or mode", dir_name);
         return false;
     }
 


### PR DESCRIPTION
Fixed typo in src/dbus/abrt-dbus.c