### PR TITLE
Fix journal entry spoofing in abrt-dump-journal-core

### DIFF
--- a/src/plugins/abrt-dump-journal-core.c
+++ b/src/plugins/abrt-dump-journal-core.c
@@ -619,7 +619,10 @@ main(int argc, char *argv[])
 
     if (!env_journal_filter)
     {
-        coredump_journal_filter = g_list_append(coredump_journal_filter, (gpointer)"_UID=0");
+        /* Filter on trusted fields (set by the kernel, not spoofable) to
+         * ensure we only process genuine systemd-coredump entries.
+         * "systemd-coredum" is not a typo — the kernel truncates _COMM to 15 chars. */
+        coredump_journal_filter = g_list_append(coredump_journal_filter, (gpointer)"_EXE=/usr/lib/systemd/systemd-coredump");
         coredump_journal_filter = g_list_append(coredump_journal_filter, (gpointer)"_COMM=systemd-coredum");
     }
 


### PR DESCRIPTION
Related: rhbz#2484614

Replace the _UID=0 filter with _EXE=/usr/lib/systemd/systemd-coredump so that only genuine systemd-coredump entries are processed.

Assisted-by: Claude