### PR TITLE
Fixed runlevel command not being found on systemd

### DIFF
--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -80,7 +80,8 @@ EVENT=post-create remote!=1
 
 # Record runlevel (if not yet done) and don't return non-0 if it fails:
 EVENT=post-create runlevel= remote!=1
-        systemctl get-default >runlevel 2>&1
+        systemctl is-system-running >runlevel 2>&1
+        systemctl get-default >>runlevel 2>&1
         exit 0
 
 # A dummy EVENT=post-create for uploaded problems.

--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -80,8 +80,8 @@ EVENT=post-create remote!=1
 
 # Record runlevel (if not yet done) and don't return non-0 if it fails:
 EVENT=post-create runlevel= remote!=1
-    systemctl get-default >runlevel 2>&1
-    exit 0
+        systemctl get-default >runlevel 2>&1
+        exit 0
 
 # A dummy EVENT=post-create for uploaded problems.
 # abrtd would delete uploaded problems without this EVENT.

--- a/src/daemon/abrt_event.conf
+++ b/src/daemon/abrt_event.conf
@@ -80,8 +80,8 @@ EVENT=post-create remote!=1
 
 # Record runlevel (if not yet done) and don't return non-0 if it fails:
 EVENT=post-create runlevel= remote!=1
-        runlevel >runlevel 2>&1
-        exit 0
+    systemctl get-default >runlevel 2>&1
+    exit 0
 
 # A dummy EVENT=post-create for uploaded problems.
 # abrtd would delete uploaded problems without this EVENT.


### PR DESCRIPTION
# What was the issue
As described by user `ferdnyc` in issue #1690, ABRT cannot run the command `runlevel` due to the command becoming deprecated on modern systemd.
# The solution I came up with
All I did was update the command inside the file `src/daemon/abrt_even.conf` at line **83**.. as you can see from the blame of the file, I pretty much just corrected and updated the commands.

#### Hope you accept my changes, I really wish the best for this awesome tool.