### PR TITLE
Use rpmPubkeyKeyIDAsHex() to obtain the gpg key in hex format

### DIFF
--- a/abrt.spec
+++ b/abrt.spec
@@ -58,7 +58,7 @@ BuildRequires: %{dbus_devel}
 BuildRequires: hostname
 BuildRequires: gtk3-devel
 BuildRequires: glib2-devel >= %{glib_ver}
-BuildRequires: rpm-devel >= 4.18
+BuildRequires: rpm-devel >= 6.0.0
 BuildRequires: desktop-file-utils
 BuildRequires: libnotify-devel
 #why? BuildRequires: file-devel

--- a/src/daemon/rpm.c
+++ b/src/daemon/rpm.c
@@ -90,7 +90,7 @@ void rpm_destroy()
     rpmFreeRpmrc();
 #endif
 
-    g_list_free_full(g_steal_pointer(&list_fingerprints), free);
+    g_list_free_full(g_steal_pointer(&list_fingerprints), g_free);
 }
 
 
@@ -113,7 +113,7 @@ void rpm_load_gpgkey(const char* filename)
     pubkey = rpmPubkeyNew(pkt, pklen);
     if (pubkey != NULL)
     {
-        fingerprint = rpmhex(pubkey->keyid, sizeof(pubkey->keyid));
+        fingerprint = g_strdup(rpmPubkeyKeyIDAsHex(pubkey));
         if (fingerprint != NULL)
             list_fingerprints = g_list_append(list_fingerprints, fingerprint);
 
@@ -123,7 +123,7 @@ void rpm_load_gpgkey(const char* filename)
             rpmPubkey subkey = subkeys[i];
             if (subkey != NULL)
             {
-                fingerprint = rpmhex(subkey->keyid, sizeof(subkey->keyid));
+                fingerprint = g_strdup(rpmPubkeyKeyIDAsHex(subkey));
                 if (fingerprint != NULL)
                     list_fingerprints = g_list_append(list_fingerprints, fingerprint);
             }


### PR DESCRIPTION
The old way doesn't work with RPM 6.0.0.

Related: rhbz#2396899