### PR TITLE
Fix journal entry spoofing in journal dump services

### DIFF
--- a/src/plugins/abrt-action-check-oops-for-hw-error.in
+++ b/src/plugins/abrt-action-check-oops-for-hw-error.in
@@ -79,7 +79,8 @@ def journal_has_string(identifier, string):
     j.this_boot()
     j.this_machine()
     j.log_level(journal.LOG_INFO)
-    j.add_match(SYSLOG_IDENTIFIER=identifier, MESSAGE=string)
+    j.add_match(SYSLOG_IDENTIFIER=identifier, MESSAGE=string,
+                _TRANSPORT="journal", _UID="0")
 
     return bool(list(j))
 

--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -617,6 +617,12 @@ main(int argc, char *argv[])
     coredump_journal_filter = g_list_append(coredump_journal_filter,
            (env_journal_filter ? (gpointer)env_journal_filter : (gpointer)"SYSLOG_IDENTIFIER=systemd-coredump"));
 
+    if (!env_journal_filter)
+    {
+        coredump_journal_filter = g_list_append(coredump_journal_filter, (gpointer)"_UID=0");
+        coredump_journal_filter = g_list_append(coredump_journal_filter, (gpointer)"_COMM=systemd-coredum");
+    }
+
     abrt_journal_t *journal = NULL;
     if ((opts & OPT_J))
     {

--- a/src/plugins/abrt-dump-journal-oops.c
+++ b/src/plugins/abrt-dump-journal-oops.c
@@ -273,6 +273,9 @@ int main(int argc, char *argv[])
     kernel_journal_filter = g_list_append(kernel_journal_filter,
             (env_journal_filter ? (gpointer)env_journal_filter : (gpointer)"SYSLOG_IDENTIFIER=kernel"));
 
+    if (!env_journal_filter)
+        kernel_journal_filter = g_list_append(kernel_journal_filter, (gpointer)"_TRANSPORT=kernel");
+
     abrt_journal_t *journal = NULL;
     if ((opts & OPT_J))
     {


### PR DESCRIPTION
Fixes: rhbz#2484614

Filter journal messages on trusted fields (underscore-prefixed, set by the kernel/journald) in addition to the user-settable SYSLOG_IDENTIFIER. Without this, a local unprivileged user can inject fake journal entries that ABRT processes as genuine crashes or kernel oopses.

abrt-dump-journal-core: require _UID=0 and _COMM=systemd-coredum so only entries genuinely written by systemd-coredump are processed.

abrt-dump-journal-oops: require _TRANSPORT=kernel so only messages from the kernel ring buffer are processed.

abrt-action-check-oops-for-hw-error: require _TRANSPORT=journal and _UID=0 so only genuine mcelog entries influence MCE classification.

Assisted-by: Claude