### PR TITLE
Fix content injection in journal log collection

### DIFF
--- a/src/plugins/ccpp_event.conf
+++ b/src/plugins/ccpp_event.conf
@@ -29,8 +29,9 @@ EVENT=post-create type=CCpp remote!=1
             executable=`cat executable` &&
             base_executable=${executable##*/} &&
             uid=`cat $DUMP_DIR/uid` &&
+            pid=`cat pid` &&
             {
-                user_log_full=`journalctl -q -b --since=-3m -n 99 _COMM="$base_executable" _UID="$uid"` &&
+                user_log_full=`journalctl -q -b --since=-3m -n 99 _COMM="$base_executable" _UID="$uid" _PID="$pid"` &&
                 while read line; do
                     if [[ $line != *" audit["* ]]; then
                         user_log=$user_log$line$'\n'
@@ -43,7 +44,7 @@ EVENT=post-create type=CCpp remote!=1
                     # Remove the line below if you don't mind sharing data from the
                     # system logs with unprivileged users -> bugzilla.redhat.com/1212868
                     false &&
-                    system_log_full=$log`journalctl -q -b --since=-3m --system -n 99 _COMM="$base_executable"` &&
+                    system_log_full=$log`journalctl -q -b --since=-3m --system -n 99 _COMM="$base_executable" _PID="$pid"` &&
                     while read line; do
                         if [[ $line != *" audit["* ]]; then
                             system_log=$system_log$line$'\n'


### PR DESCRIPTION
Fixes: CVE-2026-54231

The post-create event handler for CCpp crashes queries the systemd journal for log entries matching the crashed process and writes the results to var_log_messages in the dump directory. The journalctl query filtered only by _COMM (process name) and _UID, both of which a local attacker can match by using prctl(PR_SET_NAME). By embedding newline characters in syslog messages, the attacker could inject arbitrary content into the file that root writes to the dump directory.

Add _PID filtering to the journalctl query. The dump directory already contains a pid file with the crashed process's PID, and a local attacker cannot predict or control the PID assigned to another user's process. This prevents spoofed journal entries from being collected.

Assisted-by:: Claude