### PR TITLE
Fix race condition in ChownProblemDir

### DIFF
--- a/src/dbus/abrt-dbus.c
+++ b/src/dbus/abrt-dbus.c
@@ -491,6 +491,15 @@ static void handle_method_call(GDBusConnection *connection,
             return;
         }
 
+        if (!problem_dump_dir_is_complete(dd))
+        {
+            g_dbus_method_invocation_return_dbus_error(invocation,
+                                              "org.freedesktop.problems.InvalidProblemDir",
+                                              _("Problem directory is being processed"));
+            dd_close(dd);
+            return;
+        }
+
         int chown_res = dd_chown(dd, caller_uid);
         if (chown_res != 0)
             g_dbus_method_invocation_return_dbus_error(invocation,


### PR DESCRIPTION
Fixes: CVE-2026-54229

A local attacker could call ChownProblemDir while post-create event handlers are still processing a dump directory, seizing file ownership while privileged scripts continue writing and processing those files.

Generated-by: Claude