### PR TITLE
Fix compiler warning

### DIFF
--- a/src/lib/kernel.c
+++ b/src/lib/kernel.c
@@ -730,7 +730,7 @@ char *abrt_koops_extract_version(const char *linepointer)
 char *abrt_kernel_tainted_short(const char *kernel_bt)
 {
     /* example of flags: 'Tainted: G    B       ' */
-    char *tainted = strstr(kernel_bt, "Tainted: ");
+    const char *tainted = strstr(kernel_bt, "Tainted: ");
     if (!tainted)
         return NULL;
 

--- a/src/plugins/abrt-action-analyze-xorg.c
+++ b/src/plugins/abrt-action-analyze-xorg.c
@@ -46,7 +46,7 @@ char* is_in_comma_separated_list_with_fmt(const char *value, const char *fmt, co
     {
         const char *comma = strchrnul(list, ',');
         g_autofree char *pattern = g_strdup_printf(fmt, (int)(comma - list), list);
-        char *match = strstr(value, pattern);
+        const char *match = strstr(value, pattern);
         if (match)
             return g_strndup(list, comma - list);
         if (!*comma)


### PR DESCRIPTION
"initialization discards 'const' qualifier from pointer target type"